### PR TITLE
Improve some templates and documentation

### DIFF
--- a/README.org
+++ b/README.org
@@ -74,9 +74,12 @@ In that case you should customize ellama configuration like this:
 	     :default-chat-non-standard-params '(("stop" . ("\n")))))
     (setopt ellama-naming-scheme 'ellama-generate-name-by-llm)
     ;; Translation llm provider
-    (setopt ellama-translation-provider (make-llm-ollama
-					 :chat-model "phi3:14b-medium-128k-instruct-q6_K"
-					 :embedding-model "nomic-embed-text")))
+    (setopt ellama-translation-provider
+	  (make-llm-ollama
+	   :chat-model "qwen2.5:3b"
+	   :embedding-model "nomic-embed-text"
+	   :default-chat-non-standard-params
+	   '(("num_ctx" . 32768)))))
 #+END_SRC
 
 ** Commands
@@ -335,6 +338,8 @@ argument generated text string.
   by LLM. If not set ~ellama-provider~ will be used.
 - ~ellama-chat-translation-enabled~: Enable chat translations if set.
 - ~ellama-translation-provider~: LLM translation provider.
+  ~ellama-provider~ will be used if not set.
+- ~ellama-summarization-provider~ LLM summarization provider.
   ~ellama-provider~ will be used if not set.
 - ~ellama-show-quotes~: Show quotes content in chat buffer. Disabled
   by default.

--- a/ellama.el
+++ b/ellama.el
@@ -93,7 +93,7 @@
   :type '(sexp :validate 'llm-standard-provider-p))
 
 (defcustom ellama-summarization-provider nil
-  "LLM provider for chat translation."
+  "LLM provider for summarization."
   :group 'ellama
   :type '(sexp :validate 'llm-standard-provider-p))
 

--- a/ellama.el
+++ b/ellama.el
@@ -330,11 +330,18 @@ Topic:
   :group 'ellama
   :type 'string)
 
-(defcustom ellama-translation-template "Translate this text to %s.
-Original text:
+(defcustom ellama-translation-template "<INSTRUCTIONS>
+You are expert text translator. Translate input text to %s. Do
+not explain what you are doing. Do not self reference. You are an
+expert translator that will be tasked with translating and
+improving the spelling/grammar/literary quality of a piece of
+text. Please rewrite the translated text in your tone of voice
+and writing style. Ensure that the meaning of the original text
+is not changed.
+</INSTRUCTIONS>
+<INPUT>
 %s
-Translation to %s:
-"
+</INPUT>"
   "Translation template."
   :group 'ellama
   :type 'string)

--- a/ellama.el
+++ b/ellama.el
@@ -290,13 +290,26 @@ You are a summarizer. You write a summary of the input **IN THE SAME LANGUAGE AS
   :group 'ellama
   :type 'string)
 
-(defcustom ellama-generate-commit-message-template "You are professional software developer.
-Write concise commit message based on diff. First line should
-contain short title described major change in functionality. Then
-one empty line. Then detailed description of all changes. Reply
-with commit message only. Diff:
+(defcustom ellama-generate-commit-message-template "<INSTRUCTIONS>
+You are professional software developer.
 
-%s"
+Write concise commit message based on diff in the following format:
+<FORMAT>
+First line should contain short title described major change in functionality.
+Then one empty line. Then detailed description of all changes.
+</FORMAT>
+<EXAMPLE>
+Improve abc
+
+Improved abc feature by adding new xyz module.
+</EXAMPLE>
+
+**Reply with commit message only without any quotes.**
+</INSTRUCTIONS>
+
+<DIFF>
+%s
+</DIFF>"
   "Prompt template for `ellama-generate-commit-message'."
   :group 'ellama
   :type 'string)


### PR DESCRIPTION
Add detailed instructions for the text translator, ensuring it adheres to strict guidelines on tone of voice, writing style, and meaning preservation.