### PR TITLE
Add session ID display in header and mode lines

### DIFF
--- a/NEWS.org
+++ b/NEWS.org
@@ -1,3 +1,7 @@
+* Version 1.6.1
+- Added functionality to display the current Ellama session ID in both the
+  header line and the mode line.
+- Added globalized minor modes for enabling this feature across all buffers.
 * Version 1.6.0
 - Refactored the text insertion and handling logic in ~ellama.el~.
 - Added new customization variables ~ellama-show-reasoning~ and

--- a/README.org
+++ b/README.org
@@ -40,7 +40,9 @@ You can customize ellama configuration like this:
     :init (setopt ellama-auto-scroll t)
     :config
     ;; show ellama context in header line in all buffers
-    (ellama-context-header-line-global-mode +1))
+    (ellama-context-header-line-global-mode +1)
+    ;; show ellama session id in header line in all buffers
+    (ellama-session-header-line-global-mode +1))
 #+END_SRC
 
 More sofisticated configuration example:
@@ -114,6 +116,8 @@ More sofisticated configuration example:
     :config
     ;; show ellama context in header line in all buffers
     (ellama-context-header-line-global-mode +1)
+    ;; show ellama session id in header line in all buffers
+    (ellama-session-header-line-global-mode +1)
     ;; handle scrolling events
     (advice-add 'pixel-scroll-precision :before #'ellama-disable-scroll)
     (advice-add 'end-of-buffer :after #'ellama-enable-scroll))

--- a/README.org
+++ b/README.org
@@ -482,6 +482,7 @@ argument generated text string.
   within your ~user-emacs-directory~.
 - ~ellama-show-reasoning~: Show reasoning in separate buffer if enabled. Enabled by default.
 - ~ellama-reasoning-display-action-function~: Display action function for reasoning.
+- ~ellama-session-line-template~: Template for formatting the current session line.
 
 ** Minor modes
 

--- a/README.org
+++ b/README.org
@@ -551,6 +551,56 @@ This globalized minor mode provides a convenient way to ensure that
 context-specific mode line information is always available, regardless of the
 buffer being edited.
 
+*** Ellama Session Header Line Mode
+
+The ~ellama-session-header-line-mode~ is a minor mode that allows you to display
+the current Ellama session ID in the header line of your Emacs buffers. This
+feature helps keep track of which session you are working with, especially
+useful when managing multiple sessions.
+
+**** Enabling and Disabling
+
+To enable this mode, use the following command:
+#+BEGIN_SRC emacs-lisp
+M-x ellama-session-header-line-mode
+#+END_SRC
+
+This will toggle the display of the session ID in the header line. You can also
+enable or disable it globally across all buffers using:
+#+BEGIN_SRC emacs-lisp
+M-x ellama-session-header-line-global-mode
+#+END_SRC
+
+**** Customization
+
+The session ID is displayed with a customizable face called ~ellama-face~. You
+can customize this face to change its appearance.
+
+*** Ellama Session Mode Line Mode
+
+The ~ellama-session-mode-line-mode~ is a minor mode that allows you to display
+the current Ellama session ID in the mode line of your Emacs buffers. This
+feature provides an additional way to keep track of which session you are
+working with, especially useful when managing multiple sessions.
+
+**** Enabling and Disabling
+
+To enable this mode, use the following command:
+#+BEGIN_SRC emacs-lisp
+M-x ellama-session-mode-line-mode
+#+END_SRC
+
+This will toggle the display of the session ID in the mode line. You can also
+enable or disable it globally across all buffers using:
+#+BEGIN_SRC emacs-lisp
+M-x ellama-session-mode-line-global-mode
+#+END_SRC
+
+**** Customization
+
+The session ID is displayed with a customizable face called ~ellama-face~. You
+can customize this face to change its appearance.
+
 ** Using Blueprints
 
 Blueprints in Ellama refer to predefined templates or structures that facilitate

--- a/ellama.el
+++ b/ellama.el
@@ -6,7 +6,7 @@
 ;; URL: http://github.com/s-kostyaev/ellama
 ;; Keywords: help local tools
 ;; Package-Requires: ((emacs "28.1") (llm "0.24.0") (plz "0.8") (transient "0.7") (compat "29.1"))
-;; Version: 1.6.0
+;; Version: 1.6.1
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;; Created: 8th Oct 2023
 

--- a/ellama.el
+++ b/ellama.el
@@ -716,9 +716,14 @@ This filter contains only subset of markdown syntax to be good enough."
 
 (defvar ellama--current-session-id nil)
 
+(defcustom ellama-session-line-template " ellama session: %s"
+  "Template for formatting the current session line."
+  :type 'string
+  :group 'ellama)
+
 (defun ellama-session-line ()
   "Return current session id line."
-  (propertize (format " ellama session: %s"
+  (propertize (format ellama-session-line-template
 		      (if ellama--current-session
 			  (ellama-session-id ellama--current-session)
 			ellama--current-session-id))

--- a/ellama.el
+++ b/ellama.el
@@ -718,12 +718,13 @@ This filter contains only subset of markdown syntax to be good enough."
 
 (defun ellama-session-line ()
   "Return current session id line."
-  (propertize (format "ellama session: %s" ellama--current-session-id)
+  (propertize (format " ellama session: %s" ellama--current-session-id)
 	      'face 'ellama-face))
 
 (defun ellama-session-show-header-line ()
   "Display session id in the header line."
-  (add-to-list 'header-line-format '(:eval (ellama-session-line)) t))
+  (when (listp header-line-format)
+    (add-to-list 'header-line-format '(:eval (ellama-session-line)) t)))
 
 (defun ellama-session-hide-header-line ()
   "Hide session id from header line."
@@ -750,7 +751,8 @@ This filter contains only subset of markdown syntax to be good enough."
 
 (defun ellama-session-show-mode-line ()
   "Display session id in the mode line."
-  (add-to-list 'mode-line-format '(:eval (ellama-session-line)) t))
+  (when (listp mode-line-format)
+    (add-to-list 'mode-line-format '(:eval (ellama-session-line)) t)))
 
 (defun ellama-session-hide-mode-line ()
   "Hide session id from mode line."

--- a/ellama.el
+++ b/ellama.el
@@ -718,7 +718,10 @@ This filter contains only subset of markdown syntax to be good enough."
 
 (defun ellama-session-line ()
   "Return current session id line."
-  (propertize (format " ellama session: %s" ellama--current-session-id)
+  (propertize (format " ellama session: %s"
+		      (if ellama--current-session
+			  (ellama-session-id ellama--current-session)
+			ellama--current-session-id))
 	      'face 'ellama-face))
 
 (defun ellama-session-show-header-line ()

--- a/ellama.el
+++ b/ellama.el
@@ -716,6 +716,65 @@ This filter contains only subset of markdown syntax to be good enough."
 
 (defvar ellama--current-session-id nil)
 
+(defun ellama-session-line ()
+  "Return current session id line."
+  (propertize (format "ellama session: %s" ellama--current-session-id)
+	      'face 'ellama-face))
+
+(defun ellama-session-show-header-line ()
+  "Display session id in the header line."
+  (add-to-list 'header-line-format '(:eval (ellama-session-line)) t))
+
+(defun ellama-session-hide-header-line ()
+  "Hide session id from header line."
+  (setq header-line-format (delete '(:eval (ellama-session-line)) header-line-format)))
+
+(defun ellama-session-update-header-line ()
+  "Update header line for ellama session header line mode."
+  (if ellama-session-header-line-mode
+      (ellama-session-show-header-line)
+    (ellama-session-hide-header-line)))
+
+;;;###autoload
+(define-minor-mode ellama-session-header-line-mode
+  "Toggle Ellama Session header line mode."
+  :group 'ellama
+  (add-hook 'window-state-change-hook #'ellama-session-update-header-line)
+  (ellama-session-update-header-line))
+
+;;;###autoload
+(define-globalized-minor-mode ellama-session-header-line-global-mode
+  ellama-session-header-line-mode
+  ellama-session-header-line-mode
+  :group 'ellama)
+
+(defun ellama-session-show-mode-line ()
+  "Display session id in the mode line."
+  (add-to-list 'mode-line-format '(:eval (ellama-session-line)) t))
+
+(defun ellama-session-hide-mode-line ()
+  "Hide session id from mode line."
+  (setq mode-line-format (delete '(:eval (ellama-session-line)) mode-line-format)))
+
+(defun ellama-session-update-mode-line ()
+  "Update mode line for ellama session mode line mode."
+  (if ellama-session-mode-line-mode
+      (ellama-session-show-mode-line)
+    (ellama-session-hide-mode-line)))
+
+;;;###autoload
+(define-minor-mode ellama-session-mode-line-mode
+  "Toggle Ellama Session mode line mode."
+  :group 'ellama
+  (add-hook 'window-state-change-hook #'ellama-session-update-mode-line)
+  (ellama-session-update-mode-line))
+
+;;;###autoload
+(define-globalized-minor-mode ellama-session-mode-line-global-mode
+  ellama-session-mode-line-mode
+  ellama-session-mode-line-mode
+  :group 'ellama)
+
 (defvar ellama--active-sessions (make-hash-table :test #'equal))
 
 (cl-defstruct ellama-session


### PR DESCRIPTION
Added functionality to display the current Ellama session ID in both the header line and the mode line. This includes defining new functions for showing and hiding the session ID, as well as updating these displays when the minor modes are toggled. Also added globalized minor modes for enabling this feature across all buffers.

Relates #255 