### PR TITLE
Add `create-session` parameter to chat commands

### DIFF
--- a/NEWS.org
+++ b/NEWS.org
@@ -1,3 +1,19 @@
+* Version 1.8.0
+- Added ~create-session~ optional parameter to ~ellama-ask-about~,
+  ~ellama-ask-selection~, ~ellama-ask-line~, and ~ellama-code-review~ commands,
+  and added ~--new-session~ option to transient commands. These changes allow
+  creating a new session even if one is already active.
+- Added the ability to create an ephemeral session by adding a new ~:ephemeral~
+  argument to various functions and added the ~--ephemeral~ option to several
+  transient commands in ~ellama-transient.el~.
+- Implemented ephemeral context elements that are cleared after a single LLM
+  request. Added corresponding functions and transient suffixes to manage
+  ephemeral context elements, updating existing functions to handle both global
+  and ephemeral contexts.
+- Set up the transient menu to ensure the Ollama model is filled if it's empty.
+- Added ~use-hard-newlines~ variable and updated text insertion to use hard
+  newlines. Ensured that text is inserted only if there is a delta, and improved
+  the conditional logic for filling paragraphs.
 * Version 1.7.2
 - Added detailed context management documentation.
 * Version 1.7.1

--- a/README.org
+++ b/README.org
@@ -365,7 +365,9 @@ which may not always be appropriate.
 
 A “global context” is maintained, which is a collection of text blocks
 accessible to the LLM when responding to prompts. This global context is
-prepened to your prompt before transmission to the LLM.
+prepended to your prompt before transmission to the LLM. Additionally, Ellama
+supports an "ephemeral context," which is temporary and only available for a
+single request.
 
 ** Transient Menus for Context Management
 
@@ -378,12 +380,14 @@ The Context Commands transient menu is structured as follows:
 
 Context Commands:
 
-- Add: Provides options for adding content to the global context.
-    - “b” "Add Buffer" ~ellama-context-add-buffer~
-    - “d” "Add Directory" ~ellama-context-add-directory~
-    - “f” "Add File" ~ellama-context-add-file~
-    - “s” "Add Selection" ~ellama-context-add-selection~
-    - “i” "Add Info Node" ~ellama-context-add-info-node~
+- Options: Provides options for managing ephemeral context.
+    - “-e” "Use Ephemeral Context" ~--ephemeral~
+- Add: Provides options for adding content to the global or ephemeral context.
+    - “b” "Add Buffer" ~ellama-transient-add-buffer~
+    - “d” "Add Directory" ~ellama-transient-add-directory~
+    - “f” "Add File" ~ellama-transient-add-file~
+    - “s” "Add Selection" ~ellama-transient-add-selection~
+    - “i” "Add Info Node" ~ellama-transient-add-info-node~
 - Manage: Provides options for managing the global context.
     - “m” "Manage context" ~ellama-context-manage~ - Opens the context
       management buffer.

--- a/ellama-community-prompts.el
+++ b/ellama-community-prompts.el
@@ -113,6 +113,7 @@ PARSED-LINE is expected to be a list with three elements: :act,
 (defvar ellama-community-prompts-collection nil
   "Community prompts collection.")
 
+;;;###autoload
 (defun ellama-community-prompts-ensure ()
   "Ensure that the community prompt collection are loaded and available.
 This function ensures that the file specified by `ellama-community-prompts-file'

--- a/ellama-transient.el
+++ b/ellama-transient.el
@@ -244,13 +244,30 @@ Otherwise, prompt the user to enter a system message."
     ("f" "Make Format" ellama-make-format)]
    ["Quit" ("q" "Quit" transient-quit-one)]])
 
+(transient-define-suffix ellama-transient-ask-line (&optional args)
+  "Ask line.  ARGS used for transient arguments."
+  (interactive (list (transient-args transient-current-command)))
+  (ellama-ask-line (transient-arg-value "--new-session" args)))
+
+(transient-define-suffix ellama-transient-ask-selection (&optional args)
+  "Ask selection.  ARGS used for transient arguments."
+  (interactive (list (transient-args transient-current-command)))
+  (ellama-ask-selection (transient-arg-value "--new-session" args)))
+
+(transient-define-suffix ellama-transient-ask-about (&optional args)
+  "Ask about current buffer or region.  ARGS used for transient arguments."
+  (interactive (list (transient-args transient-current-command)))
+  (ellama-ask-about (transient-arg-value "--new-session" args)))
+
 ;;;###autoload (autoload 'ellama-transient-ask-menu "ellama-transient" nil t)
 (transient-define-prefix ellama-transient-ask-menu ()
   "Ask Commands."
   [["Ask Commands"
-    ("l" "Ask Line" ellama-ask-line)
-    ("s" "Ask Selection" ellama-ask-selection)
-    ("a" "Ask About" ellama-ask-about)]
+    ("l" "Ask Line" ellama-transient-ask-line)
+    ("s" "Ask Selection" ellama-transient-ask-selection)
+    ("a" "Ask About" ellama-transient-ask-about)]
+   ["Session Options"
+    ("-n" "Create New Session" "--new-session")]
    ["Quit" ("q" "Quit" transient-quit-one)]])
 
 ;;;###autoload (autoload 'ellama-transient-translate-menu "ellama-transient" nil t)

--- a/ellama-transient.el
+++ b/ellama-transient.el
@@ -209,6 +209,9 @@ Otherwise, prompt the user to enter a system message."
     ("i" "Improve" ellama-code-improve)
     ("r" "Review" ellama-transient-code-review)
     ("m" "Generate Commit Message" ellama-generate-commit-message)]
+   ["Session Options"
+    :description (lambda () (ellama-session-line))
+    ("-n" "Create New Session" "--new-session")]
    ["Quit" ("q" "Quit" transient-quit-one)]])
 
 ;;;###autoload (autoload 'ellama-transient-summarize-menu "ellama-transient" nil t)
@@ -272,6 +275,7 @@ Otherwise, prompt the user to enter a system message."
     ("s" "Ask Selection" ellama-transient-ask-selection)
     ("a" "Ask About" ellama-transient-ask-about)]
    ["Session Options"
+    :description (lambda () (ellama-session-line))
     ("-n" "Create New Session" "--new-session")]
    ["Quit" ("q" "Quit" transient-quit-one)]])
 
@@ -350,6 +354,9 @@ Otherwise, prompt the user to enter a system message."
    [("c" "Chat" ellama-transient-chat)
     ("b" "Chat with blueprint" ellama-blueprint-select)
     ("B" "Blueprint Commands" ellama-transient-blueprint-menu)]
+   ["Session Options"
+    :description (lambda () (ellama-session-line))
+    ("-n" "Create New Session" "--new-session")]
    [("a" "Ask Commands" ellama-transient-ask-menu)
     ("C" "Code Commands" ellama-transient-code-menu)]]
   ["Text"

--- a/ellama-transient.el
+++ b/ellama-transient.el
@@ -345,7 +345,9 @@ Otherwise, prompt the user to enter a system message."
 (transient-define-suffix ellama-transient-chat (&optional args)
   "Chat with Ellama.  ARGS used for transient arguments."
   (interactive (list (transient-args transient-current-command)))
-  (ellama-chat (transient-arg-value "--new-session" args)))
+  (ellama-chat
+   (read-string "Ask Ellama: ")
+   (transient-arg-value "--new-session" args)))
 
 ;;;###autoload (autoload 'ellama-transient-main-menu "ellama-transient" nil t)
 (transient-define-prefix ellama-transient-main-menu ()

--- a/ellama-transient.el
+++ b/ellama-transient.el
@@ -205,6 +205,12 @@ Otherwise, prompt the user to enter a system message."
 ;;;###autoload (autoload 'ellama-transient-code-menu "ellama-transient" nil t)
 (transient-define-prefix ellama-transient-code-menu ()
   "Code Commands."
+  ["Session Options"
+   :description (lambda () (ellama-session-line))
+   ("-n" "Create New Session" "--new-session")]
+  ["Ephemeral sessions"
+   :if (lambda () ellama-session-auto-save)
+   ("-e" "Create Ephemeral Session" "--ephemeral")]
   [["Code Commands"
     ("c" "Complete" ellama-code-complete)
     ("a" "Add" ellama-code-add)
@@ -212,10 +218,6 @@ Otherwise, prompt the user to enter a system message."
     ("i" "Improve" ellama-code-improve)
     ("r" "Review" ellama-transient-code-review)
     ("m" "Generate Commit Message" ellama-generate-commit-message)]
-   ["Session Options"
-    :description (lambda () (ellama-session-line))
-    ("-n" "Create New Session" "--new-session")
-    ("-e" "Create Ephemeral Session" "--ephemeral")]
    ["Quit" ("q" "Quit" transient-quit-one)]])
 
 ;;;###autoload (autoload 'ellama-transient-summarize-menu "ellama-transient" nil t)
@@ -280,14 +282,16 @@ Otherwise, prompt the user to enter a system message."
 ;;;###autoload (autoload 'ellama-transient-ask-menu "ellama-transient" nil t)
 (transient-define-prefix ellama-transient-ask-menu ()
   "Ask Commands."
+  ["Session Options"
+   :description (lambda () (ellama-session-line))
+   ("-n" "Create New Session" "--new-session")]
+  ["Ephemeral sessions"
+   :if (lambda () ellama-session-auto-save)
+   ("-e" "Create Ephemeral Session" "--ephemeral")]
   [["Ask Commands"
     ("l" "Ask Line" ellama-transient-ask-line)
     ("s" "Ask Selection" ellama-transient-ask-selection)
     ("a" "Ask About" ellama-transient-ask-about)]
-   ["Session Options"
-    :description (lambda () (ellama-session-line))
-    ("-n" "Create New Session" "--new-session")
-    ("-e" "Create Ephemeral Session" "--ephemeral")]
    ["Quit" ("q" "Quit" transient-quit-one)]])
 
 ;;;###autoload (autoload 'ellama-transient-translate-menu "ellama-transient" nil t)
@@ -405,14 +409,16 @@ ARGS used for transient arguments."
 ;;;###autoload (autoload 'ellama-transient-main-menu "ellama-transient" nil t)
 (transient-define-prefix ellama-transient-main-menu ()
   "Main Menu."
+  ["Session Options"
+   :description (lambda () (ellama-session-line))
+   ("-n" "Create New Session" "--new-session")]
+  ["Ephemeral sessions"
+   :if (lambda () ellama-session-auto-save)
+   ("-e" "Create Ephemeral Session" "--ephemeral")]
   ["Main"
    [("c" "Chat" ellama-transient-chat)
     ("b" "Chat with blueprint" ellama-blueprint-select)
     ("B" "Blueprint Commands" ellama-transient-blueprint-menu)]
-   ["Session Options"
-    :description (lambda () (ellama-session-line))
-    ("-n" "Create New Session" "--new-session")
-    ("-e" "Create Ephemeral Session" "--ephemeral")]
    [("a" "Ask Commands" ellama-transient-ask-menu)
     ("C" "Code Commands" ellama-transient-code-menu)]]
   ["Text"

--- a/ellama-transient.el
+++ b/ellama-transient.el
@@ -443,7 +443,11 @@ ARGS used for transient arguments."
   [["Problem solving"
     ("R" "Solve reasoning problem" ellama-solve-reasoning-problem)
     ("D" "Solve domain specific problem" ellama-solve-domain-specific-problem)]]
-  [["Quit" ("q" "Quit" transient-quit-one)]])
+  [["Quit" ("q" "Quit" transient-quit-one)]]
+  (interactive)
+  (transient-setup 'ellama-transient-main-menu)
+  (when (string-empty-p ellama-transient-ollama-model-name)
+    (ellama-fill-transient-ollama-model ellama-provider)))
 
 ;;;###autoload (autoload 'ellama "ellama-transient" nil t)
 (defalias 'ellama 'ellama-transient-main-menu)

--- a/ellama-transient.el
+++ b/ellama-transient.el
@@ -194,6 +194,11 @@ Otherwise, prompt the user to enter a system message."
    :default-chat-non-standard-params
    `[("num_ctx" . ,ellama-transient-context-length)]))
 
+(transient-define-suffix ellama-transient-code-review (&optional args)
+  "Review the code.  ARGS used for transient arguments."
+  (interactive (list (transient-args transient-current-command)))
+  (ellama-code-review (transient-arg-value "--new-session" args)))
+
 ;;;###autoload (autoload 'ellama-transient-code-menu "ellama-transient" nil t)
 (transient-define-prefix ellama-transient-code-menu ()
   "Code Commands."
@@ -202,7 +207,7 @@ Otherwise, prompt the user to enter a system message."
     ("a" "Add" ellama-code-add)
     ("e" "Edit" ellama-code-edit)
     ("i" "Improve" ellama-code-improve)
-    ("r" "Review" ellama-code-review)
+    ("r" "Review" ellama-transient-code-review)
     ("m" "Generate Commit Message" ellama-generate-commit-message)]
    ["Quit" ("q" "Quit" transient-quit-one)]])
 
@@ -333,11 +338,16 @@ Otherwise, prompt the user to enter a system message."
     ("k" "Kill" ellama-kill-current-buffer)
     ("q" "Quit" transient-quit-one)]])
 
+(transient-define-suffix ellama-transient-chat (&optional args)
+  "Chat with Ellama.  ARGS used for transient arguments."
+  (interactive (list (transient-args transient-current-command)))
+  (ellama-chat (transient-arg-value "--new-session" args)))
+
 ;;;###autoload (autoload 'ellama-transient-main-menu "ellama-transient" nil t)
 (transient-define-prefix ellama-transient-main-menu ()
   "Main Menu."
   ["Main"
-   [("c" "Chat" ellama-chat)
+   [("c" "Chat" ellama-transient-chat)
     ("b" "Chat with blueprint" ellama-blueprint-select)
     ("B" "Blueprint Commands" ellama-transient-blueprint-menu)]
    [("a" "Ask Commands" ellama-transient-ask-menu)

--- a/ellama-transient.el
+++ b/ellama-transient.el
@@ -31,6 +31,7 @@
 ;;; Code:
 (require 'ellama)
 (require 'transient)
+(require 'ellama-context)
 
 (defcustom ellama-transient-system-show-limit 45
   "Maximum length of system message to show."
@@ -302,6 +303,45 @@ Otherwise, prompt the user to enter a system message."
 (declare-function ellama-context-update-buffer "ellama-context")
 (defvar ellama-context-buffer)
 
+(transient-define-suffix ellama-transient-add-buffer (&optional args)
+  "Add current buffer to context.
+ARGS used for transient arguments."
+  (interactive (list (transient-args transient-current-command)))
+  (ellama-context-add-buffer
+   (read-buffer "Buffer: ")
+   (transient-arg-value "--ephemeral" args)))
+
+(transient-define-suffix ellama-transient-add-directory (&optional args)
+  "Add directory to context.
+ARGS used for transient arguments."
+  (interactive (list (transient-args transient-current-command)))
+  (let ((directory (read-directory-name "Directory: ")))
+    (ellama-context-add-directory
+     directory
+     (transient-arg-value "--ephemeral" args))))
+
+(transient-define-suffix ellama-transient-add-file (&optional args)
+  "Add file to context.
+ARGS used for transient arguments."
+  (interactive (list (transient-args transient-current-command)))
+  (ellama-context-add-file (transient-arg-value "--ephemeral" args)))
+
+(transient-define-suffix ellama-transient-add-selection (&optional args)
+  "Add current selection to context.
+ARGS used for transient arguments."
+  (interactive (list (transient-args transient-current-command)))
+  (when (region-active-p)
+    (ellama-context-add-selection (transient-arg-value "--ephemeral" args))))
+
+(transient-define-suffix ellama-transient-add-info-node (&optional args)
+  "Add Info Node to context.
+ARGS used for transient arguments."
+  (interactive (list (transient-args transient-current-command)))
+  (let ((info-node (Info-copy-current-node-name)))
+    (ellama-context-add-info-node
+     info-node
+     (transient-arg-value "--ephemeral" args))))
+
 ;;;###autoload (autoload 'ellama-transient-context-menu "ellama-transient" nil t)
 (transient-define-prefix ellama-transient-context-menu ()
   "Context Commands."
@@ -312,11 +352,13 @@ Otherwise, prompt the user to enter a system message."
 %s" (with-current-buffer ellama-context-buffer
       (buffer-substring (point-min) (point-max)))))
    ["Add"
-    ("b" "Add Buffer" ellama-context-add-buffer)
-    ("d" "Add Directory" ellama-context-add-directory)
-    ("f" "Add File" ellama-context-add-file)
-    ("s" "Add Selection" ellama-context-add-selection)
-    ("i" "Add Info Node" ellama-context-add-info-node)]
+    ("b" "Add Buffer" ellama-transient-add-buffer)
+    ("d" "Add Directory" ellama-transient-add-directory)
+    ("f" "Add File" ellama-transient-add-file)
+    ("s" "Add Selection" ellama-transient-add-selection)
+    ("i" "Add Info Node" ellama-transient-add-info-node)]
+   ["Options"
+    ("-e" "Use Ephemeral Context" "--ephemeral")]
    ["Manage"
     ("m" "Manage context" ellama-context-manage)
     ("D" "Delete element" ellama-context-element-remove-by-name)

--- a/ellama-transient.el
+++ b/ellama-transient.el
@@ -197,7 +197,9 @@ Otherwise, prompt the user to enter a system message."
 (transient-define-suffix ellama-transient-code-review (&optional args)
   "Review the code.  ARGS used for transient arguments."
   (interactive (list (transient-args transient-current-command)))
-  (ellama-code-review (transient-arg-value "--new-session" args)))
+  (ellama-code-review
+   (transient-arg-value "--new-session" args)
+   :ephemeral (transient-arg-value "--ephemeral" args)))
 
 ;;;###autoload (autoload 'ellama-transient-code-menu "ellama-transient" nil t)
 (transient-define-prefix ellama-transient-code-menu ()
@@ -211,7 +213,8 @@ Otherwise, prompt the user to enter a system message."
     ("m" "Generate Commit Message" ellama-generate-commit-message)]
    ["Session Options"
     :description (lambda () (ellama-session-line))
-    ("-n" "Create New Session" "--new-session")]
+    ("-n" "Create New Session" "--new-session")
+    ("-e" "Create Ephemeral Session" "--ephemeral")]
    ["Quit" ("q" "Quit" transient-quit-one)]])
 
 ;;;###autoload (autoload 'ellama-transient-summarize-menu "ellama-transient" nil t)
@@ -255,17 +258,23 @@ Otherwise, prompt the user to enter a system message."
 (transient-define-suffix ellama-transient-ask-line (&optional args)
   "Ask line.  ARGS used for transient arguments."
   (interactive (list (transient-args transient-current-command)))
-  (ellama-ask-line (transient-arg-value "--new-session" args)))
+  (ellama-ask-line
+   (transient-arg-value "--new-session" args)
+   :ephemeral (transient-arg-value "--ephemeral" args)))
 
 (transient-define-suffix ellama-transient-ask-selection (&optional args)
   "Ask selection.  ARGS used for transient arguments."
   (interactive (list (transient-args transient-current-command)))
-  (ellama-ask-selection (transient-arg-value "--new-session" args)))
+  (ellama-ask-selection
+   (transient-arg-value "--new-session" args)
+   :ephemeral (transient-arg-value "--ephemeral" args)))
 
 (transient-define-suffix ellama-transient-ask-about (&optional args)
   "Ask about current buffer or region.  ARGS used for transient arguments."
   (interactive (list (transient-args transient-current-command)))
-  (ellama-ask-about (transient-arg-value "--new-session" args)))
+  (ellama-ask-about
+   (transient-arg-value "--new-session" args)
+   :ephemeral (transient-arg-value "--ephemeral" args)))
 
 ;;;###autoload (autoload 'ellama-transient-ask-menu "ellama-transient" nil t)
 (transient-define-prefix ellama-transient-ask-menu ()
@@ -276,7 +285,8 @@ Otherwise, prompt the user to enter a system message."
     ("a" "Ask About" ellama-transient-ask-about)]
    ["Session Options"
     :description (lambda () (ellama-session-line))
-    ("-n" "Create New Session" "--new-session")]
+    ("-n" "Create New Session" "--new-session")
+    ("-e" "Create Ephemeral Session" "--ephemeral")]
    ["Quit" ("q" "Quit" transient-quit-one)]])
 
 ;;;###autoload (autoload 'ellama-transient-translate-menu "ellama-transient" nil t)
@@ -347,7 +357,8 @@ Otherwise, prompt the user to enter a system message."
   (interactive (list (transient-args transient-current-command)))
   (ellama-chat
    (read-string "Ask Ellama: ")
-   (transient-arg-value "--new-session" args)))
+   (transient-arg-value "--new-session" args)
+   :ephemeral (transient-arg-value "--ephemeral" args)))
 
 ;;;###autoload (autoload 'ellama-transient-main-menu "ellama-transient" nil t)
 (transient-define-prefix ellama-transient-main-menu ()
@@ -358,7 +369,8 @@ Otherwise, prompt the user to enter a system message."
     ("B" "Blueprint Commands" ellama-transient-blueprint-menu)]
    ["Session Options"
     :description (lambda () (ellama-session-line))
-    ("-n" "Create New Session" "--new-session")]
+    ("-n" "Create New Session" "--new-session")
+    ("-e" "Create Ephemeral Session" "--ephemeral")]
    [("a" "Ask Commands" ellama-transient-ask-menu)
     ("C" "Code Commands" ellama-transient-code-menu)]]
   ["Text"

--- a/ellama-transient.el
+++ b/ellama-transient.el
@@ -349,6 +349,8 @@ ARGS used for transient arguments."
 ;;;###autoload (autoload 'ellama-transient-context-menu "ellama-transient" nil t)
 (transient-define-prefix ellama-transient-context-menu ()
   "Context Commands."
+  ["Options"
+   ("-e" "Use Ephemeral Context" "--ephemeral")]
   ["Context Commands"
    :description (lambda ()
 		  (ellama-context-update-buffer)
@@ -361,8 +363,6 @@ ARGS used for transient arguments."
     ("f" "Add File" ellama-transient-add-file)
     ("s" "Add Selection" ellama-transient-add-selection)
     ("i" "Add Info Node" ellama-transient-add-info-node)]
-   ["Options"
-    ("-e" "Use Ephemeral Context" "--ephemeral")]
    ["Manage"
     ("m" "Manage context" ellama-context-manage)
     ("D" "Delete element" ellama-context-element-remove-by-name)

--- a/ellama.el
+++ b/ellama.el
@@ -1782,8 +1782,10 @@ the full response text when the request completes (with BUFFER current)."
 			     #'ellama--translate-markdown-to-org-filter))))
 
 ;;;###autoload
-(defun ellama-ask-about ()
-  "Ask ellama about selected region or current buffer."
+(defun ellama-ask-about (&optional create-session)
+  "Ask ellama about selected region or current buffer.
+
+If CREATE-SESSION set, creates new session even if there is an active session."
   (interactive)
   (declare-function ellama-context-add-selection "ellama-context")
   (declare-function ellama-context-add-buffer "ellama-context")
@@ -1791,16 +1793,18 @@ the full response text when the request completes (with BUFFER current)."
     (if (region-active-p)
 	(ellama-context-add-selection)
       (ellama-context-add-buffer (buffer-name (current-buffer))))
-    (ellama-chat input)))
+    (ellama-chat input create-session)))
 
 ;;;###autoload
-(defun ellama-ask-selection ()
-  "Send selected region or current buffer to ellama chat."
+(defun ellama-ask-selection (&optional create-session)
+  "Send selected region or current buffer to ellama chat.
+
+If CREATE-SESSION set, creates new session even if there is an active session."
   (interactive)
   (let ((text (if (region-active-p)
 		  (buffer-substring-no-properties (region-beginning) (region-end))
 		(buffer-substring-no-properties (point-min) (point-max)))))
-    (ellama-chat text)))
+    (ellama-chat text create-session)))
 
 (defcustom ellama-complete-prompt-template "You're providing text completion. Complete the text. Do not aknowledge, reply with completion only."
   "System prompt template for `ellama-complete'."
@@ -1898,11 +1902,13 @@ the full response text when the request completes (with BUFFER current)."
        :provider ellama-coding-provider))))
 
 ;;;###autoload
-(defun ellama-ask-line ()
-  "Send current line to ellama chat."
+(defun ellama-ask-line (&optional create-session)
+  "Send current line to ellama chat.
+
+If CREATE-SESSION set, creates new session even if there is an active session."
   (interactive)
   (let ((text (thing-at-point 'line)))
-    (ellama-chat text)))
+    (ellama-chat text create-session)))
 
 (defun ellama-instant (prompt &rest args)
   "Prompt ellama for PROMPT to reply instantly.
@@ -2006,13 +2012,15 @@ ARGS contains keys for fine control.
 				    (ellama-get-first-ollama-chat-model))))))
 
 ;;;###autoload
-(defun ellama-code-review ()
-  "Review code in selected region or current buffer."
+(defun ellama-code-review (&optional create-session)
+  "Review code in selected region or current buffer.
+
+If CREATE-SESSION set, creates new session even if there is an active session."
   (interactive)
   (if (region-active-p)
       (ellama-context-add-selection)
     (ellama-context-add-buffer (current-buffer)))
-  (ellama-chat ellama-code-review-prompt-template nil :provider ellama-coding-provider))
+  (ellama-chat ellama-code-review-prompt-template create-session :provider ellama-coding-provider))
 
 ;;;###autoload
 (defun ellama-write (instruction)

--- a/ellama.el
+++ b/ellama.el
@@ -1587,7 +1587,8 @@ Will call `ellama-chat-done-callback' and ON-DONE on TEXT."
   (save-excursion
     (goto-char (point-max))
     (insert "\n\n" (ellama-get-nick-prefix-for-mode) " " ellama-user-nick ":\n")
-    (when ellama-session-auto-save
+    (when (and ellama-session-auto-save
+	       buffer-file-name)
       (save-buffer)))
   (ellama--scroll)
   (when ellama-chat-done-callback

--- a/ellama.el
+++ b/ellama.el
@@ -6,7 +6,7 @@
 ;; URL: http://github.com/s-kostyaev/ellama
 ;; Keywords: help local tools
 ;; Package-Requires: ((emacs "28.1") (llm "0.24.0") (plz "0.8") (transient "0.7") (compat "29.1"))
-;; Version: 1.7.2
+;; Version: 1.8.0
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;; Created: 8th Oct 2023
 

--- a/ellama.el
+++ b/ellama.el
@@ -1235,6 +1235,7 @@ FILTER is a function for text transformation."
 	    (goto-char end-marker)
 	    (let* ((filtered-text
 		    (funcall filter text))
+		   (use-hard-newlines t)
 		   (common-prefix (concat
 				   safe-common-prefix
 				   (ellama-max-common-prefix
@@ -1248,26 +1249,26 @@ FILTER is a function for text transformation."
 				       (length common-prefix)))
 		   (delta (string-remove-prefix common-prefix filtered-text)))
 	      (delete-char (- wrong-chars-cnt))
-	      (insert delta)
-	      (when (and
-		     ellama-fill-paragraphs
-		     (pcase ellama-fill-paragraphs
-		       ((cl-type function) (funcall ellama-fill-paragraphs))
-		       ((cl-type boolean) ellama-fill-paragraphs)
-		       ((cl-type list) (and (apply #'derived-mode-p
-						   ellama-fill-paragraphs)))))
-		(if (not (eq major-mode 'org-mode))
-		    (fill-paragraph)
-		  (when (not (save-excursion
-			       (re-search-backward
-				"#\\+BEGIN_SRC"
-				beg-marker t)))
-		    (org-fill-paragraph))))
-	      (set-marker end-marker (point))
-	      (when (and ellama-auto-scroll (not ellama--stop-scroll))
-		(ellama--scroll buffer end-marker))
-	      (setq safe-common-prefix (ellama--string-without-last-line common-prefix))
-	      (setq previous-filtered-text filtered-text))))))))
+	      (when delta (insert (propertize delta 'hard t))
+		    (when (and
+			   ellama-fill-paragraphs
+			   (pcase ellama-fill-paragraphs
+			     ((cl-type function) (funcall ellama-fill-paragraphs))
+			     ((cl-type boolean) ellama-fill-paragraphs)
+			     ((cl-type list) (and (apply #'derived-mode-p
+							 ellama-fill-paragraphs)))))
+		      (if (not (eq major-mode 'org-mode))
+			  (fill-paragraph)
+			(when (not (save-excursion
+				     (re-search-backward
+				      "#\\+BEGIN_SRC"
+				      beg-marker t)))
+			  (org-fill-paragraph))))
+		    (set-marker end-marker (point))
+		    (when (and ellama-auto-scroll (not ellama--stop-scroll))
+		      (ellama--scroll buffer end-marker))
+		    (setq safe-common-prefix (ellama--string-without-last-line common-prefix))
+		    (setq previous-filtered-text filtered-text)))))))))
 
 (defun ellama--handle-partial (insert-text insert-reasoning reasoning-buffer)
   "Handle partial llm callback.

--- a/ellama.info
+++ b/ellama.info
@@ -489,7 +489,9 @@ its pre-existing knowledge, which may not always be appropriate.
 
 A “global context” is maintained, which is a collection of text blocks
 accessible to the LLM when responding to prompts.  This global context
-is prepened to your prompt before transmission to the LLM.
+is prepended to your prompt before transmission to the LLM.
+Additionally, Ellama supports an "ephemeral context," which is temporary
+and only available for a single request.
 
 * Menu:
 
@@ -512,12 +514,15 @@ The Context Commands transient menu is structured as follows:
 
 Context Commands:
 
-   • Add: Provides options for adding content to the global context.
-        • “b” "Add Buffer" ‘ellama-context-add-buffer’
-        • “d” "Add Directory" ‘ellama-context-add-directory’
-        • “f” "Add File" ‘ellama-context-add-file’
-        • “s” "Add Selection" ‘ellama-context-add-selection’
-        • “i” "Add Info Node" ‘ellama-context-add-info-node’
+   • Options: Provides options for managing ephemeral context.
+        • “-e” "Use Ephemeral Context" ‘--ephemeral’
+   • Add: Provides options for adding content to the global or ephemeral
+     context.
+        • “b” "Add Buffer" ‘ellama-transient-add-buffer’
+        • “d” "Add Directory" ‘ellama-transient-add-directory’
+        • “f” "Add File" ‘ellama-transient-add-file’
+        • “s” "Add Selection" ‘ellama-transient-add-selection’
+        • “i” "Add Info Node" ‘ellama-transient-add-info-node’
    • Manage: Provides options for managing the global context.
         • “m” "Manage context" ‘ellama-context-manage’ - Opens the
           context management buffer.
@@ -1412,30 +1417,30 @@ Node: Commands8621
 Node: Keymap14965
 Node: Configuration17798
 Node: Context Management23139
-Node: Transient Menus for Context Management23932
-Node: Managing the Context25390
-Node: Considerations26165
-Node: Minor modes26758
-Node: ellama-context-header-line-mode28746
-Node: ellama-context-header-line-global-mode29571
-Node: ellama-context-mode-line-mode30291
-Node: ellama-context-mode-line-global-mode31139
-Node: Ellama Session Header Line Mode31843
-Node: Enabling and Disabling32412
-Node: Customization32859
-Node: Ellama Session Mode Line Mode33147
-Node: Enabling and Disabling (1)33732
-Node: Customization (1)34179
-Node: Using Blueprints34473
-Node: Key Components of Ellama Blueprints35092
-Node: Creating and Managing Blueprints35699
-Node: Variable Management36680
-Node: Keymap and Mode37149
-Node: Transient Menus38085
-Node: Running Blueprints programmatically38631
-Node: Acknowledgments39218
-Node: Contributions39931
-Node: GNU Free Documentation License40315
+Node: Transient Menus for Context Management24047
+Node: Managing the Context25661
+Node: Considerations26436
+Node: Minor modes27029
+Node: ellama-context-header-line-mode29017
+Node: ellama-context-header-line-global-mode29842
+Node: ellama-context-mode-line-mode30562
+Node: ellama-context-mode-line-global-mode31410
+Node: Ellama Session Header Line Mode32114
+Node: Enabling and Disabling32683
+Node: Customization33130
+Node: Ellama Session Mode Line Mode33418
+Node: Enabling and Disabling (1)34003
+Node: Customization (1)34450
+Node: Using Blueprints34744
+Node: Key Components of Ellama Blueprints35363
+Node: Creating and Managing Blueprints35970
+Node: Variable Management36951
+Node: Keymap and Mode37420
+Node: Transient Menus38356
+Node: Running Blueprints programmatically38902
+Node: Acknowledgments39489
+Node: Contributions40202
+Node: GNU Free Documentation License40586
 
 End Tag Table
 


### PR DESCRIPTION
Added `create-session` optional parameter to `ellama-ask-about`, `ellama-ask-selection`, `ellama-ask-line`, and `ellama-code-review` commands. This allows creating a new session even if one is already active.