### PR TITLE
Add `:ensure t` clause to example use-package config.

### DIFF
--- a/README.org
+++ b/README.org
@@ -33,6 +33,7 @@ In that case you should customize ellama configuration like this:
 
 #+BEGIN_SRC  emacs-lisp
 (use-package ellama
+  :ensure t
   :bind ("C-c e" . ellama-transient-main-menu)
   :init
   ;; setup key bindings


### PR DESCRIPTION
Fix the issue #199 .

Without `:ensure t` clause, Emacs seems to install the package without dependencies, `llm-ollama` in this case. Adding `:ensure t` to `use-package config fixes this.