### PR TITLE
Add buffer quote context elements

### DIFF
--- a/NEWS.org
+++ b/NEWS.org
@@ -1,3 +1,6 @@
+* Version 1.1.1
+- Improve ~ellama-add-selection~.
+- Add buffer quote context element.
 * Version 1.1.0
 - Enhancing interaction with reasoning models. Thinking tags within
   session buffers will be collapsed by default after generation.

--- a/ellama.el
+++ b/ellama.el
@@ -1134,6 +1134,46 @@ If EPHEMERAL non nil new session will not be associated with any file."
   (with-slots (name) element
     (format "[[elisp:(display-buffer \"%s\")][%s]]" name name)))
 
+;; Buffer quote context elements
+
+(defclass ellama-context-element-buffer-quote (ellama-context-element)
+  ((name :initarg :name :type string)
+   (content :initarg :content :type string))
+  "A structure for holding information about a context element.")
+
+(cl-defmethod ellama-context-element-extract
+  ((element ellama-context-element-buffer-quote))
+  "Extract the content of the context ELEMENT."
+  (oref element content))
+
+(cl-defmethod ellama-context-element-display
+  ((element ellama-context-element-buffer-quote))
+  "Display the context ELEMENT."
+  (oref element name))
+
+(cl-defmethod ellama-context-element-format
+  ((element ellama-context-element-buffer-quote) (mode (eql 'markdown-mode)))
+  "Format the context ELEMENT for the major MODE."
+  (ignore mode)
+  (with-slots (name content) element
+    (if ellama-show-quotes
+	(format "[%s](%s):\n%s\n\n"
+		name name
+		(ellama--md-quote content))
+      (format "[%s](%s):\n```emacs-lisp\n(display-buffer \"%s\")"
+	      name name (ellama--quote-buffer content)))))
+
+(cl-defmethod ellama-context-element-format
+  ((element ellama-context-element-buffer-quote) (mode (eql 'org-mode)))
+  "Format the context ELEMENT for the major MODE."
+  (ignore mode)
+  (with-slots (name content) element
+    (if ellama-show-quotes
+	(format "[[%s][%s]]:\n#+BEGIN_QUOTE\n%s\n#+END_QUOTE\n"
+		name name (ellama--org-quote content))
+      (format "[[%s][%s]] [[elisp:(display-buffer \"%s\")][show]]"
+	      name name (ellama--quote-buffer content)))))
+
 ;; File context element
 
 (defclass ellama-context-element-file (ellama-context-element)
@@ -1461,7 +1501,12 @@ If EPHEMERAL non nil new session will not be associated with any file."
   (interactive)
   (if (region-active-p)
       (let* ((content (buffer-substring-no-properties (region-beginning) (region-end)))
-             (element (ellama-context-element-text :content content)))
+	     (file-name (buffer-file-name))
+	     (buffer-name (buffer-name (current-buffer)))
+             (element (if file-name
+			  (ellama-context-element-file-quote :path file-name
+							     :content content)
+			(ellama-context-element-buffer-quote :name buffer-name :content content))))
         (ellama-context-element-add element))
     (warn "No active region")))
 

--- a/ellama.el
+++ b/ellama.el
@@ -6,7 +6,7 @@
 ;; URL: http://github.com/s-kostyaev/ellama
 ;; Keywords: help local tools
 ;; Package-Requires: ((emacs "28.1") (llm "0.22.0") (spinner "1.7.4") (transient "0.7") (compat "29.1") (posframe "1.4.0"))
-;; Version: 1.1.0
+;; Version: 1.1.1
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;; Created: 8th Oct 2023
 
@@ -1497,7 +1497,7 @@ If EPHEMERAL non nil new session will not be associated with any file."
 
 ;;;###autoload
 (defun ellama-context-add-selection ()
-  "Add file to context."
+  "Add active region to context."
   (interactive)
   (if (region-active-p)
       (let* ((content (buffer-substring-no-properties (region-beginning) (region-end)))

--- a/tests/test-ellama.el
+++ b/tests/test-ellama.el
@@ -235,6 +235,17 @@
   (let ((element (ellama-context-element-file-quote :path "/path/to/file" :content "123")))
     (should (equal "file" (ellama-context-element-display element)))))
 
+(ert-deftest test-ellama-context-element-extract-buffer-quote ()
+  (with-temp-buffer
+    (insert "123")
+    (let ((element (ellama-context-element-buffer-quote :name (buffer-name) :content "123")))
+      (should (equal "123" (ellama-context-element-extract element))))))
+
+(ert-deftest test-ellama-context-element-display-buffer-quote ()
+  (with-temp-buffer
+    (let ((element (ellama-context-element-buffer-quote :name (buffer-name) :content "123")))
+      (should (equal (buffer-name) (ellama-context-element-display element))))))
+
 (ert-deftest test-ellama-md-to-org-code-simple ()
   (let ((result (ellama--translate-markdown-to-org-filter "Here is your TikZ code for a blue rectangle:
 ```tex


### PR DESCRIPTION
Added new functionality to handle buffer quote context elements. This includes defining a new class `ellama-context-element-buffer-quote`, implementing methods for extraction, display, and formatting in both markdown-mode and org-mode. Also updated the region handling logic to create buffer quote elements when no file is associated. Added corresponding tests for buffer quote element extraction and display.