### PR TITLE
Add completion provider customization

### DIFF
--- a/ellama.el
+++ b/ellama.el
@@ -107,6 +107,11 @@ Make reasoning models more useful for many cases."
   :group 'ellama
   :type '(sexp :validate llm-standard-provider-p))
 
+(defcustom ellama-completion-provider nil
+  "LLM provider for completions."
+  :group 'ellama
+  :type '(sexp :validate llm-standard-provider-p))
+
 (defcustom ellama-providers nil
   "LLM provider list for fast switching."
   :group 'ellama
@@ -1714,9 +1719,14 @@ the full response text when the request completes (with BUFFER current)."
 	 (word (car (reverse (string-split line " ")))))
     (ellama-stream text
 		   :system ellama-complete-prompt-template
-		   :filter (lambda (s) (string-trim-left s (rx (or (literal text)
-								   (literal line)
-								   (literal word)))))
+		   :provider ellama-completion-provider
+		   :filter (lambda (s)
+			     (let ((noprefix (string-trim-left s (rx (or (literal text)
+									 (literal line)
+									 (literal word))))))
+			       (if (string= s noprefix)
+				   (concat " " s)
+				 noprefix)))
 		   :on-done #'ellama-fix-parens)))
 
 (defvar vc-git-diff-switches)


### PR DESCRIPTION
Added `ellama-completion-provider` custom variable to specify the LLM provider for completions. Updated `ellama-stream` call in `ellama-complete-impl` to use this new provider and modified the filter function to handle prefix trimming correctly.

Fix #275