### PR TITLE
Clear session context on reset command

### DIFF
--- a/NEWS.org
+++ b/NEWS.org
@@ -1,3 +1,6 @@
+* Version 1.1.2
+- Clear session context on calling reset context commant to prevent
+  suprising behaviour.
 * Version 1.1.1
 - Improve ~ellama-add-selection~.
 - Add buffer quote context element.

--- a/ellama.el
+++ b/ellama.el
@@ -6,7 +6,7 @@
 ;; URL: http://github.com/s-kostyaev/ellama
 ;; Keywords: help local tools
 ;; Package-Requires: ((emacs "28.1") (llm "0.22.0") (spinner "1.7.4") (transient "0.7") (compat "29.1") (posframe "1.4.0"))
-;; Version: 1.1.1
+;; Version: 1.1.2
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;; Created: 8th Oct 2023
 
@@ -1042,6 +1042,9 @@ If EPHEMERAL non nil new session will not be associated with any file."
   (setq ellama--global-context nil)
   (with-current-buffer ellama--context-buffer
     (erase-buffer))
+  (when ellama--current-session-id
+    (with-current-buffer (ellama-get-session-buffer ellama--current-session-id)
+      (setf (ellama-session-context ellama--current-session) nil)))
   (posframe-hide ellama--context-buffer))
 
 ;; Context elements


### PR DESCRIPTION
Added functionality to clear the current session's context when resetting the context. This prevents unexpected behavior by ensuring that the next chat call would be with clear context.