### PR TITLE
Add fallback for AGENTS.md search when project root tool returns nil

### DIFF
--- a/NEWS.org
+++ b/NEWS.org
@@ -1,3 +1,7 @@
+* Version 1.12.8
+- Add fallback for AGENTS.md search when ~ellama-tools-project-root-tool~
+  returns nil. This ensures reliable detection of the AGENTS.md file by falling
+  back to the current directory.
 * Version 1.12.7
 - Fix bug when only single tool was available. This change fixes a duplicate
   checking issue in the tool list by using ~llm-tool-name~ instead of

--- a/ellama.el
+++ b/ellama.el
@@ -6,7 +6,7 @@
 ;; URL: http://github.com/s-kostyaev/ellama
 ;; Keywords: help local tools
 ;; Package-Requires: ((emacs "28.1") (llm "0.24.0") (plz "0.8") (transient "0.7") (compat "29.1") (yaml "1.2.3"))
-;; Version: 1.12.7
+;; Version: 1.12.8
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;; Created: 8th Oct 2023
 


### PR DESCRIPTION
Added current directory as fallback when ellama-tools-project-root-tool returns nil, ensuring reliable AGENTS.md file detection. Fix #383