### PR TITLE
Add Emacs 30.1 to MELPA workflow

### DIFF
--- a/.github/workflows/melpa.yml
+++ b/.github/workflows/melpa.yml
@@ -27,6 +27,7 @@ jobs:
           - 29.2
           - 29.3
           - 29.4
+          - 30.1
         ignore_warnings:
           - false
         warnings_as_errors:
@@ -59,6 +60,7 @@ jobs:
           - 29.2
           - 29.3
           - 29.4
+          - 30.1
         ignore_warnings:
           - false
         warnings_as_errors:

--- a/ellama.el
+++ b/ellama.el
@@ -5,7 +5,7 @@
 ;; Author: Sergey Kostyaev <sskostyaev@gmail.com>
 ;; URL: http://github.com/s-kostyaev/ellama
 ;; Keywords: help local tools
-;; Package-Requires: ((emacs "28.1") (llm "0.22.0") (plz "0.8") (transient "0.7") (compat "29.1"))
+;; Package-Requires: ((emacs "28.1") (llm "0.22.0") (plz "0.8") (transient "0.7") (compat "30.1"))
 ;; Version: 1.4.4
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;; Created: 8th Oct 2023


### PR DESCRIPTION
Added Emacs 30.1 to the list of tested versions in the MELPA GitHub Actions workflow.