### PR TITLE
Fix buffer name handling in context addition

### DIFF
--- a/ellama.el
+++ b/ellama.el
@@ -1302,7 +1302,10 @@ If EPHEMERAL non nil new session will not be associated with any file."
 (defun ellama-context-add-buffer (buf)
   "Add BUF to context."
   (interactive "bSelect buffer: ")
-  (let ((element (ellama-context-element-buffer :name buf)))
+  (let* ((buffer-name (if (stringp buf)
+			  buf
+			(buffer-name buf)))
+	 (element (ellama-context-element-buffer :name buffer-name)))
     (ellama-context-element-add element)))
 
 ;;;###autoload


### PR DESCRIPTION
Ensure that the buffer name is correctly extracted and used when adding a buffer to the context. The code now checks if `buf` is a string and uses it directly, otherwise, it retrieves the buffer name using `buffer-name`.