### PR TITLE
Add commit message generation

### DIFF
--- a/.github/workflows/melpa.yml
+++ b/.github/workflows/melpa.yml
@@ -26,6 +26,7 @@ jobs:
           - 29.1
           - 29.2
           - 29.3
+          - 29.4
         ignore_warnings:
           - false
         warnings_as_errors:

--- a/tests/test-ellama.el
+++ b/tests/test-ellama.el
@@ -1,9 +1,8 @@
-;;; test-ellama.el --- Ellama tests -*- lexical-binding: t -*-
+;;; test-ellama.el --- Ellama tests -*- lexical-binding: t; package-lint-main-file: "../ellama.el"; -*-
 
 ;; Copyright (C) 2023  Free Software Foundation, Inc.
 
 ;; Author: Sergey Kostyaev <sskostyaev@gmail.com>
-;; Package-Requires: ((emacs "28.1") (llm "0.6.0") (spinner "1.7.4"))
 
 ;; This file is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
Add a new customizable variable
`ellama-generate-commit-message-template` and a function `ellama-generate-commit-message` to generate commit messages based on diffs using ellama.

Fixes #105