### PR TITLE
Simplify project root detection

### DIFF
--- a/NEWS.org
+++ b/NEWS.org
@@ -1,3 +1,8 @@
+* Version 1.12.1
+- Simplify project root detection in ~ellama-get-agents-md-path~ to use
+  ~ellama-tools-project-root-tool~. This refactoring eliminates potential nil
+  returns from project-current, making the function more robust when locating
+  the AGENTS.md file.
 * Version 1.12.0
 - Add asynchronous task delegation functionality via the new ~task~ tool that
   allows delegating descriptions to subagents with custom roles and max-steps

--- a/ellama.el
+++ b/ellama.el
@@ -6,7 +6,7 @@
 ;; URL: http://github.com/s-kostyaev/ellama
 ;; Keywords: help local tools
 ;; Package-Requires: ((emacs "28.1") (llm "0.24.0") (plz "0.8") (transient "0.7") (compat "29.1") (yaml "1.2.3"))
-;; Version: 1.12.0
+;; Version: 1.12.1
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;; Created: 8th Oct 2023
 


### PR DESCRIPTION
Refactored the project root detection logic in ellama-find-agents-file to use ellama-tools-project-root-tool, eliminating potential nil returns from project-current. This makes the function more robust when locating the AGENTS.md file. Fixes #375