### PR TITLE
Add required llm-ollama module for ollama model retrieval

### DIFF
--- a/ellama.el
+++ b/ellama.el
@@ -2429,6 +2429,7 @@ Call CALLBACK on result list of strings.  ARGS contains keys for fine control.
 (declare-function make-llm-ollama "ext:llm-ollama")
 (defun ellama-get-ollama-model-names ()
   "Get ollama model names."
+  (require 'llm-ollama)
   (llm-models (or ellama-provider
 		  (make-llm-ollama))))
 


### PR DESCRIPTION
Added (require 'llm-ollama) to ellama-get-ollama-model-names function to ensure the llm-ollama module is loaded before attempting to retrieve ollama model names. This fixes potential errors when the function is called without the module being previously required.

Fix #313