### PR TITLE
Improve interactions with reasoning models

### DIFF
--- a/NEWS.org
+++ b/NEWS.org
@@ -1,3 +1,9 @@
+* Version 1.1.0
+- Enhancing interaction with reasoning models. Thinking tags within
+  session buffers will be collapsed by default after generation.
+  Outside of ellama sessions reasoning will be removed from model
+  output. This ensures a seamless experience for users interacting
+  with reasoning models.
 * Version 1.0.3
 - Unquote symbols in ~ellama-provider-list~.
 * Version 1.0.2

--- a/README.org
+++ b/README.org
@@ -396,6 +396,9 @@ argument generated text string.
   ~posframe-poshandler-frame-top-center~ will be used if not set.
 - ~ellama-context-border-width~: Border width for the context buffer.
 - ~ellama-context-element-padding-size~: Padding size for context elements.
+- ~ellama-session-remove-reasoning~: Remove internal reasoning from
+  the session after ellama provide an answer. This can improve
+  long-term communication with reasoning models. Enabled by default.
 
 ** Acknowledgments
 

--- a/README.org
+++ b/README.org
@@ -399,6 +399,10 @@ argument generated text string.
 - ~ellama-session-remove-reasoning~: Remove internal reasoning from
   the session after ellama provide an answer. This can improve
   long-term communication with reasoning models. Enabled by default.
+- ~ellama-session-hide-org-quotes~: Hide org quotes in the Ellama
+  session buffer. From now on, think tags will be replaced with
+  quote blocks. If this flag is enabled, reasoning steps will be collapsed
+  after generation and upon session loading.
 
 ** Acknowledgments
 

--- a/README.org
+++ b/README.org
@@ -402,7 +402,10 @@ argument generated text string.
 - ~ellama-session-hide-org-quotes~: Hide org quotes in the Ellama
   session buffer. From now on, think tags will be replaced with
   quote blocks. If this flag is enabled, reasoning steps will be collapsed
-  after generation and upon session loading.
+  after generation and upon session loading. Enabled by default.
+- ~ellama-output-remove-reasoning~: Eliminate internal reasoning from
+  ellama output to enhance the versatility of reasoning models across
+  diverse applications.
 
 ** Acknowledgments
 

--- a/ellama.el
+++ b/ellama.el
@@ -84,6 +84,12 @@ This can improve long-term communication with reasoning models."
   :group 'ellama
   :type 'boolean)
 
+(defcustom ellama-output-remove-reasoning t
+  "Remove internal reasoning from ellama output.
+Make reasoning models more useful for many cases."
+  :group 'ellama
+  :type 'boolean)
+
 (defcustom ellama-session-hide-org-quotes t
   "Hide org quotes in ellama session buffer."
   :group 'ellama
@@ -1703,7 +1709,12 @@ failure (with BUFFER current).
 				  llm-prompt
 				  insert-text
 				  (lambda (text)
-				    (funcall insert-text (string-trim text))
+				    (funcall insert-text
+					     (string-trim
+					      (if (and ellama-output-remove-reasoning
+						       (not session))
+						  (ellama-remove-reasoning text)
+						text)))
 				    (with-current-buffer buffer
 				      (accept-change-group ellama--change-group)
 				      (spinner-stop)

--- a/ellama.el
+++ b/ellama.el
@@ -239,15 +239,10 @@ PROMPT is a prompt string."
   :type 'string)
 
 (defcustom ellama-summarize-prompt-template "<INSTRUCTIONS>
-You are a summarizer. You write a summary of the input **IN THE SAME LANGUAGE AS ORIGINAL INPUT TEXT** using following steps:
-1.) Analyze the input text and generate 5 essential questions that, when answered, capture the main points and core meaning of the text.
-2.) When formulating your questions:
- a. Address the central theme or argument
- b. Identify key supporting ideas
- c. Highlight important facts or evidence
- d. Reveal the author's purpose or perspective
- e. Explore any significant implications or conclusions.
-3.) Answer all of your generated questions one-by-one in detail.
+You are a summarizer. You write a summary of the input **IN THE SAME
+LANGUAGE AS ORIGINAL INPUT TEXT**. Summarize input text concisely and
+comprehensively, ensuring all key details are included accurately.
+Focus on clarity and maintain a straightforward presentation.
 </INSTRUCTIONS>
 <INPUT>
 %s

--- a/ellama.el
+++ b/ellama.el
@@ -6,7 +6,7 @@
 ;; URL: http://github.com/s-kostyaev/ellama
 ;; Keywords: help local tools
 ;; Package-Requires: ((emacs "28.1") (llm "0.22.0") (spinner "1.7.4") (transient "0.7") (compat "29.1") (posframe "1.4.0"))
-;; Version: 1.0.3
+;; Version: 1.1.0
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;; Created: 8th Oct 2023
 

--- a/ellama.el
+++ b/ellama.el
@@ -78,6 +78,12 @@
   :group 'ellama
   :type '(sexp :validate llm-standard-provider-p))
 
+(defcustom ellama-session-remove-reasoning t
+  "Remove internal reasoning from the session after ellama provide an answer.
+This can improve long-term communication with reasoning models."
+  :group 'ellama
+  :type 'boolean)
+
 (defcustom ellama-chat-translation-enabled nil
   "Enable chat translations."
   :group 'ellama
@@ -1681,6 +1687,17 @@ failure (with BUFFER current).
 					  (mapc (lambda (fn) (funcall fn text))
 						donecb)
 					(funcall donecb text))
+				      (when (and ellama--current-session
+						 ellama-session-remove-reasoning)
+					(mapc (lambda (interaction)
+						(setf (llm-chat-prompt-interaction-content
+						       interaction)
+						      (ellama-remove-reasoning
+						       (llm-chat-prompt-interaction-content
+							interaction))))
+					      (llm-chat-prompt-interactions
+					       (ellama-session-prompt
+						ellama--current-session))))
 				      (setq ellama--current-request nil)
 				      (ellama-request-mode -1)))
 				  (lambda (_ msg)


### PR DESCRIPTION
Added new custom variable `ellama-session-remove-reasoning` to control whether internal reasoning should be removed from the session after ellama provides an answer. This can help improve long-term communication with reasoning models by reducing the conversation context.