### PR TITLE
Add `ellama` alias for main menu

### DIFF
--- a/NEWS.org
+++ b/NEWS.org
@@ -1,3 +1,7 @@
+* Version 1.5.4
+- Added an autoloadable alias ~ellama~ that points to the main menu function
+  ~ellama-transient-main-menu~, providing a convenient way to access the
+  feature.
 * Version 1.5.3
 - Added ~ellama-completion-provider~ custom variable to specify the LLM provider
   for completions. Updated ~ellama-stream~ call in ~ellama-complete~ to use this new

--- a/ellama-transient.el
+++ b/ellama-transient.el
@@ -349,5 +349,8 @@ Otherwise, prompt the user to enter a system message."
     ("D" "Solve domain specific problem" ellama-solve-domain-specific-problem)]]
   [["Quit" ("q" "Quit" transient-quit-one)]])
 
+;;;###autoload
+(defalias 'ellama 'ellama-transient-main-menu)
+
 (provide 'ellama-transient)
 ;;; ellama-transient.el ends here.

--- a/ellama.el
+++ b/ellama.el
@@ -6,7 +6,7 @@
 ;; URL: http://github.com/s-kostyaev/ellama
 ;; Keywords: help local tools
 ;; Package-Requires: ((emacs "28.1") (llm "0.22.0") (plz "0.8") (transient "0.7") (compat "29.1"))
-;; Version: 1.5.3
+;; Version: 1.5.4
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;; Created: 8th Oct 2023
 


### PR DESCRIPTION
Added an autoloadable alias `ellama` that points to the main menu function `ellama-transient-main-menu`. This provides a convenient way to access the feature.

Fix #286