### PR TITLE
Merge duplicate code

### DIFF
--- a/ellama.el
+++ b/ellama.el
@@ -178,7 +178,7 @@
 ARGS contains keys for fine control.
 
 :buffer BUFFER -- BUFFER is the buffer (or `buffer-name') to insert ellama reply
-in. Default value is (current-buffer).
+in.  Default value is (current-buffer).
 
 :point POINT -- POINT is the point in buffer to insert ellama reply at.
 
@@ -191,7 +191,7 @@ current (buffer-local) conversation.
 failure (with BUFFER current).
 
 :on-done ON-DONE -- ON-DONE a function that's called when the request completes
-(with BUFFER current)."
+\(with BUFFER current)."
   (let* ((buffer (or (plist-get args :buffer) (current-buffer)))
 	 (point (or (plist-get args :point)
 		    (with-current-buffer buffer (point))))

--- a/ellama.el
+++ b/ellama.el
@@ -178,20 +178,20 @@
 ARGS contains keys for fine control.
 
 :buffer BUFFER -- BUFFER is the buffer (or `buffer-name') to insert ellama reply
-in.  Default value is (current-buffer).
+in. Default value is (current-buffer).
 
 :point POINT -- POINT is the point in buffer to insert ellama reply at.
 
 :filter FILTER -- FILTER is a function applied to (partial) response strings.
 
-:session SESSION -- if session is non-nil, the PROMPT will be appended to the current (buffer-local)
-conversation.
+:session SESSION -- if session is non-nil, the PROMPT will be appended to the
+current (buffer-local) conversation.
 
-:on-error ON-ERROR -- ON-ERROR a function that's called with an error message on failure (with
-BUFFER current).
+:on-error ON-ERROR -- ON-ERROR a function that's called with an error message on
+failure (with BUFFER current).
 
-:on-done ON-DONE -- ON-DONE a function that's called when the request completes (with BUFFER
-current)."
+:on-done ON-DONE -- ON-DONE a function that's called when the request completes
+(with BUFFER current)."
   (let* ((buffer (or (plist-get args :buffer) (current-buffer)))
 	 (point (or (plist-get args :point)
 		    (with-current-buffer buffer (point))))

--- a/ellama.el
+++ b/ellama.el
@@ -180,7 +180,18 @@ ARGS contains keys for fine control.
 :buffer BUFFER -- BUFFER is the buffer (or `buffer-name') to insert ellama reply
 in.  Default value is (current-buffer).
 
-:point POINT -- POINT is the point in buffer to insert ellama reaply at."
+:point POINT -- POINT is the point in buffer to insert ellama reply at.
+
+:filter FILTER -- FILTER is a function applied to (partial) response strings.
+
+:session SESSION -- if session is non-nil, the PROMPT will be appended to the current (buffer-local)
+conversation.
+
+:on-error ON-ERROR -- ON-ERROR a function that's called with an error message on failure (with
+BUFFER current).
+
+:on-done ON-DONE -- ON-DONE a function that's called when the request completes (with BUFFER
+current)."
   (let* ((buffer (or (plist-get args :buffer) (current-buffer)))
 	 (point (or (plist-get args :point)
 		    (with-current-buffer buffer (point))))

--- a/ellama.el
+++ b/ellama.el
@@ -182,10 +182,11 @@ in.  Default value is (current-buffer).
 
 :point POINT -- POINT is the point in buffer to insert ellama reply at.
 
-:filter FILTER -- FILTER is a function applied to (partial) response strings.
+:filter FILTER -- FILTER is a function that's applied to (partial) response
+strings before they're inserted into the BUFFER.
 
 :session SESSION -- if session is non-nil, the PROMPT will be appended to the
-current (buffer-local) conversation.
+current (BUFFER-local) conversation.
 
 :on-error ON-ERROR -- ON-ERROR a function that's called with an error message on
 failure (with BUFFER current).

--- a/ellama.el
+++ b/ellama.el
@@ -117,6 +117,10 @@
   (rx (minimal-match
        (literal "```") (zero-or-more anything))))
 
+(defun ellama--code-filter (text)
+  "Filter code prefix/suffix from TEXT."
+  (string-trim text ellama--code-prefix ellama--code-suffix))
+
 (defun ellama-setup-keymap ()
   "Set up the Ellama keymap and bindings."
   (interactive)
@@ -179,8 +183,16 @@ in.  Default value is (current-buffer).
 :point POINT -- POINT is the point in buffer to insert ellama reaply at."
   (let* ((buffer (or (plist-get args :buffer) (current-buffer)))
 	 (point (or (plist-get args :point)
-		    (with-current-buffer buffer (point)))))
+		    (with-current-buffer buffer (point))))
+	 (filter (or (plist-get args :filter) #'identity))
+	 (session (plist-get args :session))
+	 (errcb (or (plist-get args :on-error) (lambda (msg) (error "Error calling the LLM: %s" msg))))
+	 (donecb (or (plist-get args :on-done) #'ignore)))
     (with-current-buffer buffer
+      (if (and session ellama--chat-prompt)
+	  (llm-chat-prompt-append-response
+	   ellama--chat-prompt prompt)
+	(setq ellama--chat-prompt (llm-make-simple-chat-prompt prompt)))
       (unwind-protect
 	  (save-excursion
 	    (let* ((start (make-marker))
@@ -194,7 +206,7 @@ in.  Default value is (current-buffer).
 			  (save-excursion
 			    (goto-char start)
 			    (delete-region start end)
-			    (insert text)
+			    (insert (funcall filter text))
 			    (fill-region start (point)))
 			  (goto-char pt))
 			(when ellama-auto-scroll
@@ -214,69 +226,19 @@ in.  Default value is (current-buffer).
 	      (set-marker-insertion-type end t)
 	      (spinner-start ellama-spinner-type)
 	      (llm-chat-streaming ellama-provider
-				  (llm-make-simple-chat-prompt prompt)
+				  ellama--chat-prompt
 				  insert-text
 				  (lambda (text)
 				    (funcall insert-text text)
 				    (with-current-buffer buffer
 				      (undo-amalgamate-change-group ellama--change-group)
 				      (accept-change-group ellama--change-group)
-				      (spinner-stop)))
+				      (spinner-stop)
+				      (funcall donecb)))
 				  (lambda (_ msg)
-				    (error "Error calling the LLM: %s" msg)
-				    (cancel-change-group ellama--change-group)))))))))
-
-(defun ellama-stream-filter (prompt prefix suffix buffer point)
-  "Query ellama for PROMPT with filtering.
-In BUFFER at POINT will be inserted result between PREFIX and SUFFIX."
-  (with-current-buffer buffer
-    (unwind-protect
-	(save-excursion
-	  (let* ((start (make-marker))
-		 (end (make-marker))
-		 (window (selected-window))
-		 (insert-text
-		  (lambda (text)
-		    ;; Erase and insert the new text between the marker cons.
-		    (with-current-buffer (marker-buffer start)
-		      (let ((pt (point)))
-			(save-excursion
-			  (goto-char start)
-			  (delete-region start end)
-			  ;; remove prefix and suffix parts
-			  (insert (string-trim-right
-				   (string-trim-left text prefix)
-				   suffix))
-			  (fill-region start (point)))
-			(goto-char pt))
-		      (when ellama-auto-scroll
-			(select-window (get-window-with-predicate
-					(lambda (_)
-					  (eq (current-buffer)
-					      (get-buffer ellama-buffer))))
-				       t)
-			(goto-char (point-max))
-			(recenter -1)
-			(select-window window))))))
-	    (setq ellama--change-group (prepare-change-group))
-	    (activate-change-group ellama--change-group)
-	    (set-marker start point)
-	    (set-marker end point)
-	    (set-marker-insertion-type start nil)
-	    (set-marker-insertion-type end t)
-	    (spinner-start ellama-spinner-type)
-	    (llm-chat-streaming ellama-provider
-				(llm-make-simple-chat-prompt prompt)
-				insert-text
-				(lambda (text)
-				  (funcall insert-text text)
-				  (with-current-buffer buffer
-				    (undo-amalgamate-change-group ellama--change-group)
-				    (accept-change-group ellama--change-group)
-				    (spinner-stop)))
-				(lambda (_ msg)
-				  (cancel-change-group ellama--change-group)
-				  (error "Error calling the LLM: %s" msg))))))))
+				    (with-current-buffer buffer
+				      (cancel-change-group ellama--change-group)
+				      (funcall errcb msg))))))))))
 
 ;;;###autoload
 (defun ellama-chat (prompt)
@@ -288,60 +250,15 @@ In BUFFER at POINT will be inserted result between PREFIX and SUFFIX."
       (funcall ellama-buffer-mode)))
   (display-buffer ellama-buffer)
   (with-current-buffer ellama-buffer
-    (if ellama--chat-prompt
-	(llm-chat-prompt-append-response
-	 ellama--chat-prompt prompt)
-      (setq ellama--chat-prompt (llm-make-simple-chat-prompt prompt)))
     (save-excursion
       (goto-char (point-max))
       (insert "## " ellama-user-nick ":\n" prompt "\n\n"
 	      "## " ellama-assistant-nick ":\n")
-      (let* ((start (make-marker))
-	     (end (make-marker))
-	     (point (point-max))
-	     (window (selected-window))
-	     (insert-text
-	      (lambda (text)
-		;; Erase and insert the new text between the marker cons.
-		(with-current-buffer (marker-buffer start)
-		  (let ((pt (point)))
-		    (save-excursion
-		      (goto-char start)
-		      (delete-region start end)
-		      (insert text)
-		      (fill-region start (point)))
-		    (goto-char pt))
-		  (when ellama-auto-scroll
-		    (select-window (get-window-with-predicate
-				    (lambda (_)
-				      (eq (current-buffer)
-					  (get-buffer ellama-buffer))))
-				   t)
-		    (goto-char (point-max))
-		    (recenter -1)
-		    (select-window window))))))
-	(setq ellama--change-group (prepare-change-group))
-	(activate-change-group ellama--change-group)
-	(set-marker start point)
-	(set-marker end point)
-	(set-marker-insertion-type start nil)
-	(set-marker-insertion-type end t)
-	(spinner-start ellama-spinner-type)
-	(llm-chat-streaming ellama-provider
-			    ellama--chat-prompt
-			    insert-text
-			    (lambda (text)
-			      (funcall insert-text text)
-			      (with-current-buffer ellama-buffer
-				(save-excursion
-				  (goto-char (point-max))
-				  (insert "\n\n"))
-				(undo-amalgamate-change-group ellama--change-group)
-				(accept-change-group ellama--change-group)
-				(spinner-stop)))
-			    (lambda (_ msg)
-			      (cancel-change-group ellama--change-group)
-			      (error "Error calling the LLM: %s" msg)))))))
+      (ellama-stream prompt
+		     :session t
+		     :on-done (lambda () (save-excursion
+				      (goto-char (point-max))
+				      (insert "\n\n")))))))
 
 ;;;###autoload
 (defalias 'ellama-ask 'ellama-chat)
@@ -502,14 +419,12 @@ In BUFFER at POINT will be inserted result between PREFIX and SUFFIX."
 		(point-max)))
 	 (text (buffer-substring-no-properties beg end)))
     (kill-region beg end)
-    (ellama-stream-filter
+    (ellama-stream
      (format
       "Regarding the following code, %s, only ouput the result code in format ```language\n...\n```:\n```\n%s\n```"
       change text)
-     ellama--code-prefix
-     ellama--code-suffix
-     (current-buffer)
-     beg)))
+     :filter #'ellama--code-filter
+     :point beg)))
 
 ;;;###autoload
 (defun ellama-enhance-code ()
@@ -523,14 +438,12 @@ In BUFFER at POINT will be inserted result between PREFIX and SUFFIX."
 		(point-max)))
 	 (text (buffer-substring-no-properties beg end)))
     (kill-region beg end)
-    (ellama-stream-filter
+    (ellama-stream
      (format
       "Enhance the following code, only ouput the result code in format ```language\n...\n```:\n```\n%s\n```"
       text)
-     ellama--code-prefix
-     ellama--code-suffix
-     (current-buffer)
-     beg)))
+     :filter #'ellama--code-filter
+     :point beg)))
 
 ;;;###autoload
 (defun ellama-complete-code ()
@@ -543,14 +456,12 @@ In BUFFER at POINT will be inserted result between PREFIX and SUFFIX."
 		  (region-end)
 		(point)))
 	 (text (buffer-substring-no-properties beg end)))
-    (ellama-stream-filter
+    (ellama-stream
      (format
       "Continue the following code, only write new code in format ```language\n...\n```:\n```\n%s\n```"
       text)
-     ellama--code-prefix
-     ellama--code-suffix
-     (current-buffer)
-     end)))
+     :filter #'ellama--code-filter
+     :point end)))
 
 ;;;###autoload
 (defun ellama-add-code (description)
@@ -565,14 +476,11 @@ buffer."
 		  (region-end)
 		(point-max)))
 	 (text (buffer-substring-no-properties beg end)))
-    (ellama-stream-filter
+    (ellama-stream
      (format
       "Context: \n```\n%s\n```\nBased on this context, %s, only ouput the result in format ```\n...\n```"
       text description)
-     ellama--code-prefix
-     ellama--code-suffix
-     (current-buffer)
-     (point))))
+     :filter #'ellama--code-filter)))
 
 
 ;;;###autoload

--- a/ellama.el
+++ b/ellama.el
@@ -190,8 +190,8 @@ current (buffer-local) conversation.
 :on-error ON-ERROR -- ON-ERROR a function that's called with an error message on
 failure (with BUFFER current).
 
-:on-done ON-DONE -- ON-DONE a function that's called when the request completes
-\(with BUFFER current)."
+:on-done ON-DONE -- ON-DONE a function that's called with the full response text
+when the request completes (with BUFFER current)."
   (let* ((buffer (or (plist-get args :buffer) (current-buffer)))
 	 (point (or (plist-get args :point)
 		    (with-current-buffer buffer (point))))
@@ -245,7 +245,7 @@ failure (with BUFFER current).
 				      (undo-amalgamate-change-group ellama--change-group)
 				      (accept-change-group ellama--change-group)
 				      (spinner-stop)
-				      (funcall donecb)))
+				      (funcall donecb text)))
 				  (lambda (_ msg)
 				    (with-current-buffer buffer
 				      (cancel-change-group ellama--change-group)
@@ -267,7 +267,7 @@ failure (with BUFFER current).
 	      "## " ellama-assistant-nick ":\n")
       (ellama-stream prompt
 		     :session t
-		     :on-done (lambda () (save-excursion
+		     :on-done (lambda (_) (save-excursion
 				      (goto-char (point-max))
 				      (insert "\n\n")))))))
 


### PR DESCRIPTION
`ellama-stream`, `ellama-stream-filter`, and `ellama-chat` were mostly
identical so I merged their implementations as much as possible.

`ellama-stream` now supports:

1. A `:filter` keyword argument for filtering responses.
2. A `:session` keyword argument specifying whether or not the prompt should extend an ongoing
   session or be a one-off request.
3. A `:on-error`keyword argument for specifying an "error" callback.
4. A `:on-done`keyword argument for specifying a "done" callback.

Built on #28.