### PR TITLE
:recycle: Refactor ellama.el code for improved response handling.

### DIFF
--- a/ellama.el
+++ b/ellama.el
@@ -108,6 +108,7 @@ Filter PROC output STRING."
 	(condition-case nil
 	    (progn
 	      (mapc (lambda (s)
+                      ;; (message s)
 		      (when-let ((data
 				  (json-parse-string s :object-type 'plist)))
 			(when-let ((context (plist-get data :context)))
@@ -115,6 +116,7 @@ Filter PROC output STRING."
 			  (setq ellama--extract nil)
 			  (setq ellama--extraction-state 'before))
 			(when-let ((response (plist-get data :response)))
+                          (goto-char (process-mark proc))
 			  (if ellama--extract
 			      (progn
 				(setq ellama--line (concat ellama--line response))
@@ -129,7 +131,9 @@ Filter PROC output STRING."
 				       (insert ellama--line)))
 				    (_ nil))
 				  (setq ellama--line nil)))
-			    (insert response)))))
+                            (insert response)
+                            (set-marker (process-mark proc) (point))
+                            ))))
 		    (split-string string "\n" t))
 	      (setq ellama--unprocessed-data nil)
 	      (set-marker (process-mark proc) (point))
@@ -219,7 +223,7 @@ default. Default value is `ellama-template'."
 	 :name "ellama"
 	 :command (list
 		   ellama-curl-executable
-		   "-X" "POST" ellama-url "-d"
+                   "-s" "-X" "POST" ellama-url "-d"
 		   (json-encode-plist ellama--request))
 	 :filter 'ellama--filter
 	 :sentinel sentinel)))))

--- a/ellama.el
+++ b/ellama.el
@@ -108,7 +108,6 @@ Filter PROC output STRING."
 	(condition-case nil
 	    (progn
 	      (mapc (lambda (s)
-                      ;; (message s)
 		      (when-let ((data
 				  (json-parse-string s :object-type 'plist)))
 			(when-let ((context (plist-get data :context)))
@@ -132,8 +131,7 @@ Filter PROC output STRING."
 				    (_ nil))
 				  (setq ellama--line nil)))
                             (insert response)
-                            (set-marker (process-mark proc) (point))
-                            ))))
+                            (set-marker (process-mark proc) (point))))))
 		    (split-string string "\n" t))
 	      (setq ellama--unprocessed-data nil)
 	      (set-marker (process-mark proc) (point))


### PR DESCRIPTION
I encountered some issues while using `ellama.el` in a Windows 10 environment. After fixing them, it was able to function properly. 

There were two main issues:

1. By default, `curl` outputs progress to the process, which needs to be removed.
2. When outputting a long text, there may be a problem of disorder when inserting. This can be solved by moving to the end before inserting each time.

Thank you again for providing this tool, which allows for efficient communication with LLM in emacs.
