### PR TITLE
Simplify ellama-stream

### DIFF
--- a/ellama.el
+++ b/ellama.el
@@ -212,11 +212,14 @@ when the request completes (with BUFFER current)."
 	      (lambda (text)
 		;; Erase and insert the new text between the marker cons.
 		(with-current-buffer buffer
-		  (save-excursion
+		  ;; Manually save/restore point as save-excursion doesn't restore the point into
+		  ;; the middle of replaced text.
+		  (let ((pt (point)))
 		    (goto-char start)
 		    (delete-region start end)
 		    (insert (funcall filter text))
-		    (fill-region start (point)))
+		    (fill-region start (point))
+		    (goto-char pt))
 		  (when-let ((ellama-auto-scroll)
 			     (window (get-buffer-window buffer)))
 		    (with-selected-window window

--- a/ellama.el
+++ b/ellama.el
@@ -242,6 +242,7 @@ when the request completes (with BUFFER current)."
 			    (lambda (_ msg)
 			      (with-current-buffer buffer
 				(cancel-change-group ellama--change-group)
+				(spinner-stop)
 				(funcall errcb msg))))))))
 
 ;;;###autoload


### PR DESCRIPTION
1. Remove unused `unwind-protect` & `save-excursion`.
2. Use `get-buffer-window` to get the window to scroll.
3. Simplify scroll logic.

Built on #29 (review that first).