### PR TITLE
Add summarization provider option and update prompt template

### DIFF
--- a/README.org
+++ b/README.org
@@ -32,8 +32,6 @@ You can use ~ellama~ with other model or other llm provider.
 In that case you should customize ellama configuration like this:
 
 #+BEGIN_SRC  emacs-lisp
-  ;; YOU DON'T NEED NONE OF THIS CODE FOR SIMPLE INSTALL
-  ;; IT IS AN EXAMPLE OF CUSTOMIZATION.
   (use-package ellama
     :bind ("C-c e" . ellama-transient-main-menu)
     :init
@@ -44,36 +42,41 @@ In that case you should customize ellama configuration like this:
     ;; could be llm-openai for example
     (require 'llm-ollama)
     (setopt ellama-provider
-	  (make-llm-ollama
-	   ;; this model should be pulled to use it
-	   ;; value should be the same as you print in terminal during pull
-	   :chat-model "llama3:8b-instruct-q8_0"
-	   :embedding-model "nomic-embed-text"
-	   :default-chat-non-standard-params '(("num_ctx" . 8192))))
+	    (make-llm-ollama
+	     ;; this model should be pulled to use it
+	     ;; value should be the same as you print in terminal during pull
+	     :chat-model "llama3:8b-instruct-q8_0"
+	     :embedding-model "nomic-embed-text"
+	     :default-chat-non-standard-params '(("num_ctx" . 8192))))
+    (setopt ellama-summarization-provider
+	    (make-llm-ollama
+	     :chat-model "qwen2.5:3b"
+	     :embedding-model "nomic-embed-text"
+	     :default-chat-non-standard-params '(("num_ctx" . 32768))))
     ;; Predefined llm providers for interactive switching.
     ;; You shouldn't add ollama providers here - it can be selected interactively
     ;; without it. It is just example.
     (setopt ellama-providers
-		    '(("zephyr" . (make-llm-ollama
-				   :chat-model "zephyr:7b-beta-q6_K"
-				   :embedding-model "zephyr:7b-beta-q6_K"))
-		      ("mistral" . (make-llm-ollama
-				    :chat-model "mistral:7b-instruct-v0.2-q6_K"
-				    :embedding-model "mistral:7b-instruct-v0.2-q6_K"))
-		      ("mixtral" . (make-llm-ollama
-				    :chat-model "mixtral:8x7b-instruct-v0.1-q3_K_M-4k"
-				    :embedding-model "mixtral:8x7b-instruct-v0.1-q3_K_M-4k"))))
+	    '(("zephyr" . (make-llm-ollama
+			   :chat-model "zephyr:7b-beta-q6_K"
+			   :embedding-model "zephyr:7b-beta-q6_K"))
+	      ("mistral" . (make-llm-ollama
+			    :chat-model "mistral:7b-instruct-v0.2-q6_K"
+			    :embedding-model "mistral:7b-instruct-v0.2-q6_K"))
+	      ("mixtral" . (make-llm-ollama
+			    :chat-model "mixtral:8x7b-instruct-v0.1-q3_K_M-4k"
+			    :embedding-model "mixtral:8x7b-instruct-v0.1-q3_K_M-4k"))))
     ;; Naming new sessions with llm
     (setopt ellama-naming-provider
-	  (make-llm-ollama
-	   :chat-model "llama3:8b-instruct-q8_0"
-	   :embedding-model "nomic-embed-text"
-	   :default-chat-non-standard-params '(("stop" . ("\n")))))
+	    (make-llm-ollama
+	     :chat-model "llama3:8b-instruct-q8_0"
+	     :embedding-model "nomic-embed-text"
+	     :default-chat-non-standard-params '(("stop" . ("\n")))))
     (setopt ellama-naming-scheme 'ellama-generate-name-by-llm)
     ;; Translation llm provider
     (setopt ellama-translation-provider (make-llm-ollama
-				       :chat-model "phi3:14b-medium-128k-instruct-q6_K"
-				       :embedding-model "nomic-embed-text")))
+					 :chat-model "phi3:14b-medium-128k-instruct-q6_K"
+					 :embedding-model "nomic-embed-text")))
 #+END_SRC
 
 ** Commands

--- a/ellama.el
+++ b/ellama.el
@@ -92,6 +92,11 @@
   :group 'ellama
   :type '(sexp :validate 'llm-standard-provider-p))
 
+(defcustom ellama-summarization-provider nil
+  "LLM provider for chat translation."
+  :group 'ellama
+  :type '(sexp :validate 'llm-standard-provider-p))
+
 (defcustom ellama-providers nil
   "LLM provider list for fast switching."
   :group 'ellama
@@ -222,7 +227,20 @@ PROMPT is a prompt string."
   :group 'ellama
   :type 'string)
 
-(defcustom ellama-summarize-prompt-template "Text:\n%s\nSummarize it."
+(defcustom ellama-summarize-prompt-template "<INSTRUCTIONS>
+You are a summarizer. You write a summary of the input **IN THE SAME LANGUAGE AS ORIGINAL INPUT TEXT** using following steps:
+1.) Analyze the input text and generate 5 essential questions that, when answered, capture the main points and core meaning of the text.
+2.) When formulating your questions:
+ a. Address the central theme or argument
+ b. Identify key supporting ideas
+ c. Highlight important facts or evidence
+ d. Reveal the author's purpose or perspective
+ e. Explore any significant implications or conclusions.
+3.) Answer all of your generated questions one-by-one in detail.
+</INSTRUCTIONS>
+<INPUT>
+%s
+</INPUT>"
   "Prompt template for `ellama-summarize'."
   :group 'ellama
   :type 'string)
@@ -1808,7 +1826,8 @@ ARGS contains keys for fine control.
   (let ((text (if (region-active-p)
 		  (buffer-substring-no-properties (region-beginning) (region-end))
 		(buffer-substring-no-properties (point-min) (point-max)))))
-    (ellama-instant (format ellama-summarize-prompt-template text))))
+    (ellama-instant (format ellama-summarize-prompt-template text)
+		    :provider (or ellama-summarization-provider ellama-provider))))
 
 ;;;###autoload
 (defun ellama-summarize-killring ()
@@ -1817,7 +1836,8 @@ ARGS contains keys for fine control.
   (let ((text (current-kill 0)))
     (if (string-empty-p text)
         (message "No text in the kill ring to summarize.")
-      (ellama-instant (format ellama-summarize-prompt-template text)))))
+      (ellama-instant (format ellama-summarize-prompt-template text)
+		      :provider (or ellama-summarization-provider ellama-provider)))))
 
 ;;;###autoload
 (defun ellama-code-review ()


### PR DESCRIPTION
Introduce a new custom variable `ellama-summarization-provider` to specify the LLM provider for summarization tasks. The `ellama-summarize-prompt-template` is now more detailed, instructing the model on how to generate summaries with specific steps and criteria. Additionally, updated the `ellama-summarize` and `ellama-summarize-killring` functions to use this new provider if specified.

This change ensures that summarization tasks can utilize a dedicated LLM provider for better performance and accuracy.