### PR TITLE
Use llm library for LLM calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,30 +3,54 @@
 [![License GPL 3](https://img.shields.io/badge/license-GPL_3-green.svg)](http://www.gnu.org/licenses/gpl-3.0.txt)
 [![MELPA](https://melpa.org/packages/ellama-badge.svg)](https://melpa.org/#/ellama)
 
-Ellama lets you access LLMs locally using
-[ollama](https://github.com/jmorganca/ollama)'s API from Emacs. It
-offers a set of commands that allow you to inquire, define words,
-translate text and more through the Emacs interface. Ellama natively
-supports streaming output, making it effortless to use with your
-preferred text editor.
+Ellama is a tool for interacting with large language models from
+Emacs. It allows you to ask questions and receive responses from the
+LLMs. Ellama can perform various tasks such as translation, code
+review, summarization, enhancing grammar/spelling or wording and
+more through the Emacs interface. Ellama natively supports streaming
+output, making it effortless to use with your preferred text editor.
+
+## What's new
+
+- `28.10.2023` - Switched from
+[ollama](https://github.com/jmorganca/ollama)'s API to [llm
+library](https://elpa.gnu.org/packages/llm.html). [Many
+providers](https://github.com/ahyatt/llm#setting-up-providers)
+supported.
 
 ## Installation
 
-Firstly, you need to install
-[ollama](https://github.com/jmorganca/ollama) and pull
-[zephyr](https://ollama.ai/library/zephyr) (default model) or any
-other model from [library](https://ollama.ai/library) (in that case
-you should customize `ellama-model`)
-You can now install the package `ellama` from
+Install the package `ellama` from
 [MELPA](https://melpa.org/#/getting-started). Just `M-x`
 `package-install`<kbd>Enter</kbd> `ellama` <kbd>Enter</kbd>.
+By default it uses [ollama](https://github.com/jmorganca/ollama)
+provider and [zephyr](https://ollama.ai/library/zephyr) model. If you
+ok with it, you need to install
+[ollama](https://github.com/jmorganca/ollama) and pull
+[zephyr](https://ollama.ai/library/zephyr). You can use `ellama` with
+other model or other llm provider. In that case you should customize
+ellama configuration like this:
+
+``` emacs-lisp
+(use-package ellama
+  :init
+  (setopt ellama-language "German")
+  (require 'llm-ollama)
+  (setopt ellama-provider
+		  (make-llm-ollama
+		   :chat-model "zephyr:7b-alpha-q5_K_M" :embedding-model "zephyr:7b-alpha-q5_K_M")))
+```
 
 ## Commands
 
-### ellama-ask
+### ellama-chat
 
 Ask Ellama about something by entering a prompt in an interactive
-buffer.
+buffer and continue conversation.
+
+### ellama-ask
+
+Alias for `ellama-chat`.
 ![ellama-ask](imgs/ellama-ask.gif)
 
 ### ellama-ask-about
@@ -108,19 +132,20 @@ Summarize a webpage fetched from a URL using Ellama.
 
 The following variables can be customized for the Ellama client:
 
-- `ellama-url`: The URL to call Ollama.
-- `ellama-curl-executable`: The path to curl executable.
-- `ellama-model`: The model to use Ollama with. Default model is
-  [zephyr](https://ollama.ai/library/zephyr).
 - `ellama-buffer`: The default Ellama buffer name.
-- `ellama-always-show-buffer`: Whether to always show the Ellama buffer.
 - `ellama-user-nick`: The user nick in logs.
 - `ellama-assistant-nick`: The assistant nick in logs.
 - `ellama-buffer-mode`: The major mode for the Ellama logs buffer.
   Default mode is `markdown-mode`.
 - `ellama-language`: The language for Ollama translation. Default
   language is english.
-- `ellama-template`: The template to use with Ollama instead of the default.
+- `ellama-provider`: llm provider for ellama. Default provider is
+  `ollama` with [zephyr](https://ollama.ai/library/zephyr) model.
+  There are many supported providers: `ollama`, `open ai`, `vertex`,
+  `GPT4All`. For more information see [llm
+  documentation](https://elpa.gnu.org/packages/llm.html)
+- `ellama-spinner-type`: Spinner type for ellama. Default type is
+  `progress-bar`.
 
 ## Acknowledgments
 
@@ -134,3 +159,6 @@ client in Emacs can do.
 
 Thanks [Dr. David A. Kunz](https://github.com/David-Kunz) - I got more
 ideas from [gen.nvim](https://github.com/David-Kunz/gen.nvim).
+
+Thanks [Andrew Hyatt](https://github.com/ahyatt) for `llm` library.
+Without it only `ollama` would be supported.

--- a/ellama.el
+++ b/ellama.el
@@ -5,7 +5,7 @@
 ;; Author: Sergey Kostyaev <sskostyaev@gmail.com>
 ;; URL: http://github.com/s-kostyaev/ellama
 ;; Keywords: help local tools
-;; Package-Requires: ((emacs "28.1") (spinner "1.7.4"))
+;; Package-Requires: ((emacs "28.1")(llm "0.4.0")(spinner "1.7.4"))
 ;; Version: 0.1.0
 ;; Created: 8th Oct 2023
 
@@ -31,6 +31,8 @@
 ;;; Code:
 
 (require 'json)
+(require 'llm)
+(require 'llm-ollama)
 (require 'spinner)
 
 (defgroup ellama nil
@@ -76,6 +78,13 @@
 (defcustom ellama-template nil "Template to use with ollama instead of default."
   :group 'ellama
   :type 'string)
+
+(defcustom ellama-provider
+  (make-llm-ollama
+   :chat-model "zephyr" :embedding-model "zephyr")
+  "Backend LLM provider."
+  :group 'ellama
+  :type 'cl-struct)
 
 (defvar-local ellama-context nil "Context that contains ellama conversation memory.")
 
@@ -254,7 +263,14 @@ default. Default value is `ellama-template'."
 
 (defun ellama-instant (prompt)
   "Prompt ellama for PROMPT to reply instantly."
-  (ellama-query prompt :display t :buffer (make-temp-name ellama-buffer)))
+  (let ((buffer (get-buffer-create (make-temp-name ellama-buffer))))
+    (display-buffer buffer)
+    (llm-chat-streaming-to-point
+     ellama-provider
+     (llm-make-simple-chat-prompt prompt)
+     buffer
+     (point-min)
+     (lambda () nil))))
 
 ;;;###autoload
 (defun ellama-translate ()
@@ -304,11 +320,13 @@ default. Default value is `ellama-template'."
 		(point-max)))
 	 (text (buffer-substring-no-properties beg end)))
     (kill-region beg end)
-    (ellama-query
-     (format
-      "Change the following text, %s, just output the final text without additional quotes around it:\n%s"
-      change text)
-     :buffer (current-buffer))))
+    (llm-chat-streaming-to-point
+     ellama-provider
+     (llm-make-simple-chat-prompt
+      (format
+       "Change the following text, %s, just output the final text without additional quotes around it:\n%s"
+       change text))
+     (current-buffer) (point) (lambda () nil))))
 
 ;;;###autoload
 (defun ellama-enhance-grammar-spelling ()
@@ -417,11 +435,15 @@ buffer."
 		(point-max)))
 	 (text (buffer-substring-no-properties beg end)))
     (kill-region beg end)
-    (ellama-query
-     (format
-      "Render the following text as a %s:\n%s"
-      needed-format text)
-     :buffer (current-buffer))))
+    (llm-chat-streaming-to-point
+     ellama-provider
+     (llm-make-simple-chat-prompt
+      (format
+       "Render the following text as a %s:\n%s"
+       needed-format text))
+     (current-buffer)
+     (point)
+     (lambda () nil))))
 
 ;;;###autoload
 (defun ellama-make-list ()

--- a/ellama.el
+++ b/ellama.el
@@ -86,6 +86,10 @@
   :group 'ellama
   :type '(sexp :validate 'cl-struct-p))
 
+(defcustom ellama-spinner-type 'progress-bar "Spinner type for ellama."
+  :group 'ellama
+  :type 'symbol)
+
 (defvar-local ellama-context nil "Context that contains ellama conversation memory.")
 
 (defvar-local ellama--unprocessed-data nil)
@@ -242,7 +246,7 @@ default. Default value is `ellama-template'."
 		   (json-encode-plist ellama--request))
 	 :filter 'ellama--filter
 	 :sentinel sentinel)
-	(spinner-start 'progress-bar)))))
+	(spinner-start ellama-spinner-type)))))
 
 ;;;###autoload
 (defun ellama-ask ()


### PR DESCRIPTION
Instead of manage low level interactions with ollama API, use `llm` library. As a bonus I will get proprietary LLMs support.