### PR TITLE
Fix context element insertion order

### DIFF
--- a/NEWS.org
+++ b/NEWS.org
@@ -1,3 +1,9 @@
+* Version 1.2.0
+- Add interactive context management in special buffer with preview.
+- Fix context element ordering.
+- Deprecate local session context.
+- Add option to toggle posframe showing global context.
+- Add instruction document for simplify help from ellama.
 * Version 1.1.7
 - Added transient suffix to load model from the current session.
 * Version 1.1.6

--- a/README.org
+++ b/README.org
@@ -273,6 +273,28 @@ Add info node to context.
 
 Clear global context.
 
+*** ellama-manage-context
+
+Manage the global context. Inside context management buffer you can
+see ellama context elements. Availible actions with key bindings:
+- *~n~*: Move to the next line.
+- *~p~*: Move to the previous line.
+- *~q~*: Quit the window.
+- *~g~*: Update context management buffer.
+- *~a~*: Open the transient context menu for adding new elements.
+- *~d~*: Remove the context element at the current point.
+- *~RET~*: Preview the context element at the current point.
+
+*** ellama-preview-context-element-at-point
+
+Preview ellama context element at point. Works inside ellama context
+management buffer.
+
+*** ellama-remove-context-element-at-point
+
+Remove ellama context element at point from global context. Works
+inside ellama context management buffer.
+
 *** ellama-chat-translation-enable
 
 Chat translation enable.
@@ -412,6 +434,13 @@ argument generated text string.
 - ~ellama-output-remove-reasoning~: Eliminate internal reasoning from
   ellama output to enhance the versatility of reasoning models across
   diverse applications.
+- ~ellama-context-posframe-enabled~: Enable showing posframe with
+  ellama context. Enabled by default.
+- ~ellama-manage-context-display-action-function~: Display action
+  function for ~ellama-render-context~. Default value
+  ~display-buffer-same-window~.
+- ~ellama-preview-context-element-display-action-function~: Display
+  action function for ~ellama-preview-context-element~.
 
 ** Acknowledgments
 

--- a/docs/instructions.org
+++ b/docs/instructions.org
@@ -1,0 +1,9 @@
+* About this project
+
+This project is written in emacs lisp.
+
+* Rules
+
+- Write simple and readable code.
+- Always use ~ert~ for tests.
+- All function names and custom variable names should start with ~ellama-~.

--- a/ellama.el
+++ b/ellama.el
@@ -1086,11 +1086,17 @@ If EPHEMERAL non nil new session will not be associated with any file."
 
 (cl-defmethod ellama-context-element-add ((element ellama-context-element))
   "Add the ELEMENT to the Ellama context."
-  (if-let* ((id ellama--current-session-id)
-	    (session (with-current-buffer (ellama-get-session-buffer id)
-		       ellama--current-session)))
-      (cl-pushnew element (ellama-session-context session) :test #'equal-including-properties))
-  (cl-pushnew element ellama--global-context :test #'equal-including-properties)
+  (when-let* ((id ellama--current-session-id)
+	      (session (with-current-buffer (ellama-get-session-buffer id)
+			 ellama--current-session)))
+    (setf (ellama-session-context session) (nreverse (ellama-session-context session)))
+    (cl-pushnew element (ellama-session-context session)
+		:test #'equal-including-properties)
+    (setf (ellama-session-context session) (nreverse (ellama-session-context session))))
+  (setf ellama--global-context (nreverse ellama--global-context))
+  (cl-pushnew element ellama--global-context
+	      :test #'equal-including-properties)
+  (setf ellama--global-context (nreverse ellama--global-context))
   (get-buffer-create ellama--context-buffer t)
   (with-current-buffer ellama--context-buffer
     (erase-buffer)

--- a/ellama.el
+++ b/ellama.el
@@ -1040,6 +1040,11 @@ If EPHEMERAL non nil new session will not be associated with any file."
 
 (defvar ellama--context-buffer " *ellama-context*")
 
+(defcustom ellama-context-posframe-enabled t
+  "Enable showing posframe with ellama context."
+  :group 'ellama
+  :type 'boolean)
+
 ;;;###autoload
 (defun ellama-context-reset ()
   "Clear global context."
@@ -1050,7 +1055,8 @@ If EPHEMERAL non nil new session will not be associated with any file."
   (when ellama--current-session-id
     (with-current-buffer (ellama-get-session-buffer ellama--current-session-id)
       (setf (ellama-session-context ellama--current-session) nil)))
-  (posframe-hide ellama--context-buffer))
+  (when ellama-context-posframe-enabled
+    (posframe-hide ellama--context-buffer)))
 
 ;; Context elements
 
@@ -1086,24 +1092,25 @@ If EPHEMERAL non nil new session will not be associated with any file."
 
 (defun ellama-update-context-posframe-show ()
   "Update and show context posframe."
-  (with-current-buffer ellama--context-buffer
-    (erase-buffer)
-    (when ellama--global-context
-      (insert (format
-	       "context: %s"
-	       (string-join
-		(mapcar
-		 (lambda (el)
-		   (string-pad
-		    (ellama-context-element-display el) ellama-context-element-padding-size))
-		 ellama--global-context)
-		"  ")))))
-  (if ellama--global-context
-      (posframe-show
-       ellama--context-buffer
-       :poshandler ellama-context-poshandler
-       :internal-border-width ellama-context-border-width)
-    (posframe-hide ellama--context-buffer)))
+  (when ellama-context-posframe-enabled
+    (with-current-buffer ellama--context-buffer
+      (erase-buffer)
+      (when ellama--global-context
+	(insert (format
+		 "context: %s"
+		 (string-join
+		  (mapcar
+		   (lambda (el)
+		     (string-pad
+		      (ellama-context-element-display el) ellama-context-element-padding-size))
+		   ellama--global-context)
+		  "  ")))))
+    (if ellama--global-context
+	(posframe-show
+	 ellama--context-buffer
+	 :poshandler ellama-context-poshandler
+	 :internal-border-width ellama-context-border-width)
+      (posframe-hide ellama--context-buffer))))
 
 (cl-defmethod ellama-context-element-add ((element ellama-context-element))
   "Add the ELEMENT to the Ellama context."

--- a/ellama.el
+++ b/ellama.el
@@ -6,7 +6,7 @@
 ;; URL: http://github.com/s-kostyaev/ellama
 ;; Keywords: help local tools
 ;; Package-Requires: ((emacs "28.1") (llm "0.22.0") (spinner "1.7.4") (transient "0.7") (compat "29.1") (posframe "1.4.0"))
-;; Version: 1.1.7
+;; Version: 1.2.0
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;; Created: 8th Oct 2023
 

--- a/tests/test-ellama.el
+++ b/tests/test-ellama.el
@@ -434,6 +434,14 @@ print(f\"The average score of {student_name} in {class_name} is: {average_score:
 	   (ellama--fix-file-name "a/\\?%*:|\"<>.;=")
 	   "a_____________")))
 
+(ert-deftest ellama-context-minor-mode-test ()
+  (with-temp-buffer
+    (should-not ellama-context-mode)
+    (ellama-context-mode 1)
+    (should ellama-context-mode)
+    (ellama-context-mode -1)
+    (should-not ellama-context-mode)))
+
 (provide 'test-ellama)
 
 ;;; test-ellama.el ends here


### PR DESCRIPTION
Fixed the issue where context elements were not being added in the correct order by reversing the session and global contexts before and after adding new elements. This ensures that elements are inserted in a consistent order, which is crucial for maintaining logical flow in the application.

Fix #223 