### PR TITLE
Remove unnecessary quote from validate function calls

### DIFF
--- a/ellama.el
+++ b/ellama.el
@@ -75,7 +75,7 @@
      :chat-model "zephyr" :embedding-model "zephyr"))
   "Backend LLM provider."
   :group 'ellama
-  :type '(sexp :validate 'llm-standard-provider-p))
+  :type '(sexp :validate llm-standard-provider-p))
 
 (defcustom ellama-chat-translation-enabled nil
   "Enable chat translations."
@@ -85,23 +85,23 @@
 (defcustom ellama-translation-provider nil
   "LLM provider for chat translation."
   :group 'ellama
-  :type '(sexp :validate 'llm-standard-provider-p))
+  :type '(sexp :validate llm-standard-provider-p))
 
 (defcustom ellama-summarization-provider nil
   "LLM provider for summarization."
   :group 'ellama
-  :type '(sexp :validate 'llm-standard-provider-p))
+  :type '(sexp :validate llm-standard-provider-p))
 
 (defcustom ellama-coding-provider nil
   "LLM provider for coding tasks."
   :group 'ellama
-  :type '(sexp :validate 'llm-standard-provider-p))
+  :type '(sexp :validate llm-standard-provider-p))
 
 (defcustom ellama-providers nil
   "LLM provider list for fast switching."
   :group 'ellama
   :type '(alist :key-type string
-		:value-type (sexp :validate 'llm-standard-provider-p)))
+		:value-type (sexp :validate llm-standard-provider-p)))
 
 (defcustom ellama-spinner-type 'progress-bar
   "Spinner type for ellama."
@@ -370,7 +370,7 @@ is not changed.
 (defcustom ellama-extraction-provider nil
   "LLM provider for data extraction."
   :group 'ellama
-  :type '(sexp :validate 'llm-standard-provider-p))
+  :type '(sexp :validate llm-standard-provider-p))
 
 (defcustom ellama-chat-done-callback nil
   "Callback that will be called on ellama chat response generation done.
@@ -596,7 +596,7 @@ This filter contains only subset of markdown syntax to be good enough."
 (defcustom ellama-naming-provider nil
   "LLM provider for generating names."
   :group 'ellama
-  :type '(sexp :validate 'llm-standard-provider-p))
+  :type '(sexp :validate llm-standard-provider-p))
 
 (defcustom ellama-always-show-chain-steps nil
   "Always show ellama chain buffers."


### PR DESCRIPTION
Removed the single quotes around the `llm-standard-provider-p` function in several defcustom declarations to ensure proper syntax and functionality.

Fix #195