### PR TITLE
feat/custom_keymap_and_line_breaking

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,11 +145,78 @@ Create a markdown table from the active region or the current buffer using Ellam
 
 Summarize a webpage fetched from a URL using Ellama.
 
+### ellama-code-complete
+
+Alias to the `ellama-complete-code` function.
+
+### ellama-code-add
+
+Alias to the `ellama-add-code` function.
+
+### ellama-code-edit
+
+Alias to the `ellama-change-code` function.
+
+### ellama-code-improve
+
+Alias to the `ellama-enhance-code` function.
+
+### ellama-improve-wording
+
+Alias to the `ellama-enhance-wording` function.
+
+### ellama-improve-grammar
+
+Alias to the `ellama-enhance-grammar-spelling` function.
+
+### ellama-improve-conciseness
+
+Alias to the `ellama-make-concise` function.
+
+### ellama-make-format
+
+Alias to the `ellama-render` function.
+
+### ellama-ask-interactive
+Alias to the `ellama-ask` function.
+
+
+## Keymap
+
+Here is a table of keybindings and their associated functions in
+Ellama, using the `C-x e` prefix:
+
+| Keymap | Function                   | Description                        |
+|--------|----------------------------|------------------------------------|
+| "c c"  | ellama-code-complete       | Code complete                      |
+| "c a"  | ellama-code-add            | Code add                           |
+| "c e"  | ellama-code-edit           | Code edit                          |
+| "c i"  | ellama-code-improve        | Code improve                       |
+| "c r"  | ellama-code-review         | Code review                        |
+| "s s"  | ellama-summarize           | Summarize                          |
+| "s w"  | ellama-summarize-webpage   | Summarize webpage                  |
+| "i w"  | ellama-improve-wording     | Improve wording                    |
+| "i g"  | ellama-improve-grammar     | Improve grammar and spelling       |
+| "i c"  | ellama-improve-conciseness | Improve conciseness                |
+| "m l"  | ellama-make-list           | Make list                          |
+| "m t"  | ellama-make-table          | Make table                         |
+| "m f"  | ellama-make-format         | Make format                        |
+| "a a"  | ellama-ask-about           | Ask about                          |
+| "a i"  | ellama-ask-interactive     | Chat with ellama (Interactive)     |
+| "t"    | ellama-translate           | Translate the selected region      |
+| "d"    | ellama-define-word         | Define selected word               |
+
+
 ## Configuration
 
 The following variables can be customized for the Ellama client:
 
 - `ellama-buffer`: The default Ellama buffer name.
+- `ellama-enable-break-lines`: Enable visual-mode to \*\*ellama\*\*
+  buffers, hence avoiding the need of horizontal scrolling on long
+  lines.
+- `ellama-enable-keymap`: Enable the Ellama keymap.
+- `ellama-keymap-prefix`: The keymap prefix for Ellama.
 - `ellama-user-nick`: The user nick in logs.
 - `ellama-assistant-nick`: The assistant nick in logs.
 - `ellama-buffer-mode`: The major mode for the Ellama logs buffer.

--- a/README.md
+++ b/README.md
@@ -203,6 +203,8 @@ Ellama, using the `C-x e` prefix:
 | "m f"  | ellama-make-format         | Make format                        |
 | "a a"  | ellama-ask-about           | Ask about                          |
 | "a i"  | ellama-ask-interactive     | Chat with ellama (Interactive)     |
+| "a l"  | ellama-ask-line            | Ask about current line             |
+| "a s"  | ellama-ask-selection       | Ask about selection                |
 | "t"    | ellama-translate           | Translate the selected region      |
 | "d"    | ellama-define-word         | Define selected word               |
 

--- a/README.md
+++ b/README.md
@@ -205,8 +205,9 @@ Ellama, using the `C-x e` prefix:
 | "a i"  | ellama-ask-interactive     | Chat with ellama (Interactive)     |
 | "a l"  | ellama-ask-line            | Ask about current line             |
 | "a s"  | ellama-ask-selection       | Ask about selection                |
-| "t"    | ellama-translate           | Translate the selected region      |
-| "d"    | ellama-define-word         | Define selected word               |
+| "t t"  | ellama-translate           | Text translate                     |
+| "t c"  | ellama-complete            | Text complete                      |
+| "d w"  | ellama-define-word         | Define word                        |
 
 
 ## Configuration
@@ -214,9 +215,6 @@ Ellama, using the `C-x e` prefix:
 The following variables can be customized for the Ellama client:
 
 - `ellama-buffer`: The default Ellama buffer name.
-- `ellama-enable-break-lines`: Enable visual-mode to \*\*ellama\*\*
-  buffers, hence avoiding the need of horizontal scrolling on long
-  lines.
 - `ellama-enable-keymap`: Enable the Ellama keymap.
 - `ellama-keymap-prefix`: The keymap prefix for Ellama.
 - `ellama-user-nick`: The user nick in logs.

--- a/README.md
+++ b/README.md
@@ -180,7 +180,6 @@ Alias to the `ellama-render` function.
 ### ellama-ask-interactive
 Alias to the `ellama-ask` function.
 
-
 ## Keymap
 
 Here is a table of keybindings and their associated functions in
@@ -208,7 +207,6 @@ Ellama, using the `C-x e` prefix:
 | "t t"  | ellama-translate           | Text translate                     |
 | "t c"  | ellama-complete            | Text complete                      |
 | "d w"  | ellama-define-word         | Define word                        |
-
 
 ## Configuration
 

--- a/ellama.el
+++ b/ellama.el
@@ -97,21 +97,6 @@
   (rx (minimal-match
        (literal "```") (zero-or-more anything))))
 
-(defun ellama-set-visual-line-mode-for-ellama-buffer ()
-  "Set `visual-line-mode' for the *ellama* buffer."
-  (when (string-prefix-p "*ellama*" (buffer-name))
-    (visual-line-mode 1)))
-
-(defcustom ellama-enable-break-lines t
-  "Enable or disable break lines for *ellama* buffer."
-  :type 'boolean
-  :group 'ellama
-  :set (lambda (symbol value)
-         (set symbol value)
-         (if value
-             (add-hook 'buffer-list-update-hook 'ellama-set-visual-line-mode-for-ellama-buffer)
-           (remove-hook 'buffer-list-update-hook 'ellama-set-visual-line-mode-for-ellama-buffer))))
-
 (defun ellama-setup-keymap ()
   "Set up the Ellama keymap and bindings."
   (interactive)
@@ -122,7 +107,7 @@
 
   (let ((key-commands
           '(
-             ;; code
+               ;; code
 	           ("c c" ellama-code-complete "Code complete")
 	           ("c a" ellama-code-add "Code add")
 	           ("c e" ellama-code-edit "Code edit")
@@ -141,15 +126,16 @@
 	           ("m f" ellama-make-format "Make format")
 	           ;; ask
 	           ("a a" ellama-ask-about "Ask about")
-	           ("a i" ellama-ask-interactive "Chat with ellama")
+	           ("a i" ellama-ask-interactive "Ask interactively")
 	           ("a l" ellama-ask-line "Ask about current line")
 	           ("a s" ellama-ask-selection "Ask about selection")
-	           ;; other
-	           ("t"   ellama-translate "Translate the selected region")
-	           ("d"   ellama-define-word "Define selected word"))))
+	           ;; text
+	           ("t t" ellama-translate "Text translate")
+	           ("t c" ellama-complete "Text complete")
+			   ;; define
+	           ("d w" ellama-define-word "Define word"))))
             (dolist (key-command key-commands)
             (define-key ellama-keymap (kbd (car key-command)) (cadr key-command)))))
-
 
 (defcustom ellama-keymap-prefix "C-x e"
   "Key sequence for Ellama Commands."

--- a/ellama.el
+++ b/ellama.el
@@ -98,8 +98,8 @@
        (literal "```") (zero-or-more anything))))
 
 
-(defun set-visual-line-mode-for-ellama-buffer ()
-  "Sets visual-line-mode for the *ellama* buffer"
+(defun ellama-set-visual-line-mode-for-ellama-buffer ()
+  "Set `visual-line-mode' for the *ellama* buffer."
   (when (string-prefix-p "*ellama*" (buffer-name))
     (visual-line-mode 1)))
 
@@ -110,8 +110,8 @@
 	:set (lambda (symbol value)
          (set symbol value)
          (if value
-           (add-hook 'buffer-list-update-hook 'set-visual-line-mode-for-ellama-buffer)
-			     (remove-hook 'buffer-list-update-hook 'set-visual-line-mode-for-ellama-buffer))))
+           (add-hook 'buffer-list-update-hook 'ellama-set-visual-line-mode-for-ellama-buffer)
+			     (remove-hook 'buffer-list-update-hook 'ellama-set-visual-line-mode-for-ellama-buffer))))
 
 (defun ellama-setup-keymap ()
 	"Set up the Ellama keymap and bindings."
@@ -123,13 +123,22 @@
 
 	(let ((key-commands
           '(("a" ellama-ask-about "Ask about selected region")
-			       ("b" ellama-make-concise "Better text")
-			       ("c" ellama-chat "Chat with Ellama")
-			       ("d" ellama-define-word "Define selected word")
-			       ("r" ellama-code-review "Code-review selected code")
-			       ("s" ellama-summarize "Summarize selected text")
-			       ("t" ellama-translate "Translate the selected region")
-			       ("w" ellama-summarize-webpage "Summarize a web page"))))
+			      ("b" ellama-make-concise "Better text")
+			      ("c" ellama-chat "Chat with Ellama")
+			      ("d" ellama-define-word "Define selected word")
+			      ("r" ellama-code-review "Code-review selected code")
+			      ("s" ellama-summarize "Summarize selected text")
+			      ("t" ellama-translate "Translate the selected region")
+			      ("w" ellama-summarize-webpage "Summarize a web page")
+            ("c" ellama-render "Convert text to a specified format")
+            ("e" ellama-enhance-grammar-spelling "Enhance grammar and spelling")
+            ("g" ellama-change-code "Change selected code")
+            ("m" ellama-make-list "Create a markdown list")
+            ("n" ellama-enhance-wording "Enhance wording")
+            ("o" ellama-enhance-code "Enhance selected code")
+            ("t" ellama-make-table "Generate a markdown table")
+            ("x" ellama-complete-code "Complete selected code")
+            ("z" ellama-add-code "Add new code based on description"))))
     (dolist (key-command key-commands)
 		  (define-key ellama-keymap (kbd (car key-command)) (cadr key-command)))))
 

--- a/ellama.el
+++ b/ellama.el
@@ -142,6 +142,8 @@
 	           ;; ask
 	           ("a a" ellama-ask-about "Ask about")
 	           ("a i" ellama-ask-interactive "Chat with ellama")
+	           ("a l" ellama-ask-line "Ask about current line")
+	           ("a s" ellama-ask-selection "Ask about selection")
 	           ;; other
 	           ("t"   ellama-translate "Translate the selected region")
 	           ("d"   ellama-define-word "Define selected word"))))

--- a/ellama.el
+++ b/ellama.el
@@ -97,6 +97,59 @@
   (rx (minimal-match
        (literal "```") (zero-or-more anything))))
 
+
+(defun set-visual-line-mode-for-ellama-buffer ()
+  "Sets visual-line-mode for the *ellama* buffer"
+  (when (string-prefix-p "*ellama*" (buffer-name))
+    (visual-line-mode 1)))
+
+(defcustom ellama-enable-break-lines t
+	"Enable or disable break lines for *ellama* buffer."
+	:type 'boolean
+	:group 'ellama
+	:set (lambda (symbol value)
+         (set symbol value)
+         (if value
+           (add-hook 'buffer-list-update-hook 'set-visual-line-mode-for-ellama-buffer)
+			     (remove-hook 'buffer-list-update-hook 'set-visual-line-mode-for-ellama-buffer))))
+
+(defun ellama-setup-keymap ()
+	"Set up the Ellama keymap and bindings."
+	(interactive)
+	(defvar ellama-keymap (make-sparse-keymap)
+    "Keymap for Ellama Commands")
+
+	(define-key global-map (kbd ellama-keymap-prefix) ellama-keymap)
+
+	(let ((key-commands
+          '(("a" ellama-ask-about "Ask about selected region")
+			       ("b" ellama-make-concise "Better text")
+			       ("c" ellama-chat "Chat with Ellama")
+			       ("d" ellama-define-word "Define selected word")
+			       ("r" ellama-code-review "Code-review selected code")
+			       ("s" ellama-summarize "Summarize selected text")
+			       ("t" ellama-translate "Translate the selected region")
+			       ("w" ellama-summarize-webpage "Summarize a web page"))))
+    (dolist (key-command key-commands)
+		  (define-key ellama-keymap (kbd (car key-command)) (cadr key-command)))))
+
+(defcustom ellama-keymap-prefix "C-x e"
+	"Key sequence for Ellama Commands."
+	:type 'string
+	:group 'ellama)
+
+(defcustom ellama-enable-keymap t
+	"Enable or disable Ellama keymap."
+	:type 'boolean
+	:group 'ellama
+	:set (lambda (symbol value)
+         (set symbol value)
+         (if value
+           (ellama-setup-keymap)
+			     ;; If ellama-enable-keymap is nil, remove the key bindings
+			     (define-key global-map (kbd ellama-keymap-prefix) nil))))
+
+
 (defun ellama-stream (prompt &rest args)
   "Query ellama for PROMPT.
 ARGS contains keys for fine control.

--- a/ellama.el
+++ b/ellama.el
@@ -111,7 +111,7 @@
          (set symbol value)
          (if value
            (add-hook 'buffer-list-update-hook 'ellama-set-visual-line-mode-for-ellama-buffer)
-			     (remove-hook 'buffer-list-update-hook 'ellama-set-visual-line-mode-for-ellama-buffer))))
+           (remove-hook 'buffer-list-update-hook 'ellama-set-visual-line-mode-for-ellama-buffer))))
 
 (defun ellama-setup-keymap ()
 	"Set up the Ellama keymap and bindings."
@@ -123,13 +123,13 @@
 
 	(let ((key-commands
           '(("a" ellama-ask-about "Ask about selected region")
-			      ("b" ellama-make-concise "Better text")
-			      ("c" ellama-chat "Chat with Ellama")
-			      ("d" ellama-define-word "Define selected word")
-			      ("r" ellama-code-review "Code-review selected code")
-			      ("s" ellama-summarize "Summarize selected text")
-			      ("t" ellama-translate "Translate the selected region")
-			      ("w" ellama-summarize-webpage "Summarize a web page")
+            ("b" ellama-make-concise "Better text")
+            ("c" ellama-chat "Chat with Ellama")
+            ("d" ellama-define-word "Define selected word")
+            ("r" ellama-code-review "Code-review selected code")
+            ("s" ellama-summarize "Summarize selected text")
+            ("t" ellama-translate "Translate the selected region")
+            ("w" ellama-summarize-webpage "Summarize a web page")
             ("c" ellama-render "Convert text to a specified format")
             ("e" ellama-enhance-grammar-spelling "Enhance grammar and spelling")
             ("g" ellama-change-code "Change selected code")
@@ -140,7 +140,7 @@
             ("x" ellama-complete-code "Complete selected code")
             ("z" ellama-add-code "Add new code based on description"))))
     (dolist (key-command key-commands)
-		  (define-key ellama-keymap (kbd (car key-command)) (cadr key-command)))))
+      (define-key ellama-keymap (kbd (car key-command)) (cadr key-command)))))
 
 (defcustom ellama-keymap-prefix "C-x e"
 	"Key sequence for Ellama Commands."
@@ -155,8 +155,8 @@
          (set symbol value)
          (if value
            (ellama-setup-keymap)
-			     ;; If ellama-enable-keymap is nil, remove the key bindings
-			     (define-key global-map (kbd ellama-keymap-prefix) nil))))
+           ;; If ellama-enable-keymap is nil, remove the key bindings
+           (define-key global-map (kbd ellama-keymap-prefix) nil))))
 
 
 (defun ellama-stream (prompt &rest args)

--- a/ellama.el
+++ b/ellama.el
@@ -97,66 +97,69 @@
   (rx (minimal-match
        (literal "```") (zero-or-more anything))))
 
-
 (defun ellama-set-visual-line-mode-for-ellama-buffer ()
   "Set `visual-line-mode' for the *ellama* buffer."
   (when (string-prefix-p "*ellama*" (buffer-name))
     (visual-line-mode 1)))
 
 (defcustom ellama-enable-break-lines t
-	"Enable or disable break lines for *ellama* buffer."
-	:type 'boolean
-	:group 'ellama
-	:set (lambda (symbol value)
+  "Enable or disable break lines for *ellama* buffer."
+  :type 'boolean
+  :group 'ellama
+  :set (lambda (symbol value)
          (set symbol value)
          (if value
-           (add-hook 'buffer-list-update-hook 'ellama-set-visual-line-mode-for-ellama-buffer)
+             (add-hook 'buffer-list-update-hook 'ellama-set-visual-line-mode-for-ellama-buffer)
            (remove-hook 'buffer-list-update-hook 'ellama-set-visual-line-mode-for-ellama-buffer))))
 
 (defun ellama-setup-keymap ()
-	"Set up the Ellama keymap and bindings."
-	(interactive)
-	(defvar ellama-keymap (make-sparse-keymap)
+  "Set up the Ellama keymap and bindings."
+  (interactive)
+  (defvar ellama-keymap (make-sparse-keymap)
     "Keymap for Ellama Commands")
 
-	(define-key global-map (kbd ellama-keymap-prefix) ellama-keymap)
+  (define-key global-map (kbd ellama-keymap-prefix) ellama-keymap)
 
-	(let ((key-commands
-          '(("a" ellama-ask-about "Ask about selected region")
-            ("b" ellama-make-concise "Better text")
-            ("c" ellama-chat "Chat with Ellama")
-            ("d" ellama-define-word "Define selected word")
-            ("r" ellama-code-review "Code-review selected code")
-            ("s" ellama-summarize "Summarize selected text")
-            ("t" ellama-translate "Translate the selected region")
-            ("w" ellama-summarize-webpage "Summarize a web page")
-            ("c" ellama-render "Convert text to a specified format")
-            ("e" ellama-enhance-grammar-spelling "Enhance grammar and spelling")
-            ("g" ellama-change-code "Change selected code")
-            ("m" ellama-make-list "Create a markdown list")
-            ("n" ellama-enhance-wording "Enhance wording")
-            ("o" ellama-enhance-code "Enhance selected code")
-            ("t" ellama-make-table "Generate a markdown table")
-            ("x" ellama-complete-code "Complete selected code")
-            ("z" ellama-add-code "Add new code based on description"))))
+  (let ((key-commands
+         '(("a a"   ellama-ask-about "Ask about selected region")
+           ("m c"   ellama-make-concise "Better text")
+           ("c h"   ellama-chat "Chat with Ellama")
+           ("d w"   ellama-define-word "Define selected word")
+           ("c r"   ellama-code-review "Code-review selected code")
+           ("s m"   ellama-summarize "Summarize selected region")
+           ("s w"   ellama-summarize-webpage "Summarize a web page")
+           ("t"     ellama-translate "Translate the selected region")
+           ("r"     ellama-render "Convert text to a specified format")
+           ("e g s" ellama-enhance-grammar-spelling "Enhance grammar and spelling")
+           ("e w"   ellama-enhance-wording "Enhance wording")
+           ("e c"   ellama-enhance-code "Enhance selected code")
+           ("c c"   ellama-change-code "Replace selected code")
+           ("m l"   ellama-make-list "Create a markdown list")
+           ("m t"   ellama-make-table "Generate a markdown table")
+           ("c o"   ellama-complete-code "Complete selected code")
+           ("a c"   ellama-add-code "Add new code based on description"))))
     (dolist (key-command key-commands)
-      (define-key ellama-keymap (kbd (car key-command)) (cadr key-command)))))
+      (let ((key (car key-command))
+            (function (cadr key-command)))
+        (eval `(define-key ellama-keymap (kbd ,key) ',function))))))
 
 (defcustom ellama-keymap-prefix "C-x e"
-	"Key sequence for Ellama Commands."
-	:type 'string
-	:group 'ellama)
+  "Key sequence for Ellama Commands."
+  :type 'string
+  :group 'ellama)
 
 (defcustom ellama-enable-keymap t
-	"Enable or disable Ellama keymap."
-	:type 'boolean
-	:group 'ellama
-	:set (lambda (symbol value)
+  "Enable or disable Ellama keymap."
+  :type 'boolean
+  :group 'ellama
+  :set (lambda (symbol value)
          (set symbol value)
          (if value
-           (ellama-setup-keymap)
+             (ellama-setup-keymap)
            ;; If ellama-enable-keymap is nil, remove the key bindings
            (define-key global-map (kbd ellama-keymap-prefix) nil))))
+
+
 
 
 (defun ellama-stream (prompt &rest args)

--- a/ellama.el
+++ b/ellama.el
@@ -121,27 +121,33 @@
   (define-key global-map (kbd ellama-keymap-prefix) ellama-keymap)
 
   (let ((key-commands
-         '(("a a"   ellama-ask-about "Ask about selected region")
-           ("m c"   ellama-make-concise "Better text")
-           ("c h"   ellama-chat "Chat with Ellama")
-           ("d w"   ellama-define-word "Define selected word")
-           ("c r"   ellama-code-review "Code-review selected code")
-           ("s m"   ellama-summarize "Summarize selected region")
-           ("s w"   ellama-summarize-webpage "Summarize a web page")
-           ("t"     ellama-translate "Translate the selected region")
-           ("r"     ellama-render "Convert text to a specified format")
-           ("e g s" ellama-enhance-grammar-spelling "Enhance grammar and spelling")
-           ("e w"   ellama-enhance-wording "Enhance wording")
-           ("e c"   ellama-enhance-code "Enhance selected code")
-           ("c c"   ellama-change-code "Replace selected code")
-           ("m l"   ellama-make-list "Create a markdown list")
-           ("m t"   ellama-make-table "Generate a markdown table")
-           ("c o"   ellama-complete-code "Complete selected code")
-           ("a c"   ellama-add-code "Add new code based on description"))))
-    (dolist (key-command key-commands)
-      (let ((key (car key-command))
-            (function (cadr key-command)))
-        (eval `(define-key ellama-keymap (kbd ,key) ',function))))))
+          '(
+             ;; code
+	           ("c c" ellama-code-complete "Code complete")
+	           ("c a" ellama-code-add "Code add")
+	           ("c e" ellama-code-edit "Code edit")
+	           ("c i" ellama-code-improve "Code improve")
+	           ("c r" ellama-code-review "Code review")
+	           ;; summarize
+	           ("s s" ellama-summarize "Summarize")
+	           ("s w" ellama-summarize-webpage "Summarize webpage")
+	           ;; improve
+	           ("i w" ellama-improve-wording "Improve wording")
+	           ("i g" ellama-improve-grammar "Improve grammar and spelling")
+	           ("i c" ellama-improve-conciseness "Improve conciseness")
+	           ;; make
+	           ("m l" ellama-make-list "Make list")
+	           ("m t" ellama-make-table "Make table")
+	           ("m f" ellama-make-format "Make format")
+	           ;; ask
+	           ("a a" ellama-ask-about "Ask about")
+	           ("a i" ellama-ask-interactive "Chat with ellama")
+	           ;; other
+	           ("t"   ellama-translate "Translate the selected region")
+	           ("d"   ellama-define-word "Define selected word"))))
+            (dolist (key-command key-commands)
+            (define-key ellama-keymap (kbd (car key-command)) (cadr key-command)))))
+
 
 (defcustom ellama-keymap-prefix "C-x e"
   "Key sequence for Ellama Commands."
@@ -158,9 +164,6 @@
              (ellama-setup-keymap)
            ;; If ellama-enable-keymap is nil, remove the key bindings
            (define-key global-map (kbd ellama-keymap-prefix) nil))))
-
-
-
 
 (defun ellama-stream (prompt &rest args)
   "Query ellama for PROMPT.
@@ -300,6 +303,33 @@ In BUFFER at POINT will be inserted result between PREFIX and SUFFIX."
 
 ;;;###autoload
 (defalias 'ellama-ask 'ellama-chat)
+
+;;;###autoload
+(defalias 'ellama-code-complete 'ellama-complete-code)
+
+;;;###autoload
+(defalias 'ellama-code-add 'ellama-add-code)
+
+;;;###autoload
+(defalias 'ellama-code-edit 'ellama-change-code)
+
+;;###autoload
+(defalias 'ellama-code-improve 'ellama-enhance-code)
+
+;;;###autoload
+(defalias 'ellama-improve-wording 'ellama-enhance-wording)
+
+;;;###autoload
+(defalias 'ellama-improve-grammar 'ellama-enhance-grammar-spelling)
+
+;;;###autoload
+(defalias 'ellama-improve-conciseness 'ellama-make-concise)
+
+;;;###autoload
+(defalias 'ellama-make-format 'ellama-render)
+
+;;;###autoload
+(defalias 'ellama-ask-interactive 'ellama-ask)
 
 ;;;###autoload
 (defun ellama-ask-about ()


### PR DESCRIPTION
Hello there! Thanks for this awesome package!

I was customizing it a bit and making a blog post about it when I decided to perform a **couple** of additions, I hope this surprise PR is OK with you :)

Demo: 

https://github.com/s-kostyaev/ellama/assets/16169950/4dc6c39e-29e9-432b-a44c-7ad02623c650


**1.** Adds a custom keymap (default C-x e ...) to the main commands of ellama. This is customizable via 2 variables, on to turn the feature ON/OFF, another to change "C-x e" to another prefix.

C-x e ?  will list available commands

M-x ellama will show defined keybindings

C-x e (wait) will show available commands if which key mode is on

C-x e c - will chat, C-x e a will ask about selection, and so on:

<img width="339" alt="image" src="https://github.com/s-kostyaev/ellama/assets/16169950/59af438c-f1fd-4ce4-9aac-3b298467ab25">

As you see I only added a few major features, if you wish, complementing after will be easy. 

**2.** Adds breaking lines to all ellama* buffers by adding the visual-line mode to the buffer. Customizable via another custom variable.

Note: I wanted all changes to be available as soon as set/reseted, the only way I could find to do so was defining this defcustom after the functions were created, so the :set lambda function could call it.

This is nice because instead of this:
<img width="1181" alt="image" src="https://github.com/s-kostyaev/ellama/assets/16169950/d527c74a-f63b-43ec-9fff-3a289fbd1d60">

We get this:
<img width="1185" alt="image" src="https://github.com/s-kostyaev/ellama/assets/16169950/40e7066f-a0de-49b0-9266-00f9f35f0b70">

These are the new entries to the `customize-group ellama`:

<img width="848" alt="image" src="https://github.com/s-kostyaev/ellama/assets/16169950/3a3bcbbd-a9b9-4bbc-a576-42235348af86">

