### PR TITLE
Fix inline code snake case translation in markdown to org

### DIFF
--- a/NEWS.org
+++ b/NEWS.org
@@ -1,3 +1,7 @@
+* Version 1.5.6
+- Fix support for translating inline code from markdown to org format by
+  handling backticks.
+- Updated tests to include cases with inline code.
 * Version 1.5.5
 - Added an explicit autoload form to fix non package.el installations for Emacs
   28 and 29.

--- a/ellama.el
+++ b/ellama.el
@@ -6,7 +6,7 @@
 ;; URL: http://github.com/s-kostyaev/ellama
 ;; Keywords: help local tools
 ;; Package-Requires: ((emacs "28.1") (llm "0.22.0") (plz "0.8") (transient "0.7") (compat "29.1"))
-;; Version: 1.5.5
+;; Version: 1.5.6
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;; Created: 8th Oct 2023
 

--- a/tests/test-ellama.el
+++ b/tests/test-ellama.el
@@ -410,12 +410,30 @@ In this example:
 - The function name `calculate_average_score` also follows the snake_case convention.
 
 Snake case helps improve readability, especially in languages that are sensitive to capitalization like Python.")))
-    (should (string-equal result "#+BEGIN_SRC python\n# Example of snake case variables and functions\n\n# Variable names using snake_case\nstudent_name = \"Alice Johnson\"\nclass_name = \"Mathematics\"\ngrade_level = 10\n\n# Function name using snake_case\ndef calculate_average_score(math_score, science_score, english_score):\n    average_score = (math_score + science_score + english_score) / 3\n    return average_score\n\n# Using the function\nstudent_math_score = 85\nstudent_science_score = 90\nstudent_english_score = 78\n\naverage_score = calculate_average_score(student_math_score, student_science_score, student_english_score)\nprint(f\"The average score of {student_name} in {class_name} is: {average_score:.2f}\")\n#+END_SRC\n\nIn this example:\n- Variable names like ~student/name~, ~class/name~, and ~grade/level~\n  use snake/case.\n- The function name ~calculate/average/score~ also follows the\n  snake_case convention.\n\nSnake case helps improve readability, especially in languages that are\nsensitive to capitalization like Python."))))
+    (should (string-equal result "#+BEGIN_SRC python\n# Example of snake case variables and functions\n\n# Variable names using snake_case\nstudent_name = \"Alice Johnson\"\nclass_name = \"Mathematics\"\ngrade_level = 10\n\n# Function name using snake_case\ndef calculate_average_score(math_score, science_score, english_score):\n    average_score = (math_score + science_score + english_score) / 3\n    return average_score\n\n# Using the function\nstudent_math_score = 85\nstudent_science_score = 90\nstudent_english_score = 78\n\naverage_score = calculate_average_score(student_math_score, student_science_score, student_english_score)\nprint(f\"The average score of {student_name} in {class_name} is: {average_score:.2f}\")\n#+END_SRC\n\nIn this example:\n- Variable names like ~student_name~, ~class_name~, and ~grade_level~\n  use snake_case.\n- The function name ~calculate_average_score~ also follows the\n  snake_case convention.\n\nSnake case helps improve readability, especially in languages that are\nsensitive to capitalization like Python."))))
 
 (ert-deftest test-ellama--fix-file-name ()
   (should (string=
 	   (ellama--fix-file-name "a/\\?%*:|\"<>.;=")
 	   "a_____________")))
+
+(ert-deftest test-ellama-md-to-org-code-inline-code ()
+  (let ((result (ellama--translate-markdown-to-org-filter "_some italic_
+`some_snake_case`
+_more italic_
+```emacs-lisp
+(msg \"ok\")
+```
+$P_\\theta$
+_more italic_")))
+    (should (string-equal result "/some italic/
+~some_snake_case~
+/more italic/
+#+BEGIN_SRC emacs-lisp
+(msg \"ok\")
+#+END_SRC
+$P_\\theta$
+/more italic/"))))
 
 (provide 'test-ellama)
 


### PR DESCRIPTION
Add support for translating inline code from markdown to org format by handling backticks. Update the regex pattern in `ellama--apply-transformations` and add a new block type 'code-inline' in the loop. Also, update tests to include cases with inline code.