### PR TITLE
Add completion provider customization

### DIFF
--- a/NEWS.org
+++ b/NEWS.org
@@ -1,3 +1,7 @@
+* Version 1.5.3
+- Added ~ellama-completion-provider~ custom variable to specify the LLM provider
+  for completions. Updated ~ellama-stream~ call in ~ellama-complete~ to use this new
+  provider and modified the filter function to handle prefix trimming correctly.
 * Version 1.5.2
 - Fixed a bug in session delete or kill that deletes or kills the current file
   or buffer when no session is selected.

--- a/ellama.el
+++ b/ellama.el
@@ -6,7 +6,7 @@
 ;; URL: http://github.com/s-kostyaev/ellama
 ;; Keywords: help local tools
 ;; Package-Requires: ((emacs "28.1") (llm "0.22.0") (plz "0.8") (transient "0.7") (compat "29.1"))
-;; Version: 1.5.2
+;; Version: 1.5.3
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;; Created: 8th Oct 2023
 

--- a/ellama.el
+++ b/ellama.el
@@ -107,6 +107,11 @@ Make reasoning models more useful for many cases."
   :group 'ellama
   :type '(sexp :validate llm-standard-provider-p))
 
+(defcustom ellama-completion-provider nil
+  "LLM provider for completions."
+  :group 'ellama
+  :type '(sexp :validate llm-standard-provider-p))
+
 (defcustom ellama-providers nil
   "LLM provider list for fast switching."
   :group 'ellama
@@ -1714,9 +1719,14 @@ the full response text when the request completes (with BUFFER current)."
 	 (word (car (reverse (string-split line " ")))))
     (ellama-stream text
 		   :system ellama-complete-prompt-template
-		   :filter (lambda (s) (string-trim-left s (rx (or (literal text)
-								   (literal line)
-								   (literal word)))))
+		   :provider ellama-completion-provider
+		   :filter (lambda (s)
+			     (let ((noprefix (string-trim-left s (rx (or (literal text)
+									 (literal line)
+									 (literal word))))))
+			       (if (string= s noprefix)
+				   (concat " " s)
+				 noprefix)))
 		   :on-done #'ellama-fix-parens)))
 
 (defvar vc-git-diff-switches)


### PR DESCRIPTION
Added `ellama-completion-provider` custom variable to specify the LLM provider for completions. Updated `ellama-stream` call in `ellama-complete-impl` to use this new provider and modified the filter function to handle prefix trimming correctly.

Fix #275