### PR TITLE
Add coding-provider and update documentation

### DIFF
--- a/README.org
+++ b/README.org
@@ -53,6 +53,11 @@ In that case you should customize ellama configuration like this:
 	     :chat-model "qwen2.5:3b"
 	     :embedding-model "nomic-embed-text"
 	     :default-chat-non-standard-params '(("num_ctx" . 32768))))
+    (setopt ellama-coding-provider
+	    (make-llm-ollama
+	     :chat-model "qwen2.5-coder:3b"
+	     :embedding-model "nomic-embed-text"
+	     :default-chat-non-standard-params '(("num_ctx" . 32768))))
     ;; Predefined llm providers for interactive switching.
     ;; You shouldn't add ollama providers here - it can be selected interactively
     ;; without it. It is just example.
@@ -338,6 +343,8 @@ argument generated text string.
   by LLM. If not set ~ellama-provider~ will be used.
 - ~ellama-chat-translation-enabled~: Enable chat translations if set.
 - ~ellama-translation-provider~: LLM translation provider.
+  ~ellama-provider~ will be used if not set.
+- ~ellama-coding-provider~: LLM coding tasks provider.
   ~ellama-provider~ will be used if not set.
 - ~ellama-summarization-provider~ LLM summarization provider.
   ~ellama-provider~ will be used if not set.

--- a/ellama.el
+++ b/ellama.el
@@ -97,6 +97,11 @@
   :group 'ellama
   :type '(sexp :validate 'llm-standard-provider-p))
 
+(defcustom ellama-coding-provider nil
+  "LLM provider for coding tasks."
+  :group 'ellama
+  :type '(sexp :validate 'llm-standard-provider-p))
+
 (defcustom ellama-providers nil
   "LLM provider list for fast switching."
   :group 'ellama
@@ -1778,7 +1783,8 @@ the full response text when the request completes (with BUFFER current)."
 		(diff (or (ellama--diff-cached)
 			  (ellama--diff))))
       (ellama-stream
-       (format ellama-generate-commit-message-template diff)))))
+       (format ellama-generate-commit-message-template diff)
+       :provider ellama-coding-provider))))
 
 ;;;###autoload
 (defun ellama-ask-line ()
@@ -1866,7 +1872,8 @@ ARGS contains keys for fine control.
   (let ((text (if (region-active-p)
 		  (buffer-substring-no-properties (region-beginning) (region-end))
 		(buffer-substring-no-properties (point-min) (point-max)))))
-    (ellama-instant (format ellama-code-review-prompt-template text))))
+    (ellama-instant (format ellama-code-review-prompt-template text)
+                    :provider ellama-coding-provider)))
 
 ;;;###autoload
 (defun ellama-change (change &optional edit-template)
@@ -1930,6 +1937,7 @@ prefix (\\[universal-argument]), prompt the user to amend the template."
      (format
       ellama-code-edit-prompt-template
       change text)
+     :provider ellama-coding-provider
      :filter #'ellama--code-filter
      :point beg)))
 
@@ -1949,6 +1957,7 @@ prefix (\\[universal-argument]), prompt the user to amend the template."
      (format
       ellama-code-improve-prompt-template
       text)
+     :provider ellama-coding-provider
      :filter #'ellama--code-filter
      :point beg)))
 
@@ -1967,6 +1976,7 @@ prefix (\\[universal-argument]), prompt the user to amend the template."
      (format
       ellama-code-complete-prompt-template
       text)
+     :provider ellama-coding-provider
      :filter #'ellama--code-filter
      :point end)))
 
@@ -1987,6 +1997,7 @@ buffer."
      (format
       ellama-code-add-prompt-template
       text description)
+     :provider ellama-coding-provider
      :filter #'ellama--code-filter)))
 
 


### PR DESCRIPTION
As currently there is no possibility to specify the provider for coding tasks I added this.
This helps a lot because we do not need switching from for example Qwen2.5 to Qwen2.5-Coder when asking for coding tasks.

FSF Papers in progress..