### PR TITLE
ellama-nick-prefix is now configurable.

### DIFF
--- a/ellama.el
+++ b/ellama.el
@@ -59,6 +59,11 @@
   :group 'ellama
   :type 'string)
 
+(defcustom ellama-nick-prefix "##"
+  "User and assistant nick prefix in logs."
+  :group 'ellama
+  :type 'string)
+
 (defcustom ellama-buffer-mode (if (fboundp 'markdown-mode)
 				  'markdown-mode
 				'text-mode)
@@ -412,8 +417,8 @@ Will call `ellama-chat-done-callback' on TEXT."
   (with-current-buffer ellama-buffer
     (save-excursion
       (goto-char (point-max))
-      (insert "## " ellama-user-nick ":\n" prompt "\n\n"
-	      "## " ellama-assistant-nick ":\n")
+      (insert ellama-nick-prefix " " ellama-user-nick ":\n" prompt "\n\n"
+	      ellama-nick-prefix " " ellama-assistant-nick ":\n")
       (ellama-stream prompt
 		     :session t
 		     :on-done #'ellama-chat-done))))


### PR DESCRIPTION
ellama-nick-prefix defaults to "##".

ellama-buffer-mode lets you choose the major mode for ellama interactions, but switching it from markdown-mode to org-mode doesn't help much because there's no syntax highlighting.

Changing ellama-nick-prefix to "**" provides a more natural interface for Org lovers.

Using ellama-user-nick-prefix and ellama-assistant-nick-prefix may be preferred.

Potential use case:

```elisp
(setq ellama-user-nick-prefix "**")
(setq ellama-assistant-nick-prefix "***")
```

This would ease scanning.