### PR TITLE
Rename ellama-transient-system to ellama-global-system

### DIFF
--- a/NEWS.org
+++ b/NEWS.org
@@ -1,3 +1,8 @@
+* Version 1.5.1
+- Renamed the variable ~ellama-transient-system~ to ~ellama-global-system~ to
+  reflect its broader scope and updated all references in ~ellama.el~,
+  ~ellama-transient.el~ and ~ellama-blueprint.el~. Moved it from
+  ellama-transient to ellama. Fix symbol’s value as variable is void bug.
 * Version 1.5.0
 **** Code Refactoring and Modularity
 - Moved transient menu-related functions and variables from ~ellama.el~ to

--- a/ellama-blueprint.el
+++ b/ellama-blueprint.el
@@ -178,11 +178,11 @@ ARGS contains keys for fine control.
 (defun ellama-blueprint-edit-system-message ()
   "Edit system message as blueprint."
   (interactive)
-  (when ellama-transient-system
+  (when ellama-global-system
     (with-current-buffer (get-buffer-create ellama-blueprint-buffer)
       (erase-buffer)
       (let ((hard-newline t))
-	(insert ellama-transient-system)
+	(insert ellama-global-system)
 	(ellama-blueprint-mode))
       (switch-to-buffer (current-buffer))
       (ellama-blueprint-fill-variables))))

--- a/ellama-transient.el
+++ b/ellama-transient.el
@@ -42,12 +42,11 @@
 (defvar ellama-transient-context-length 4096)
 (defvar ellama-transient-host "localhost")
 (defvar ellama-transient-port 11434)
-(defvar ellama-transient-system nil)
 
 (defun ellama-transient-system-show ()
   "Show transient system message."
   (format "System message (%s)"
-          (string-limit (car (string-lines ellama-transient-system))
+          (string-limit (car (string-lines ellama-global-system))
                         ellama-transient-system-show-limit)))
 
 (transient-define-suffix ellama-transient-set-system ()
@@ -56,17 +55,17 @@ If a region is active, use the text within the region as the system message.
 Otherwise, prompt the user to enter a system message."
   (interactive)
   (if (region-active-p)
-      (setq ellama-transient-system (buffer-substring-no-properties
-                                     (region-beginning) (region-end)))
+      (setq ellama-global-system (buffer-substring-no-properties
+                                  (region-beginning) (region-end)))
     (let* ((msg-string (read-string "Set system mesage: "))
            (msg (when (not (string-empty-p msg-string)) msg-string)))
-      (setq ellama-transient-system msg))))
+      (setq ellama-global-system msg))))
 
 (defun ellama-transient-set-system-from-buffer ()
   "Set system message from current buffer."
   (interactive)
-  (setq ellama-transient-system (buffer-substring-no-properties
-			         (point-min) (point-max))))
+  (setq ellama-global-system (buffer-substring-no-properties
+			      (point-min) (point-max))))
 
 (transient-define-suffix ellama-transient-set-ollama-model ()
   "Set ollama model name."

--- a/ellama.el
+++ b/ellama.el
@@ -1145,7 +1145,7 @@ Otherwire return current active session."
     (with-current-buffer buf
       (ellama-collapse-org-quotes))))
 
-(defvar ellama-transient-system)
+(defvar ellama-global-system nil)
 
 (defun ellama-stream (prompt &rest args)
   "Query ellama for PROMPT.
@@ -1201,7 +1201,7 @@ failure (with BUFFER current).
 	 (donecb (or (plist-get args :on-done) #'ignore))
 	 (prompt-with-ctx (ellama-context-prompt-with-context prompt))
 	 (system (or (plist-get args :system)
-		     ellama-transient-system))
+		     ellama-global-system))
 	 (llm-prompt (if session
 			 (if (llm-chat-prompt-p (ellama-session-prompt session))
 			     (progn

--- a/ellama.el
+++ b/ellama.el
@@ -6,7 +6,7 @@
 ;; URL: http://github.com/s-kostyaev/ellama
 ;; Keywords: help local tools
 ;; Package-Requires: ((emacs "28.1") (llm "0.22.0") (plz "0.8") (transient "0.7") (compat "29.1"))
-;; Version: 1.5.0
+;; Version: 1.5.1
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;; Created: 8th Oct 2023
 


### PR DESCRIPTION
Renamed the variable `ellama-transient-system` to `ellama-global-system` to reflect its broader scope and updated all references in both `ellama.el` and `ellama-transient.el`. Move it from ellama-transient to ellama.

Fix #278