### PR TITLE
Fix bug in session delete/kill that deletes/kills the current file/buffer when no session is selected

### DIFF
--- a/ellama.el
+++ b/ellama.el
@@ -980,10 +980,10 @@ If EPHEMERAL non nil new session will not be associated with any file."
 	      "Select session to remove: "
 	      (hash-table-keys ellama--active-sessions)))
 	 (buffer (ellama-get-session-buffer id))
-	 (file (buffer-file-name buffer))
+	 (file (when buffer (buffer-file-name buffer)))
 	 (session-file (when file (ellama--get-session-file-name file)))
 	 (translation-file (when file (ellama--get-translation-file-name file))))
-    (kill-buffer buffer)
+    (when buffer (kill-buffer buffer))
     (when file (delete-file file t))
     (when session-file (delete-file session-file t))
     (mapc
@@ -1022,7 +1022,7 @@ If EPHEMERAL non nil new session will not be associated with any file."
 	      "Select session to kill: "
 	      (hash-table-keys ellama--active-sessions)))
 	 (buffer (ellama-get-session-buffer id)))
-    (kill-buffer buffer)))
+    (when buffer (kill-buffer buffer))))
 
 ;;;###autoload
 (defun ellama-session-rename ()


### PR DESCRIPTION
When any file was opened in the current buffer, ellama-session-delete() was run but no session was selected, for example because there are none, then the file of the current buffer would get deleted.

This happens because (buffer-file-name nil) returns the file name for the current buffer. Adding a simple when condition solves the problem. The same applies to kill-buffer() where the current buffer would get killed.