### PR TITLE
Fix cancel current request

### DIFF
--- a/NEWS.org
+++ b/NEWS.org
@@ -1,5 +1,9 @@
+* Version 1.1.5
+- Fix cancel current stream by pressing ~C-g~ in buffer with active
+  streaming.
 * Version 1.1.4
-- Improve the accuracy and reliability of the ~ellama-semantic-similar-p~ function.
+- Improve the accuracy and reliability of the
+  ~ellama-semantic-similar-p~ function.
 * Version 1.1.3
 - Ensure unique elements in session and global contexts.
 - Change default transient host and port to fix ollama provider setup.

--- a/README.org
+++ b/README.org
@@ -295,6 +295,9 @@ like a professional and adds a planning step.
 
 ** Keymap
 
+In any buffer where there is active ellama streaming, you can press
+~C-g~ and it will cancel current stream.
+
 Here is a table of keybindings and their associated functions in
 Ellama, using the ~ellama-keymap-prefix~ prefix (not set by default):
 

--- a/ellama.el
+++ b/ellama.el
@@ -6,7 +6,7 @@
 ;; URL: http://github.com/s-kostyaev/ellama
 ;; Keywords: help local tools
 ;; Package-Requires: ((emacs "28.1") (llm "0.22.0") (spinner "1.7.4") (transient "0.7") (compat "29.1") (posframe "1.4.0"))
-;; Version: 1.1.4
+;; Version: 1.1.5
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;; Created: 8th Oct 2023
 


### PR DESCRIPTION
Refactored ellama.el by moving the spinner and request mode updates to ensure they are executed in the correct context. This change ensures that the spinner is stopped and the request mode is reset properly after a request completes or fails, regardless of the session state. The request is now stored in a local variable where streaming is active to be able to cancel LLM streaming from this buffer.

Fixes #185 #164 