### PR TITLE
Use appropriate ellama prefix based on mode.

### DIFF
--- a/ellama.el
+++ b/ellama.el
@@ -490,18 +490,16 @@ CONTEXT contains context for next request."
 (defun ellama-get-nick-prefix-for-mode ()
   "Returns preferred header prefix char based om the current mode.
 Defaults to #, but supports org-mode. Depends on ellama-major-mode."
-  (let* ((preferred-mode (symbol-name ellama-major-mode))
-         (prefix-char
-          (cond ((string= preferred-mode "org-mode") ?*)
+  (let* ((prefix-char
+          (cond ((provided-mode-derived-p ellama-major-mode "org-mode") ?*)
                 (t ?#))))
     (make-string ellama-nick-prefix-depth prefix-char)))
 
 (defun ellama-get-session-file-extension ()
   "Returns file extension based om the current mode.
 Defaults to md, but supports org. Depends on ellama-major-mode."
-  (let ((preferred-mode (symbol-name ellama-major-mode)))
-    (cond ((= preferred-mode "org-mode") "org")
-          (t "md"))))
+  (cond ((provided-mode-derived-p ellama-major-mode "org-mode") "org")
+        (t "md")))
 
 (defun ellama-new-session (provider prompt &optional ephemeral)
   "Create new ellama session with unique id.

--- a/ellama.el
+++ b/ellama.el
@@ -512,16 +512,16 @@ CONTEXT contains context for next request."
 
 (defun ellama-get-nick-prefix-for-mode ()
   "Return preferred header prefix char based om the current mode.
-Defaults to #, but supports \"org-mode\".  Depends on \"ellama-major-mode.\""
+Defaults to #, but supports `org-mode'.  Depends on `ellama-major-mode'."
   (let* ((prefix-char
-          (cond ((provided-mode-derived-p ellama-major-mode "org-mode") ?*)
+          (cond ((provided-mode-derived-p ellama-major-mode 'org-mode) ?*)
                 (t ?#))))
     (make-string ellama-nick-prefix-depth prefix-char)))
 
 (defun ellama-get-session-file-extension ()
   "Return file extension based om the current mode.
 Defaults to md, but supports org.  Depends on \"ellama-major-mode.\""
-  (cond ((provided-mode-derived-p ellama-major-mode "org-mode") "org")
+  (cond ((provided-mode-derived-p ellama-major-mode 'org-mode) "org")
         (t "md")))
 
 (defun ellama-new-session (provider prompt &optional ephemeral)

--- a/ellama.el
+++ b/ellama.el
@@ -1016,9 +1016,9 @@ Will call `ellama-chat-done-callback' on TEXT."
     (with-current-buffer buffer
       (save-excursion
 	(goto-char (point-max))
-	(insert ellama-nick-prefix " " ellama-user-nick ":\n"
+	(insert (ellama-get-nick-prefix-for-mode) " " ellama-user-nick ":\n"
 		(ellama--format-context session) result "\n\n"
-		ellama-nick-prefix " " ellama-assistant-nick ":\n")
+		(ellama-get-nick-prefix-for-mode) " " ellama-assistant-nick ":\n")
 	(ellama-stream result
 		       :session session
 		       :on-done (ellama--translate-generated-text-on-done translation-buffer)
@@ -1031,9 +1031,9 @@ Will call `ellama-chat-done-callback' on TEXT."
   (with-current-buffer translation-buffer
     (save-excursion
       (goto-char (point-max))
-      (insert ellama-nick-prefix " " ellama-user-nick ":\n"
+      (insert (ellama-get-nick-prefix-for-mode) " " ellama-user-nick ":\n"
 	      (ellama--format-context session) prompt "\n\n"
-	      ellama-nick-prefix " " ellama-assistant-nick ":\n")
+	      (ellama-get-nick-prefix-for-mode) " " ellama-assistant-nick ":\n")
       (ellama-stream
        (format ellama-translation-template
 	       "english"
@@ -1093,9 +1093,9 @@ ARGS contains keys for fine control.
       (with-current-buffer buffer
 	(save-excursion
 	  (goto-char (point-max))
-	  (insert ellama-nick-prefix " " ellama-user-nick ":\n"
+	  (insert (ellama-get-nick-prefix-for-mode) " " ellama-user-nick ":\n"
 		  (ellama--format-context session) prompt "\n\n"
-		  ellama-nick-prefix " " ellama-assistant-nick ":\n")
+		  (ellama-get-nick-prefix-for-mode) " " ellama-assistant-nick ":\n")
 	  (ellama-stream prompt
 			 :session session
 			 :on-done #'ellama-chat-done

--- a/ellama.el
+++ b/ellama.el
@@ -56,7 +56,7 @@
   :type 'string)
 
 (defcustom ellama-nick-prefix-depth 2
-  "Prefix depth"
+  "Prefix depth."
   :group 'ellama
   :type 'integer)
 
@@ -488,6 +488,8 @@ CONTEXT contains context for next request."
 (defvar ellama--new-session-context nil)
 
 (defun ellama-get-nick-prefix-for-mode ()
+  "Returns preferred header prefix char based om the current mode.
+Defaults to #, but supports org-mode. Depends on ellama-major-mode."
   (let* ((preferred-mode (symbol-name ellama-major-mode))
          (prefix-char
           (cond ((string= preferred-mode "org-mode") ?*)
@@ -495,6 +497,8 @@ CONTEXT contains context for next request."
     (make-string ellama-nick-prefix-depth prefix-char)))
 
 (defun ellama-get-session-file-extension ()
+  "Returns file extension based om the current mode.
+Defaults to md, but supports org. Depends on ellama-major-mode."
   (let ((preferred-mode (symbol-name ellama-major-mode)))
     (cond ((= preferred-mode "org-mode") "org")
           (t "md"))))

--- a/ellama.el
+++ b/ellama.el
@@ -488,16 +488,16 @@ CONTEXT contains context for next request."
 (defvar ellama--new-session-context nil)
 
 (defun ellama-get-nick-prefix-for-mode ()
-  "Returns preferred header prefix char based om the current mode.
-Defaults to #, but supports org-mode. Depends on ellama-major-mode."
+  "Return preferred header prefix char based om the current mode.
+Defaults to #, but supports \"org-mode\".  Depends on \"ellama-major-mode.\""
   (let* ((prefix-char
           (cond ((provided-mode-derived-p ellama-major-mode "org-mode") ?*)
                 (t ?#))))
     (make-string ellama-nick-prefix-depth prefix-char)))
 
 (defun ellama-get-session-file-extension ()
-  "Returns file extension based om the current mode.
-Defaults to md, but supports org. Depends on ellama-major-mode."
+  "Return file extension based om the current mode.
+Defaults to md, but supports org.  Depends on \"ellama-major-mode.\""
   (cond ((provided-mode-derived-p ellama-major-mode "org-mode") "org")
         (t "md")))
 


### PR DESCRIPTION
Depends on `ellama-major-mode` and `ellama-nick-prefix-depth`.

Currently supports org-mode, but defaults to markdown-mode's prefix character #.

Eliminates the need for ellama-nick-prefix and ellama-session-file-extension.

Solves #57.