### PR TITLE
Add directory tracking to sessions

### DIFF
--- a/NEWS.org
+++ b/NEWS.org
@@ -1,3 +1,7 @@
+* Version 1.10.2
+- Added directory tracking to sessions, including a directory path in the extra
+  data field and setting the default directory when a session is initialized to
+  maintain working directory context.
 * Version 1.10.1
 - Added option to allow all tools without confirmation using new
   ~ellama-tools-allow-all~ variable marked as dangerous.

--- a/ellama.el
+++ b/ellama.el
@@ -6,7 +6,7 @@
 ;; URL: http://github.com/s-kostyaev/ellama
 ;; Keywords: help local tools
 ;; Package-Requires: ((emacs "28.1") (llm "0.24.0") (plz "0.8") (transient "0.7") (compat "29.1"))
-;; Version: 1.10.1
+;; Version: 1.10.2
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;; Created: 8th Oct 2023
 


### PR DESCRIPTION
Extended the session creation to include a directory path in the extra data field and updated the session buffer to set the default directory when the session is initialized. This ensures that sessions maintain their working directory context.