### PR TITLE
feat: Introduce interactive LLM switching

### DIFF
--- a/ellama.el
+++ b/ellama.el
@@ -180,6 +180,23 @@ In BUFFER at POINT will be inserted result between PREFIX and SUFFIX."
 			      (cancel-change-group ellama--change-group)
 			      (error "Error calling the LLM: %s" msg))))))))
 
+(defun ellama-select-local-ollama-model ()
+  "Override the default `ellama-provider' with the local selected model."
+  (interactive)
+  (let* ((ollama-list-command "ollama list | sed 1d")
+         (ollama-models (split-string (shell-command-to-string ollama-list-command) "\n" t))
+         (ellama-selected-ollama-model
+          (car (split-string (completing-read "Select a local model: " ollama-models)))))
+
+    (setq-local ellama-selected-ollama-model ellama-selected-ollama-model)
+    
+    (setopt ellama-provider
+            (make-llm-ollama
+             :chat-model ellama-selected-ollama-model :embedding-model ellama-selected-ollama-model))
+
+    (message "Using now Ollama Model: %s. Default configuration is dropped for this Emacs session."
+			 (propertize ellama-selected-ollama-model 'face '(:weight bold)))))
+
 ;;;###autoload
 (defun ellama-chat (prompt)
   "Send PROMPT to ellama chat with conversation history."

--- a/ellama.el
+++ b/ellama.el
@@ -183,18 +183,16 @@ In BUFFER at POINT will be inserted result between PREFIX and SUFFIX."
 (defun ellama-select-local-ollama-model ()
   "Override the default `ellama-provider' with the local selected model."
   (interactive)
-  (let* ((ollama-list-command "ollama list | sed 1d")
+  (let* ((ollama-list-command "ollama list")
          (ollama-models (split-string (shell-command-to-string ollama-list-command) "\n" t))
          (ellama-selected-ollama-model
-          (car (split-string (completing-read "Select a local model: " ollama-models)))))
+         (car (split-string (completing-read "Select a local model: " (cdr ollama-models))))))
 
-    (setq-local ellama-selected-ollama-model ellama-selected-ollama-model)
-    
-    (setopt ellama-provider
+         (setq ellama-provider
             (make-llm-ollama
              :chat-model ellama-selected-ollama-model :embedding-model ellama-selected-ollama-model))
 
-    (message "Using now Ollama Model: %s. Default configuration is dropped for this Emacs session."
+         (message "Using now Ollama Model: %s. Default configuration is dropped for this Emacs session."
 			 (propertize ellama-selected-ollama-model 'face '(:weight bold)))))
 
 ;;;###autoload


### PR DESCRIPTION
This commit adds the `ellama-select-local-ollama-model` function, allowing users to interactively switch between locally available Ollama models.

You can call this function:
![image](https://github.com/s-kostyaev/ellama/assets/16169950/bc14af1c-d5f2-4157-b790-1d204d4fdd7f)

It will prompt you to select a model:
![image](https://github.com/s-kostyaev/ellama/assets/16169950/b6d7a25f-9cdb-4d5c-a7c9-37b4da4388c4)

You select your model:
![image](https://github.com/s-kostyaev/ellama/assets/16169950/d4a9f9f7-763f-4364-bf86-fe22c9c39095)

You interact with the model:
![image](https://github.com/s-kostyaev/ellama/assets/16169950/68398590-c208-4162-91a9-cb781d2e7d2a)

You then call the function again, select another model, like:
![image](https://github.com/s-kostyaev/ellama/assets/16169950/11c1eac1-2258-441c-951e-2950d355204a)

And then, you can use this one:
![image](https://github.com/s-kostyaev/ellama/assets/16169950/77cdb86b-868f-4091-8268-e8494afa0e8b)

This provides a "quick switch" between models. I've been using it to change codellama models when the less powerfull ones starts giving nonsense answers, quicky and some sort of dirty. ;)

