### PR TITLE
Don't insert initial blank line when improving code

### DIFF
--- a/ellama.el
+++ b/ellama.el
@@ -346,7 +346,7 @@ Too low value can break generated code by splitting long comment lines."
 
 (defconst ellama--code-prefix
   (rx (minimal-match
-       (zero-or-more anything) (literal "```") (zero-or-more anything) line-end)))
+       (zero-or-more anything) (literal "```") (zero-or-more anything) (+ (or "\n" "\r")))))
 
 (defconst ellama--code-suffix
   (rx (minimal-match

--- a/tests/test-ellama.el
+++ b/tests/test-ellama.el
@@ -31,11 +31,11 @@
 (ert-deftest test-ellama--code-filter ()
   (should (equal "" (ellama--code-filter "")))
   (should (equal "(hello)" (ellama--code-filter "(hello)")))
-  (should (equal "(hello)" (ellama--code-filter "```lisp\n(hello)```"))))
+  (should (equal "(hello)\n" (ellama--code-filter "```lisp\n(hello)\n```"))))
 
 (ert-deftest test-ellama-code-improve ()
-  (let ((original "(hello)")
-        (improved "```lisp\n(hello)```"))
+  (let ((original "(hello)\n")
+        (improved "```lisp\n(hello)\n```"))
     (with-temp-buffer
       (insert original)
       (cl-letf (((symbol-function 'llm-chat-streaming)

--- a/tests/test-ellama.el
+++ b/tests/test-ellama.el
@@ -1,0 +1,52 @@
+;;; test-ellama.el --- Ellama tests -*- lexical-binding: t -*-
+
+;; Copyright (C) 2023  Free Software Foundation, Inc.
+
+;; Author: Sergey Kostyaev <sskostyaev@gmail.com>
+
+;; This file is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation; either version 3, or (at your option)
+;; any later version.
+
+;; This file is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with GNU Emacs.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Commentary:
+;;
+;; Ellama tests.
+;;
+
+;;; Code:
+
+(require 'cl-lib)
+(require 'ellama)
+(require 'ert)
+
+(ert-deftest test-ellama--code-filter ()
+  (should (equal "" (ellama--code-filter "")))
+  (should (equal "(hello)" (ellama--code-filter "(hello)")))
+  (should (equal "(hello)" (ellama--code-filter "```lisp\n(hello)```"))))
+
+(ert-deftest test-ellama-code-improve ()
+  (let ((original "(hello)")
+        (improved "```lisp\n(hello)```"))
+    (with-temp-buffer
+      (insert original)
+      (cl-letf (((symbol-function 'llm-chat-streaming)
+                 (lambda (_provider prompt partial-callback response-callback _error-callback)
+                   (should (string-match original (llm-chat-prompt-to-text prompt)))
+                   (cl-loop for i from 0 to (- (length improved) 1)
+                            do (funcall partial-callback (substring improved 0 i)))
+                   (funcall response-callback improved))))
+        (ellama-code-improve)
+        (should (equal original (buffer-string)))))))
+
+(provide 'test-ellama)
+
+;;; test-ellama.el ends here


### PR DESCRIPTION
Hi Sergey,

first, thanks for Ellama. It's a nice package I'm starting to use as my daily driver.

I think I found an issue:

Ellama inserts blank lines when improving code. Steps to reproduce are:

- Open a new file.
- Enter the following code.
```emacs-lisp
  (defun hello-world ()
    (interactive)
    (message "Hello, world!"))
```
- Mark the whole buffer `M-x mark-whole-buffer`.
- Run `M-x ellama-code-improve`.
- Notice that the improved code inserted into the buffer contains an  extra blank line at the beginning.

```emacs-lisp
  ;;; HERE IS A BLANK LINE
  (defun hello-world ()
    (interactive)
    (message "Hello, world!"))
```

This is due to the `ellama--code-prefix` matching against the end of line. When using this function to strip off the prefix, an extra blank line remains at the beginning.

I included 2 tests to prevent a regression.

Would you like to merge this PR?

My FSF assignment is in process. I hope to have it done very soon.

Thanks, Roman.