### PR TITLE
Remove advice and introduce a session-mode

### DIFF
--- a/ellama.el
+++ b/ellama.el
@@ -281,6 +281,7 @@ Too low value can break generated code by splitting long comment lines."
         (add-hook 'kill-buffer-hook 'ellama--session-deactivate nil t))
     (remove-hook 'kill-buffer-hook 'ellama--cancel-current-request)
     (remove-hook 'kill-buffer-hook 'ellama--session-deactivate)
+    (remove-hook 'after-save-hook 'ellama--save-session)
     (ellama--cancel-current-request)
     (ellama--session-deactivate)))
 


### PR DESCRIPTION
This fixes #61 and #60 by:

1. Introducing an `ellama-session-mode` activated in all session buffers and an `ellama-instant-mode` activated in all instant buffers.
2. Binding `[remap keyboard-quit]` in those minor-modes instead of advising it.
3. Hooking into the save and kill buffer hooks instead of advising those functions.