### PR TITLE
Move SRC block delimiters to their own lines

### DIFF
--- a/ellama.el
+++ b/ellama.el
@@ -635,6 +635,9 @@ This filter contains only subset of markdown syntax to be good enough."
     (replace-regexp-in-string "<think>[\n]?" "#+BEGIN_QUOTE\n")
     (replace-regexp-in-string "[\n]?</think>[\n]?" "\n#+END_QUOTE\n")
     (ellama--replace-bad-code-blocks)
+    ;; Making code blocks properly line-separated
+    (replace-regexp-in-string "\\([^\n]+\\)#\\+\\(BEGIN_SRC\\|END_SRC\\)" "\\1\n#+\\2")
+    ;; Outside of code blocks
     (ellama--replace-outside-of-code-blocks)))
 
 (defcustom ellama-enable-keymap t
@@ -1253,7 +1256,7 @@ FILTER is a function for text transformation."
 			     ((cl-type boolean) ellama-fill-paragraphs)
 			     ((cl-type list) (and (apply #'derived-mode-p
 							 ellama-fill-paragraphs)))))
-		      (if (not (eq major-mode 'org-mode))
+		      (if (not (derived-mode-p 'org-mode))
 			  (fill-paragraph)
 			(when (not (save-excursion
 				     (re-search-backward


### PR DESCRIPTION
This PR fixes a bug where if you're in a _derived_ mode of `org-mode`, SRC blocks are not properly formatted.

It also adds a small validator for cases where the LLM itself has forgotten to add line breaks preceding a \`\`\` or `BEGIN_SRC`/`END_SRC` term, as the existing regexes for markdown-to-org conversion don't seem to cover that case.