### PR TITLE
Fix code trimming

### DIFF
--- a/ellama.el
+++ b/ellama.el
@@ -119,7 +119,8 @@
 
 (defun ellama--code-filter (text)
   "Filter code prefix/suffix from TEXT."
-  (string-trim text ellama--code-prefix ellama--code-suffix))
+  ;; Trim left first as `string-trim' trims from the right and ends up deleting all the code.
+  (string-trim-right (string-trim-left text ellama--code-prefix) ellama--code-suffix))
 
 (defun ellama-setup-keymap ()
   "Set up the Ellama keymap and bindings."


### PR DESCRIPTION
Unfortunately, we need to trim the left side before the right. The default `string-trim` behavior is to trim the right before the left, which deletes the code.

(sorry about that)