### PR TITLE
Implement automatic session context compaction

### DIFF
--- a/NEWS.org
+++ b/NEWS.org
@@ -1,3 +1,24 @@
+* Version 1.14.0
+- Implement automatic session context compaction. This feature automatically
+  summarizes chat history when it reaches a certain token threshold to manage
+  context window limits. It includes customization variables for threshold,
+  target size, provider, and turn retention.
+- Refactor session compaction to be asynchronous using `llm-chat-async`. This
+  introduces helper functions to manage token counts, apply compaction results,
+  and handle asynchronous errors and state changes.
+- Add a compaction minor mode (`ellama-compaction-mode`) for visual feedback in
+  the mode line when session compaction is in progress.
+- Refactor session compaction to use synthetic interactions for
+  summaries. Instead of appending the summary to the prompt context, it is now
+  represented as a synthetic assistant interaction. This ensures the original
+  system context is preserved and subsequent compactions correctly replace the
+  previous summary.
+- Improve session compaction system interaction handling. Added functions to
+  identify, drop, and extract system context from leading system interactions,
+  ensuring they are correctly preserved during the compaction process.
+- Add session compaction options to the transient menu, including "Compact
+  Current Session" and "Compact Session" commands.
+- Fix docstring warnings and reformat code.
 * Version 1.13.0
 - Implement DLP (Data Loss Prevention) layer.
 - Add prompt‑injection detection and configurable output‑warning handling.

--- a/README.org
+++ b/README.org
@@ -185,6 +185,8 @@ More sophisticated configuration example:
 - ~ellama-session-switch~: Change current active session.
 - ~ellama-session-kill~: Select and kill one of active sessions.
 - ~ellama-session-rename~: Rename current ellama session.
+- ~ellama-session-compact-current~: Compact current Ellama session context.
+- ~ellama-session-compact~: Select and compact an active Ellama session context.
 - ~ellama-context-add-file~: Add file to context.
 - ~ellama-context-add-directory~: Add all files in directory to the context.
 - ~ellama-context-add-buffer~: Add buffer to context.
@@ -317,6 +319,26 @@ generated text string.
 - ~ellama-major-mode~: Major mode for ellama commands. Org mode by default.
 - ~ellama-session-auto-save~: Automatically save ellama sessions if set. Enabled
   by default.
+- ~ellama-session-auto-compact-enabled~: Automatically compact long chat session
+  context. Enabled by default.
+- ~ellama-session-auto-compact-token-threshold~: Total token count that triggers
+  automatic session compaction. If not set, Ellama uses
+  ~ellama-session-auto-compact-threshold-percent~ of the provider context
+  window.
+- ~ellama-session-auto-compact-threshold-percent~: Percentage of provider
+  context limit that triggers automatic compaction. Default value is 80.
+- ~ellama-session-auto-compact-keep-last-turns~: Number of recent user turns to
+  keep verbatim during compaction. Default value is 3.
+- ~ellama-session-auto-compact-target-token-threshold~: Preferred target token
+  count after compaction. If not set, Ellama targets half of the compaction
+  threshold.
+- ~ellama-session-auto-compact-provider~: Provider used to summarize old session
+  context. If not set, Ellama uses ~ellama-summarization-provider~, then the
+  session provider.
+- ~ellama-session-auto-compact-show-message~: Show compaction notices in chat
+  buffers. Enabled by default.
+- ~ellama-session-auto-compact-prompt-template~: Prompt template for automatic
+  session context compaction.
 - ~ellama-naming-scheme~: How to name new sessions.
 - ~ellama-naming-provider~: LLM provider for generating session names by LLM. If
   not set ~ellama-provider~ will be used.
@@ -407,6 +429,40 @@ generated text string.
   auto-continue steps for a sub-agent. Default value is 30.
 - ~ellama-tools-subagent-roles~: Subagent roles with provider, system prompt and
   allowed tools. Configuration of subagents for the ~task~ tool.
+
+** Session Compaction
+
+Ellama can compact long chat sessions to keep them within the provider context
+window.  Compaction summarizes older conversation turns into one synthetic
+assistant message and keeps the most recent user turns verbatim.  New messages
+continue from the compacted prompt, so the session can keep running without
+resending the full history.
+
+Automatic compaction is enabled by default with
+~ellama-session-auto-compact-enabled~.  It runs after a response when Ellama can
+determine or estimate token usage and the session crosses the configured
+threshold.  Use ~ellama-session-auto-compact-token-threshold~ for an absolute
+token threshold, or leave it unset to use
+~ellama-session-auto-compact-threshold-percent~ of the provider context limit.
+
+You can compact sessions manually:
+
+- ~M-x ellama-session-compact-current~ compacts the current session.
+- ~M-x ellama-session-compact~ prompts for an active session and compacts it.
+
+The system message is not summarized by the compaction LLM.  Ellama restores the
+original system message in the compacted session prompt context, including when
+an LLM provider moved the system message into a system interaction before the
+request.
+
+Example configuration:
+
+#+BEGIN_SRC emacs-lisp
+  (setopt ellama-session-auto-compact-enabled t)
+  (setopt ellama-session-auto-compact-threshold-percent 75)
+  (setopt ellama-session-auto-compact-keep-last-turns 4)
+  (setopt ellama-session-auto-compact-provider ellama-summarization-provider)
+#+END_SRC
 
 ** DLP for Tool Input/Output
 

--- a/ellama-transient.el
+++ b/ellama-transient.el
@@ -268,7 +268,9 @@ Otherwise, prompt the user to enter a system message."
     ("r" "Rename Session" ellama-session-rename)
     ("d" "Delete Session" ellama-session-delete)
     ("a" "Activate Session" ellama-session-switch)
-    ("k" "Kill Session" ellama-session-kill)]
+    ("k" "Kill Session" ellama-session-kill)
+    ("c" "Compact Current Session" ellama-session-compact-current)
+    ("C" "Compact Session" ellama-session-compact)]
    ["Quit" ("q" "Quit" transient-quit-one)]])
 
 ;;;###autoload (autoload 'ellama-transient-improve-menu "ellama-transient" nil t)

--- a/ellama.el
+++ b/ellama.el
@@ -931,6 +931,16 @@ CONTEXT will be ignored.  Use global context instead.
     (setf (ellama-session-extra session)
           (plist-put extra key value))))
 
+(defun ellama--session-token-count (session)
+  "Return latest known token count stored for SESSION."
+  (or (ellama--session-extra-get session :token-count)
+      (ellama--session-extra-get session :auto-compact-last-token-count)))
+
+(defun ellama--session-set-token-count (session token-count)
+  "Store TOKEN-COUNT for SESSION when it is known."
+  (when token-count
+    (ellama--session-extra-put session :token-count token-count)))
+
 (defun ellama--session-response-token-use (provider response text)
   "Return token use from RESPONSE for PROVIDER and TEXT."
   (let* ((input-tokens (plist-get response :input-tokens))
@@ -944,6 +954,14 @@ CONTEXT will be ignored.  Use global context instead.
     (when (or input-tokens reported-output-tokens)
       (+ (or input-tokens 0)
          (or output-tokens 0)))))
+
+(defun ellama--session-store-response-token-count
+    (session provider response text)
+  "Persist latest known token count for SESSION from RESPONSE and TEXT."
+  (when-let ((token-count
+              (ellama--session-response-token-use provider response text)))
+    (ellama--session-set-token-count session token-count)
+    token-count))
 
 (defun ellama--session-auto-compact-threshold (provider)
   "Return automatic compaction token threshold for PROVIDER."
@@ -1060,6 +1078,29 @@ CONTEXT will be ignored.  Use global context instead.
         (llm-count-tokens provider (llm-chat-prompt-to-text prompt))
       (error nil))))
 
+(defun ellama--session-compact-current-token-count
+    (session provider prompt token-count)
+  "Return best known token count for SESSION before compaction."
+  (or token-count
+      (ellama--session-token-count session)
+      (let ((estimated
+             (ellama--session-compact-estimate-prompt-tokens
+              provider prompt)))
+        (ellama--session-set-token-count session estimated)
+        estimated)))
+
+(defun ellama--session-compact-new-interactions
+    (original-interactions current-interactions)
+  "Return interactions added after ORIGINAL-INTERACTIONS.
+Signal an error when CURRENT-INTERACTIONS no longer starts with
+ORIGINAL-INTERACTIONS."
+  (let ((original-length (length original-interactions)))
+    (unless (and (>= (length current-interactions) original-length)
+                 (equal original-interactions
+                        (cl-subseq current-interactions 0 original-length)))
+      (error "Ellama session changed during compaction"))
+    (cl-subseq current-interactions original-length)))
+
 (defun ellama--session-insert-compaction-message
     (buffer summarized-turns kept-turns before-tokens after-tokens)
   "Insert compaction message into BUFFER.
@@ -1092,6 +1133,54 @@ TARGET-TOKENS is the approximate target size."
           (ellama--session-compact-render-interactions
            old-interactions)))
 
+(defun ellama--session-compact-apply
+    (session prompt provider buffer original-context interactions
+             old-interactions recent-interactions token-count summary)
+  "Apply completed compaction for SESSION to PROMPT."
+  (let* ((current-prompt (ellama-session-prompt session)))
+    (unless (and (eq current-prompt prompt)
+                 (llm-chat-prompt-p current-prompt))
+      (error "Ellama session prompt changed during compaction"))
+    (let* ((current-interactions (llm-chat-prompt-interactions current-prompt))
+         (new-interactions
+          (ellama--session-compact-new-interactions
+           interactions current-interactions))
+         (kept-interactions (append recent-interactions new-interactions))
+         (summarized-turns
+          (ellama--session-compact-turn-count old-interactions))
+         (kept-turns
+          (ellama--session-compact-turn-count kept-interactions)))
+      (setf (llm-chat-prompt-context current-prompt)
+            (ellama--session-compact-context
+             original-context summary))
+      (setf (llm-chat-prompt-interactions current-prompt)
+            kept-interactions)
+      (ellama--session-extra-put
+       session :auto-compact-original-context original-context)
+      (ellama--session-extra-put
+       session :auto-compact-summary summary)
+      (ellama--session-extra-put
+       session :auto-compact-count
+       (1+ (or (ellama--session-extra-get
+                session :auto-compact-count)
+               0)))
+      (ellama--session-extra-put
+       session :auto-compact-last-token-count token-count)
+      (ellama--session-extra-put
+       session :auto-compact-last-time (current-time))
+      (let ((after-tokens
+             (ellama--session-compact-estimate-prompt-tokens
+              provider current-prompt)))
+        (ellama--session-set-token-count session after-tokens)
+        (ellama--session-insert-compaction-message
+         buffer summarized-turns kept-turns token-count after-tokens))
+      t)))
+
+(defun ellama--session-compact-handle-async-error (session err)
+  "Reset SESSION compaction state and report asynchronous ERR."
+  (ellama--session-extra-put session :auto-compact-in-progress nil)
+  (message "Ellama context compaction failed: %s" err))
+
 (cl-defun ellama--session-compact
     (session &key provider buffer token-count automatic)
   "Compact SESSION conversation context.
@@ -1120,59 +1209,59 @@ If AUTOMATIC is non-nil, fail quietly and return nil."
             (error "Not enough session history to compact"))
           (ellama--session-extra-put
            session :auto-compact-in-progress t)
-          (unwind-protect
-              (let* ((old-interactions (car split))
-                     (recent-interactions (cdr split))
-                     (extra-original
-                      (ellama--session-extra-get
-                       session :auto-compact-original-context))
-                     (original-context
-                      (if (ellama--session-extra-get
-                           session :auto-compact-summary)
-                          extra-original
-                        (llm-chat-prompt-context prompt)))
-                     (previous-summary
-                      (ellama--session-extra-get
-                       session :auto-compact-summary))
-                     (target
-                      (ellama--session-auto-compact-target
-                       (ellama--session-auto-compact-threshold provider)))
-                     (summary-prompt
-                      (ellama--session-compact-build-summary-prompt
-                       previous-summary old-interactions target))
-                     (summary
-                      (llm-chat summary-provider
-                                (llm-make-chat-prompt summary-prompt)))
-                     (summarized-turns
-                      (ellama--session-compact-turn-count old-interactions))
-                     (kept-turns
-                      (ellama--session-compact-turn-count
-                       recent-interactions)))
-                (setf (llm-chat-prompt-context prompt)
-                      (ellama--session-compact-context
-                       original-context summary))
-                (setf (llm-chat-prompt-interactions prompt)
-                      recent-interactions)
-                (ellama--session-extra-put
-                 session :auto-compact-original-context original-context)
-                (ellama--session-extra-put
-                 session :auto-compact-summary summary)
-                (ellama--session-extra-put
-                 session :auto-compact-count
-                 (1+ (or (ellama--session-extra-get
-                          session :auto-compact-count)
-                         0)))
-                (ellama--session-extra-put
-                 session :auto-compact-last-token-count token-count)
-                (ellama--session-extra-put
-                 session :auto-compact-last-time (current-time))
-                (ellama--session-insert-compaction-message
-                 buffer summarized-turns kept-turns token-count
-                 (ellama--session-compact-estimate-prompt-tokens
-                  provider prompt))
-                t)
-            (ellama--session-extra-put
-             session :auto-compact-in-progress nil))))
+          (let* ((old-interactions (car split))
+                 (recent-interactions (cdr split))
+                 (extra-original
+                  (ellama--session-extra-get
+                   session :auto-compact-original-context))
+                 (original-context
+                  (if (ellama--session-extra-get
+                       session :auto-compact-summary)
+                      extra-original
+                    (llm-chat-prompt-context prompt)))
+                 (previous-summary
+                  (ellama--session-extra-get
+                   session :auto-compact-summary))
+                 (target
+                  (ellama--session-auto-compact-target
+                   (ellama--session-auto-compact-threshold provider)))
+                 (before-token-count
+                  (ellama--session-compact-current-token-count
+                   session provider prompt token-count))
+                 (summary-prompt
+                  (ellama--session-compact-build-summary-prompt
+                   previous-summary old-interactions target)))
+            (condition-case err
+                (progn
+                  (llm-chat-async
+                   summary-provider
+                   (llm-make-chat-prompt summary-prompt)
+                   (lambda (response)
+                     (condition-case compact-err
+                         (ellama--session-compact-apply
+                          session prompt provider buffer original-context
+                          interactions old-interactions recent-interactions
+                          before-token-count
+                          (if (stringp response)
+                              response
+                            (plist-get response :text)))
+                       (error
+                        (ellama--session-compact-handle-async-error
+                         session (error-message-string compact-err))))
+                     (ellama--session-extra-put
+                      session :auto-compact-in-progress nil))
+                   (lambda (&rest err)
+                     (ellama--session-compact-handle-async-error
+                      session
+                      (mapconcat
+                       (lambda (item) (format "%s" item))
+                       err " ")))
+                   t)
+                  t)
+              (error
+               (ellama--session-extra-put
+                session :auto-compact-in-progress nil)
+               (signal (car err) (cdr err)))))))
     (error
      (if automatic
          (progn
@@ -2144,6 +2233,8 @@ inserted into the BUFFER."
             (spinner-stop))
           (when (and (not tool-result)
                      (ellama-session-p ellama--current-session))
+            (ellama--session-store-response-token-count
+             ellama--current-session provider response text)
             (ellama--session-auto-compact-maybe
              ellama--current-session provider response text buffer))
           (if (and (listp donecb)

--- a/ellama.el
+++ b/ellama.el
@@ -944,7 +944,7 @@ CONTEXT will be ignored.  Use global context instead.
       (ellama--session-extra-get session :auto-compact-last-token-count)))
 
 (defun ellama--session-compaction-buffer (session buffer)
-  "Return live buffer for SESSION compaction status."
+  "Return live BUFFER for SESSION compaction status."
   (or (and (buffer-live-p buffer) buffer)
       (when-let ((uid (ellama--session-uid session)))
         (let ((session-buffer (ellama-get-session-buffer uid)))
@@ -979,7 +979,7 @@ CONTEXT will be ignored.  Use global context instead.
 
 (defun ellama--session-store-response-token-count
     (session provider response text)
-  "Persist latest known token count for SESSION from RESPONSE and TEXT."
+  "Persist latest known token count for SESSION from PROVIDER RESPONSE and TEXT."
   (when-let ((token-count
               (ellama--session-response-token-use provider response text)))
     (ellama--session-set-token-count session token-count)
@@ -1120,7 +1120,9 @@ Drop the synthetic summary interaction inserted by previous compaction."
 
 (defun ellama--session-compact-current-token-count
     (session provider prompt token-count)
-  "Return best known token count for SESSION before compaction."
+  "Return best known token count for SESSION before compaction.
+PROVIDER and PROMPT are used for fallback estimation.
+TOKEN-COUNT overrides any stored value when non-nil."
   (or token-count
       (ellama--session-token-count session)
       (let ((estimated
@@ -1176,7 +1178,12 @@ TARGET-TOKENS is the approximate target size."
 (defun ellama--session-compact-apply
     (session prompt provider buffer original-context interactions
              old-interactions recent-interactions token-count summary)
-  "Apply completed compaction for SESSION to PROMPT."
+  "Apply completed compaction for SESSION to PROMPT.
+PROVIDER estimates resulting token count.  BUFFER receives notices.
+ORIGINAL-CONTEXT stays as the system message.
+INTERACTIONS is the pre-compaction interaction snapshot.
+OLD-INTERACTIONS and RECENT-INTERACTIONS are the compaction split.
+TOKEN-COUNT is the pre-compaction estimate.  SUMMARY is the new summary."
   (let* ((current-prompt (ellama-session-prompt session)))
     (unless (and (eq current-prompt prompt)
                  (llm-chat-prompt-p current-prompt))

--- a/ellama.el
+++ b/ellama.el
@@ -1191,14 +1191,14 @@ TOKEN-COUNT is the pre-compaction estimate.  SUMMARY is the new summary."
     (let* ((current-interactions
             (ellama--session-compact-base-interactions
              session current-prompt))
-         (new-interactions
-          (ellama--session-compact-new-interactions
-           interactions current-interactions))
-         (kept-interactions (append recent-interactions new-interactions))
-         (summarized-turns
-          (ellama--session-compact-turn-count old-interactions))
-         (kept-turns
-          (ellama--session-compact-turn-count kept-interactions)))
+           (new-interactions
+            (ellama--session-compact-new-interactions
+             interactions current-interactions))
+           (kept-interactions (append recent-interactions new-interactions))
+           (summarized-turns
+            (ellama--session-compact-turn-count old-interactions))
+           (kept-turns
+            (ellama--session-compact-turn-count kept-interactions)))
       (setf (llm-chat-prompt-context current-prompt)
             original-context)
       (setf (llm-chat-prompt-interactions current-prompt)
@@ -1298,7 +1298,7 @@ If AUTOMATIC is non-nil, fail quietly and return nil."
                               response
                             (plist-get response :text)))
                        (error
-                       (ellama--session-compact-handle-async-error
+                        (ellama--session-compact-handle-async-error
                          session (error-message-string compact-err))))
                      (ellama--session-set-compaction-mode
                       session buffer nil)

--- a/ellama.el
+++ b/ellama.el
@@ -595,6 +595,11 @@ It should be a function with single argument generated text string."
                  'ellama--cancel-current-request-on-kill)
     (ellama--cancel-current-request)))
 
+(define-minor-mode ellama-compaction-mode
+  "Minor mode for `ellama' buffers with active session compaction."
+  :interactive nil
+  :lighter " ellama:compacting")
+
 (defvar-local ellama--change-group nil)
 
 (defvar-local ellama--current-request nil)
@@ -936,6 +941,21 @@ CONTEXT will be ignored.  Use global context instead.
   (or (ellama--session-extra-get session :token-count)
       (ellama--session-extra-get session :auto-compact-last-token-count)))
 
+(defun ellama--session-compaction-buffer (session buffer)
+  "Return live buffer for SESSION compaction status."
+  (or (and (buffer-live-p buffer) buffer)
+      (when-let ((uid (ellama--session-uid session)))
+        (let ((session-buffer (ellama-get-session-buffer uid)))
+          (and (buffer-live-p session-buffer) session-buffer)))))
+
+(defun ellama--session-set-compaction-mode (session buffer enabled)
+  "Set compaction lighter for SESSION BUFFER to ENABLED."
+  (when-let ((target-buffer
+              (ellama--session-compaction-buffer session buffer)))
+    (with-current-buffer target-buffer
+      (ellama-compaction-mode (if enabled +1 -1))
+      (force-mode-line-update t))))
+
 (defun ellama--session-set-token-count (session token-count)
   "Store TOKEN-COUNT for SESSION when it is known."
   (when token-count
@@ -1179,6 +1199,7 @@ TARGET-TOKENS is the approximate target size."
 (defun ellama--session-compact-handle-async-error (session err)
   "Reset SESSION compaction state and report asynchronous ERR."
   (ellama--session-extra-put session :auto-compact-in-progress nil)
+  (ellama--session-set-compaction-mode session nil nil)
   (message "Ellama context compaction failed: %s" err))
 
 (cl-defun ellama--session-compact
@@ -1209,6 +1230,7 @@ If AUTOMATIC is non-nil, fail quietly and return nil."
             (error "Not enough session history to compact"))
           (ellama--session-extra-put
            session :auto-compact-in-progress t)
+          (ellama--session-set-compaction-mode session buffer t)
           (let* ((old-interactions (car split))
                  (recent-interactions (cdr split))
                  (extra-original
@@ -1246,8 +1268,10 @@ If AUTOMATIC is non-nil, fail quietly and return nil."
                               response
                             (plist-get response :text)))
                        (error
-                        (ellama--session-compact-handle-async-error
+                       (ellama--session-compact-handle-async-error
                          session (error-message-string compact-err))))
+                     (ellama--session-set-compaction-mode
+                      session buffer nil)
                      (ellama--session-extra-put
                       session :auto-compact-in-progress nil))
                    (lambda (&rest err)
@@ -1259,6 +1283,7 @@ If AUTOMATIC is non-nil, fail quietly and return nil."
                    t)
                   t)
               (error
+               (ellama--session-set-compaction-mode session buffer nil)
                (ellama--session-extra-put
                 session :auto-compact-in-progress nil)
                (signal (car err) (cdr err)))))))

--- a/ellama.el
+++ b/ellama.el
@@ -6,7 +6,7 @@
 ;; URL: http://github.com/s-kostyaev/ellama
 ;; Keywords: help local tools
 ;; Package-Requires: ((emacs "28.1") (llm "0.24.0") (plz "0.8") (transient "0.7") (compat "29.1") (yaml "1.2.3"))
-;; Version: 1.13.0
+;; Version: 1.14.0
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;; Created: 8th Oct 2023
 

--- a/ellama.el
+++ b/ellama.el
@@ -81,6 +81,40 @@ Make reasoning models more useful for many cases."
   "Hide org quotes in ellama session buffer."
   :type 'boolean)
 
+(defcustom ellama-session-auto-compact-enabled t
+  "Enable automatic compaction of long chat session context."
+  :type 'boolean)
+
+(defcustom ellama-session-auto-compact-token-threshold nil
+  "Total token count that triggers automatic session compaction.
+When nil, use `ellama-session-auto-compact-threshold-percent' of the
+provider context limit."
+  :type '(choice (const :tag "Use provider context percentage" nil)
+                 integer))
+
+(defcustom ellama-session-auto-compact-threshold-percent 80
+  "Percentage of provider context limit that triggers compaction."
+  :type 'integer)
+
+(defcustom ellama-session-auto-compact-keep-last-turns 3
+  "Number of recent user turns to keep verbatim during compaction."
+  :type 'integer)
+
+(defcustom ellama-session-auto-compact-target-token-threshold nil
+  "Preferred target token count after compaction.
+When nil, use a conservative automatic target."
+  :type '(choice (const :tag "Use automatic target" nil)
+                 integer))
+
+(defcustom ellama-session-auto-compact-provider nil
+  "Provider used to summarize old session context.
+When nil, use `ellama-summarization-provider', then the session provider."
+  :type '(sexp :validate llm-standard-provider-p))
+
+(defcustom ellama-session-auto-compact-show-message t
+  "Show compaction notices in chat buffers."
+  :type 'boolean)
+
 (defcustom ellama-chat-translation-enabled nil
   "Enable chat translations."
   :type 'boolean)
@@ -258,6 +292,32 @@ clarity and maintain a straightforward presentation.
 3. ADD NO NEW IDEAS
    Use only words from input text"
   "Prompt template for `ellama-summarize'."
+  :type 'string)
+
+(defcustom ellama-session-auto-compact-prompt-template
+  "Summarize this Ellama chat history for future conversation context.
+
+Keep durable information that future replies need:
+- user goals and preferences,
+- decisions already made,
+- constraints and instructions,
+- important files, buffers, packages, symbols, APIs, commands, errors,
+  and results,
+- pending tasks and unresolved questions,
+- exact wording only when the wording itself matters.
+
+Discard greetings, repeated confirmations, superseded failed attempts,
+assistant narration, and long raw output unless it contains durable facts.
+
+Merge the previous summary with the older chat history into one updated
+summary.  Keep it under approximately %s tokens.
+
+Previous summary:
+%s
+
+Older chat history:
+%s"
+  "Prompt template for automatic session context compaction."
   :type 'string)
 
 (defcustom ellama-code-review-prompt-template "You are professional software engineer. Review the provided code and make concise suggestions."
@@ -857,6 +917,284 @@ CONTEXT will be ignored.  Use global context instead.
     (setf (ellama-session-extra session) (plist-put extra :uid uid))
     uid))
 
+(defun ellama--session-extra-get (session key)
+  "Return KEY from SESSION extra plist."
+  (when-let* ((extra (ellama-session-extra session))
+              ((plistp extra)))
+    (plist-get extra key)))
+
+(defun ellama--session-extra-put (session key value)
+  "Set KEY to VALUE in SESSION extra plist."
+  (let ((extra (if (plistp (ellama-session-extra session))
+                   (copy-sequence (ellama-session-extra session))
+                 nil)))
+    (setf (ellama-session-extra session)
+          (plist-put extra key value))))
+
+(defun ellama--session-response-token-use (provider response text)
+  "Return token use from RESPONSE for PROVIDER and TEXT."
+  (let* ((input-tokens (plist-get response :input-tokens))
+         (reported-output-tokens (plist-get response :output-tokens))
+         (output-tokens
+          (or reported-output-tokens
+              (when (and provider text)
+                (condition-case nil
+                    (llm-count-tokens provider text)
+                  (error nil))))))
+    (when (or input-tokens reported-output-tokens)
+      (+ (or input-tokens 0)
+         (or output-tokens 0)))))
+
+(defun ellama--session-auto-compact-threshold (provider)
+  "Return automatic compaction token threshold for PROVIDER."
+  (or ellama-session-auto-compact-token-threshold
+      (when provider
+        (condition-case nil
+            (floor (* (llm-chat-token-limit provider)
+                      (/ ellama-session-auto-compact-threshold-percent
+                         100.0)))
+          (error nil)))))
+
+(defun ellama--session-auto-compact-target (threshold)
+  "Return compaction target token count for THRESHOLD."
+  (or ellama-session-auto-compact-target-token-threshold
+      (when threshold
+        (floor (* threshold 0.5)))))
+
+(defun ellama--session-auto-compact-provider (session)
+  "Return provider used to compact SESSION."
+  (or ellama-session-auto-compact-provider
+      ellama-summarization-provider
+      (ellama-session-provider session)
+      ellama-provider))
+
+(defun ellama--session-auto-compact-needed-p
+    (session provider response text)
+  "Return token count for PROVIDER when SESSION should compact RESPONSE."
+  (when (and ellama-session-auto-compact-enabled
+             (ellama-session-p session)
+             (llm-chat-prompt-p (ellama-session-prompt session))
+             (not (ellama--session-extra-get
+                   session :auto-compact-in-progress)))
+    (when-let* ((token-use
+                 (ellama--session-response-token-use provider response text))
+                (threshold
+                 (ellama--session-auto-compact-threshold provider))
+                ((>= token-use threshold)))
+      token-use)))
+
+(defun ellama--session-compact-content-to-string (content)
+  "Return string representation of interaction CONTENT."
+  (cond
+   ((stringp content) content)
+   ((and (fboundp 'llm-multipart-p)
+         (llm-multipart-p content))
+    (string-join
+     (mapcar (lambda (part)
+               (if (stringp part)
+                   part
+                 (format "%S" part)))
+             (llm-multipart-parts content))
+     "\n"))
+   (t (format "%S" content))))
+
+(defun ellama--session-compact-render-interaction (interaction)
+  "Render INTERACTION for summary generation."
+  (let ((role (llm-chat-prompt-interaction-role interaction))
+        (content (llm-chat-prompt-interaction-content interaction))
+        (tool-results (llm-chat-prompt-interaction-tool-results
+                       interaction)))
+    (string-join
+     (delq nil
+           (list
+            (format "%s:\n%s"
+                    (capitalize (symbol-name role))
+                    (ellama--session-compact-content-to-string content))
+            (when tool-results
+              (format "Tool results:\n%S" tool-results))))
+     "\n")))
+
+(defun ellama--session-compact-render-interactions (interactions)
+  "Render INTERACTIONS for summary generation."
+  (string-join
+   (mapcar #'ellama--session-compact-render-interaction interactions)
+   "\n\n"))
+
+(defun ellama--session-compact-split-interactions (interactions keep-turns)
+  "Split INTERACTIONS into old and recent parts keeping KEEP-TURNS."
+  (let ((index nil)
+        (turns 0)
+        (pos (1- (length interactions))))
+    (while (and (>= pos 0) (< turns keep-turns))
+      (when (eq (llm-chat-prompt-interaction-role
+                 (nth pos interactions))
+                'user)
+        (setq turns (1+ turns))
+        (setq index pos))
+      (setq pos (1- pos)))
+    (when (and index (> index 0))
+      (cons (cl-subseq interactions 0 index)
+            (cl-subseq interactions index)))))
+
+(defun ellama--session-compact-context (original-context summary)
+  "Return compacted context from ORIGINAL-CONTEXT and SUMMARY."
+  (string-join
+   (delq nil
+         (list (unless (string-empty-p (or original-context ""))
+                 original-context)
+               "Previous conversation summary:"
+               summary))
+   "\n\n"))
+
+(defun ellama--session-compact-turn-count (interactions)
+  "Return user turn count for INTERACTIONS."
+  (cl-count-if
+   (lambda (interaction)
+     (eq (llm-chat-prompt-interaction-role interaction) 'user))
+   interactions))
+
+(defun ellama--session-compact-estimate-prompt-tokens (provider prompt)
+  "Return estimated token count for PROMPT with PROVIDER."
+  (when provider
+    (condition-case nil
+        (llm-count-tokens provider (llm-chat-prompt-to-text prompt))
+      (error nil))))
+
+(defun ellama--session-insert-compaction-message
+    (buffer summarized-turns kept-turns before-tokens after-tokens)
+  "Insert compaction message into BUFFER.
+SUMMARIZED-TURNS is count of summarized user turns.
+KEPT-TURNS is count of kept recent user turns.
+BEFORE-TOKENS and AFTER-TOKENS are token estimates."
+  (when (and ellama-session-auto-compact-show-message
+             (buffer-live-p buffer))
+    (with-current-buffer buffer
+      (save-excursion
+        (goto-char (point-max))
+        (insert
+         (format
+          (concat
+           "\n\n[Ellama compacted conversation context: summarized %d "
+           "earlier turns, kept %d recent turns, estimated context "
+           "%s -> %s tokens.]\n")
+          summarized-turns
+          kept-turns
+          (or before-tokens "unknown")
+          (or after-tokens "unknown")))))))
+
+(defun ellama--session-compact-build-summary-prompt
+    (previous-summary old-interactions target-tokens)
+  "Build summary prompt from PREVIOUS-SUMMARY and OLD-INTERACTIONS.
+TARGET-TOKENS is the approximate target size."
+  (format ellama-session-auto-compact-prompt-template
+          (or target-tokens "the smallest useful number of")
+          (or previous-summary "None.")
+          (ellama--session-compact-render-interactions
+           old-interactions)))
+
+(cl-defun ellama--session-compact
+    (session &key provider buffer token-count automatic)
+  "Compact SESSION conversation context.
+PROVIDER is the current session provider.
+BUFFER is the chat buffer that should receive a notice.
+TOKEN-COUNT is the estimated context size before compaction.
+If AUTOMATIC is non-nil, fail quietly and return nil."
+  (condition-case err
+      (let* ((provider (or provider (ellama-session-provider session)))
+             (summary-provider
+              (ellama--session-auto-compact-provider session))
+             (prompt (ellama-session-prompt session)))
+        (unless (ellama-session-p session)
+          (error "No Ellama session to compact"))
+        (unless (llm-chat-prompt-p prompt)
+          (error "Ellama session prompt is not a chat prompt"))
+        (when (ellama--session-extra-get session :auto-compact-in-progress)
+          (error "Ellama session compaction is already in progress"))
+        (unless summary-provider
+          (error "No provider available for Ellama session compaction"))
+        (let* ((interactions (llm-chat-prompt-interactions prompt))
+               (split (ellama--session-compact-split-interactions
+                       interactions
+                       (max 0 ellama-session-auto-compact-keep-last-turns))))
+          (unless split
+            (error "Not enough session history to compact"))
+          (ellama--session-extra-put
+           session :auto-compact-in-progress t)
+          (unwind-protect
+              (let* ((old-interactions (car split))
+                     (recent-interactions (cdr split))
+                     (extra-original
+                      (ellama--session-extra-get
+                       session :auto-compact-original-context))
+                     (original-context
+                      (if (ellama--session-extra-get
+                           session :auto-compact-summary)
+                          extra-original
+                        (llm-chat-prompt-context prompt)))
+                     (previous-summary
+                      (ellama--session-extra-get
+                       session :auto-compact-summary))
+                     (target
+                      (ellama--session-auto-compact-target
+                       (ellama--session-auto-compact-threshold provider)))
+                     (summary-prompt
+                      (ellama--session-compact-build-summary-prompt
+                       previous-summary old-interactions target))
+                     (summary
+                      (llm-chat summary-provider
+                                (llm-make-chat-prompt summary-prompt)))
+                     (summarized-turns
+                      (ellama--session-compact-turn-count old-interactions))
+                     (kept-turns
+                      (ellama--session-compact-turn-count
+                       recent-interactions)))
+                (setf (llm-chat-prompt-context prompt)
+                      (ellama--session-compact-context
+                       original-context summary))
+                (setf (llm-chat-prompt-interactions prompt)
+                      recent-interactions)
+                (ellama--session-extra-put
+                 session :auto-compact-original-context original-context)
+                (ellama--session-extra-put
+                 session :auto-compact-summary summary)
+                (ellama--session-extra-put
+                 session :auto-compact-count
+                 (1+ (or (ellama--session-extra-get
+                          session :auto-compact-count)
+                         0)))
+                (ellama--session-extra-put
+                 session :auto-compact-last-token-count token-count)
+                (ellama--session-extra-put
+                 session :auto-compact-last-time (current-time))
+                (ellama--session-insert-compaction-message
+                 buffer summarized-turns kept-turns token-count
+                 (ellama--session-compact-estimate-prompt-tokens
+                  provider prompt))
+                t)
+            (ellama--session-extra-put
+             session :auto-compact-in-progress nil))))
+    (error
+     (if automatic
+         (progn
+           (message "Ellama context compaction failed: %s"
+                    (error-message-string err))
+           nil)
+       (signal (car err) (cdr err))))))
+
+(defun ellama--session-auto-compact-maybe
+    (session provider response text buffer)
+  "Compact SESSION when RESPONSE token use for TEXT crosses threshold.
+PROVIDER is the session provider.  BUFFER is the chat buffer."
+  (when-let ((token-count
+              (ellama--session-auto-compact-needed-p
+               session provider response text)))
+    (ellama--session-compact
+     session
+     :provider provider
+     :buffer buffer
+     :token-count token-count
+     :automatic t)))
+
 (defun ellama--active-session-by-id (id)
   "Return active session matching display ID."
   (catch 'session
@@ -1305,6 +1643,38 @@ REQUEST-CONTEXT is a request context."
     (ellama-activate-session id)
     (display-buffer buffer (when ellama-chat-display-action-function
                              `((ignore . (,ellama-chat-display-action-function)))))))
+
+;;;###autoload
+(defun ellama-session-compact-current ()
+  "Compact current Ellama session context."
+  (interactive)
+  (let* ((session (or ellama--current-session
+                      (ellama--resolve-session)))
+         (buffer (and session
+                      (ellama-get-session-buffer
+                       (ellama--session-uid session)))))
+    (unless session
+      (error "No active ellama session to compact"))
+    (ellama--session-compact
+     session
+     :provider (ellama-session-provider session)
+     :buffer (or buffer (current-buffer)))))
+
+;;;###autoload
+(defun ellama-session-compact ()
+  "Select and compact an active Ellama session context."
+  (interactive)
+  (let* ((id (completing-read
+              "Select session to compact: "
+              (ellama--active-session-ids)))
+         (session (ellama--resolve-session nil id))
+         (buffer (ellama-get-session-buffer id)))
+    (unless session
+      (error "No active ellama session to compact"))
+    (ellama--session-compact
+     session
+     :provider (ellama-session-provider session)
+     :buffer buffer)))
 
 ;;;###autoload
 (defun ellama-session-kill ()
@@ -1772,6 +2142,10 @@ inserted into the BUFFER."
           (accept-change-group ellama--change-group)
           (when ellama-spinner-enabled
             (spinner-stop))
+          (when (and (not tool-result)
+                     (ellama-session-p ellama--current-session))
+            (ellama--session-auto-compact-maybe
+             ellama--current-session provider response text buffer))
           (if (and (listp donecb)
                    (functionp (car donecb)))
               (mapc (lambda (fn) (funcall fn text))

--- a/ellama.el
+++ b/ellama.el
@@ -308,6 +308,8 @@ Keep durable information that future replies need:
 
 Discard greetings, repeated confirmations, superseded failed attempts,
 assistant narration, and long raw output unless it contains durable facts.
+Do not copy or restate the system message.  The compacted session keeps
+the original system message separately in `:context`.
 
 Merge the previous summary with the older chat history into one updated
 summary.  Keep it under approximately %s tokens.
@@ -1074,15 +1076,33 @@ CONTEXT will be ignored.  Use global context instead.
       (cons (cl-subseq interactions 0 index)
             (cl-subseq interactions index)))))
 
-(defun ellama--session-compact-context (original-context summary)
-  "Return compacted context from ORIGINAL-CONTEXT and SUMMARY."
-  (string-join
-   (delq nil
-         (list (unless (string-empty-p (or original-context ""))
-                 original-context)
-               "Previous conversation summary:"
-               summary))
-   "\n\n"))
+(defun ellama--session-summary-interaction-content (summary)
+  "Return synthetic interaction content for SUMMARY."
+  (format "Previous conversation summary:\n\n%s" summary))
+
+(defun ellama--session-summary-interaction (summary)
+  "Return synthetic assistant interaction carrying SUMMARY."
+  (make-llm-chat-prompt-interaction
+   :role 'assistant
+   :content (ellama--session-summary-interaction-content summary)))
+
+(defun ellama--session-summary-interaction-p (session interaction)
+  "Return non-nil when INTERACTION is stored compaction summary for SESSION."
+  (let ((stored-summary (ellama--session-extra-get session :auto-compact-summary)))
+    (and stored-summary
+         (eq (llm-chat-prompt-interaction-role interaction) 'assistant)
+         (equal (llm-chat-prompt-interaction-content interaction)
+                (ellama--session-summary-interaction-content stored-summary)))))
+
+(defun ellama--session-compact-base-interactions (session prompt)
+  "Return compactable interactions from PROMPT for SESSION.
+Drop the synthetic summary interaction inserted by previous compaction."
+  (let ((interactions (llm-chat-prompt-interactions prompt)))
+    (if (and interactions
+             (ellama--session-summary-interaction-p
+              session (car interactions)))
+        (cdr interactions)
+      interactions)))
 
 (defun ellama--session-compact-turn-count (interactions)
   "Return user turn count for INTERACTIONS."
@@ -1161,7 +1181,9 @@ TARGET-TOKENS is the approximate target size."
     (unless (and (eq current-prompt prompt)
                  (llm-chat-prompt-p current-prompt))
       (error "Ellama session prompt changed during compaction"))
-    (let* ((current-interactions (llm-chat-prompt-interactions current-prompt))
+    (let* ((current-interactions
+            (ellama--session-compact-base-interactions
+             session current-prompt))
          (new-interactions
           (ellama--session-compact-new-interactions
            interactions current-interactions))
@@ -1171,10 +1193,10 @@ TARGET-TOKENS is the approximate target size."
          (kept-turns
           (ellama--session-compact-turn-count kept-interactions)))
       (setf (llm-chat-prompt-context current-prompt)
-            (ellama--session-compact-context
-             original-context summary))
+            original-context)
       (setf (llm-chat-prompt-interactions current-prompt)
-            kept-interactions)
+            (cons (ellama--session-summary-interaction summary)
+                  kept-interactions))
       (ellama--session-extra-put
        session :auto-compact-original-context original-context)
       (ellama--session-extra-put
@@ -1222,7 +1244,8 @@ If AUTOMATIC is non-nil, fail quietly and return nil."
           (error "Ellama session compaction is already in progress"))
         (unless summary-provider
           (error "No provider available for Ellama session compaction"))
-        (let* ((interactions (llm-chat-prompt-interactions prompt))
+        (let* ((interactions
+                (ellama--session-compact-base-interactions session prompt))
                (split (ellama--session-compact-split-interactions
                        interactions
                        (max 0 ellama-session-auto-compact-keep-last-turns))))

--- a/ellama.el
+++ b/ellama.el
@@ -1094,10 +1094,46 @@ CONTEXT will be ignored.  Use global context instead.
          (equal (llm-chat-prompt-interaction-content interaction)
                 (ellama--session-summary-interaction-content stored-summary)))))
 
+(defun ellama--session-system-interaction-p (interaction)
+  "Return non-nil when INTERACTION is a system interaction."
+  (eq (llm-chat-prompt-interaction-role interaction) 'system))
+
+(defun ellama--session-drop-system-interactions (interactions)
+  "Drop leading system interactions from INTERACTIONS."
+  (while (and interactions
+              (ellama--session-system-interaction-p (car interactions)))
+    (setq interactions (cdr interactions)))
+  interactions)
+
+(defun ellama--session-system-context-from-interactions (interactions)
+  "Return system context from leading system INTERACTIONS."
+  (let ((system-interactions nil))
+    (while (and interactions
+                (ellama--session-system-interaction-p (car interactions)))
+      (push (car interactions) system-interactions)
+      (setq interactions (cdr interactions)))
+    (when system-interactions
+      (string-join
+       (mapcar
+        (lambda (interaction)
+          (ellama--session-compact-content-to-string
+           (llm-chat-prompt-interaction-content interaction)))
+        (nreverse system-interactions))
+       "\n"))))
+
+(defun ellama--session-original-context (session prompt)
+  "Return original system context for SESSION PROMPT."
+  (or (ellama--session-extra-get session :auto-compact-original-context)
+      (llm-chat-prompt-context prompt)
+      (ellama--session-system-context-from-interactions
+       (llm-chat-prompt-interactions prompt))))
+
 (defun ellama--session-compact-base-interactions (session prompt)
   "Return compactable interactions from PROMPT for SESSION.
-Drop the synthetic summary interaction inserted by previous compaction."
-  (let ((interactions (llm-chat-prompt-interactions prompt)))
+Drop the synthetic summary interaction inserted by previous compaction.
+Drop leading system interactions; they are restored as prompt context."
+  (let ((interactions (ellama--session-drop-system-interactions
+                       (llm-chat-prompt-interactions prompt))))
     (if (and interactions
              (ellama--session-summary-interaction-p
               session (car interactions)))
@@ -1267,10 +1303,8 @@ If AUTOMATIC is non-nil, fail quietly and return nil."
                   (ellama--session-extra-get
                    session :auto-compact-original-context))
                  (original-context
-                  (if (ellama--session-extra-get
-                       session :auto-compact-summary)
-                      extra-original
-                    (llm-chat-prompt-context prompt)))
+                  (or extra-original
+                      (ellama--session-original-context session prompt)))
                  (previous-summary
                   (ellama--session-extra-get
                    session :auto-compact-summary))

--- a/ellama.info
+++ b/ellama.info
@@ -75,6 +75,7 @@ Assistant".  Previous sentence was written by Ellama itself.
 
 Configuration
 
+* Session Compaction::
 * DLP for Tool Input/Output::
 * SRT Filesystem Policy for Tools::
 
@@ -299,6 +300,10 @@ File: ellama.info,  Node: Commands,  Next: Keymap,  Prev: Installation,  Up: Top
    • ‘ellama-session-switch’: Change current active session.
    • ‘ellama-session-kill’: Select and kill one of active sessions.
    • ‘ellama-session-rename’: Rename current ellama session.
+   • ‘ellama-session-compact-current’: Compact current Ellama session
+     context.
+   • ‘ellama-session-compact’: Select and compact an active Ellama
+     session context.
    • ‘ellama-context-add-file’: Add file to context.
    • ‘ellama-context-add-directory’: Add all files in directory to the
      context.
@@ -450,6 +455,27 @@ argument generated text string.
      default.
    • ‘ellama-session-auto-save’: Automatically save ellama sessions if
      set.  Enabled by default.
+   • ‘ellama-session-auto-compact-enabled’: Automatically compact long
+     chat session context.  Enabled by default.
+   • ‘ellama-session-auto-compact-token-threshold’: Total token count
+     that triggers automatic session compaction.  If not set, Ellama
+     uses ‘ellama-session-auto-compact-threshold-percent’ of the
+     provider context window.
+   • ‘ellama-session-auto-compact-threshold-percent’: Percentage of
+     provider context limit that triggers automatic compaction.  Default
+     value is 80.
+   • ‘ellama-session-auto-compact-keep-last-turns’: Number of recent
+     user turns to keep verbatim during compaction.  Default value is 3.
+   • ‘ellama-session-auto-compact-target-token-threshold’: Preferred
+     target token count after compaction.  If not set, Ellama targets
+     half of the compaction threshold.
+   • ‘ellama-session-auto-compact-provider’: Provider used to summarize
+     old session context.  If not set, Ellama uses
+     ‘ellama-summarization-provider’, then the session provider.
+   • ‘ellama-session-auto-compact-show-message’: Show compaction notices
+     in chat buffers.  Enabled by default.
+   • ‘ellama-session-auto-compact-prompt-template’: Prompt template for
+     automatic session context compaction.
    • ‘ellama-naming-scheme’: How to name new sessions.
    • ‘ellama-naming-provider’: LLM provider for generating session names
      by LLM.  If not set ‘ellama-provider’ will be used.
@@ -556,13 +582,52 @@ argument generated text string.
 
 * Menu:
 
+* Session Compaction::
 * DLP for Tool Input/Output::
 * SRT Filesystem Policy for Tools::
 
 
-File: ellama.info,  Node: DLP for Tool Input/Output,  Next: SRT Filesystem Policy for Tools,  Up: Configuration
+File: ellama.info,  Node: Session Compaction,  Next: DLP for Tool Input/Output,  Up: Configuration
 
-4.1 DLP for Tool Input/Output
+4.1 Session Compaction
+======================
+
+Ellama can compact long chat sessions to keep them within the provider
+context window.  Compaction summarizes older conversation turns into one
+synthetic assistant message and keeps the most recent user turns
+verbatim.  New messages continue from the compacted prompt, so the
+session can keep running without resending the full history.
+
+Automatic compaction is enabled by default with
+‘ellama-session-auto-compact-enabled’.  It runs after a response when
+Ellama can determine or estimate token usage and the session crosses the
+configured threshold.  Use ‘ellama-session-auto-compact-token-threshold’
+for an absolute token threshold, or leave it unset to use
+‘ellama-session-auto-compact-threshold-percent’ of the provider context
+limit.
+
+You can compact sessions manually:
+
+   • ‘M-x ellama-session-compact-current’ compacts the current session.
+   • ‘M-x ellama-session-compact’ prompts for an active session and
+     compacts it.
+
+The system message is not summarized by the compaction LLM.  Ellama
+restores the original system message in the compacted session prompt
+context, including when an LLM provider moved the system message into a
+system interaction before the request.
+
+Example configuration:
+
+     (setopt ellama-session-auto-compact-enabled t)
+     (setopt ellama-session-auto-compact-threshold-percent 75)
+     (setopt ellama-session-auto-compact-keep-last-turns 4)
+     (setopt ellama-session-auto-compact-provider ellama-summarization-provider)
+
+
+File: ellama.info,  Node: DLP for Tool Input/Output,  Next: SRT Filesystem Policy for Tools,  Prev: Session Compaction,  Up: Configuration
+
+4.2 DLP for Tool Input/Output
 =============================
 
 Ellama includes an optional DLP (Data Loss Prevention) layer for tool
@@ -888,7 +953,7 @@ Troubleshooting:
 
 File: ellama.info,  Node: SRT Filesystem Policy for Tools,  Prev: DLP for Tool Input/Output,  Up: Configuration
 
-4.2 SRT Filesystem Policy for Tools
+4.3 SRT Filesystem Policy for Tools
 ===================================
 
 When ‘ellama-tools-use-srt’ is non-nil, the ‘srt’ settings file is the
@@ -2127,43 +2192,44 @@ their use in free software.
 
 Tag Table:
 Node: Top1379
-Node: Installation3830
-Node: Commands8844
-Node: Keymap16131
-Node: Configuration18965
-Node: DLP for Tool Input/Output27557
-Node: SRT Filesystem Policy for Tools42431
-Node: Context Management48100
-Node: Transient Menus for Context Management49168
-Node: Managing the Context50782
-Node: Considerations51557
-Node: Minor modes52150
-Node: ellama-context-header-line-mode54138
-Node: ellama-context-header-line-global-mode54963
-Node: ellama-context-mode-line-mode55683
-Node: ellama-context-mode-line-global-mode56531
-Node: Ellama Session Header Line Mode57235
-Node: Enabling and Disabling57804
-Node: Customization58251
-Node: Ellama Session Mode Line Mode58539
-Node: Enabling and Disabling (1)59124
-Node: Customization (1)59571
-Node: Using Blueprints59865
-Node: Key Components of Ellama Blueprints60505
-Node: Creating and Managing Blueprints61112
-Node: Blueprints files62090
-Node: Variable Management62511
-Node: Keymap and Mode62964
-Node: Transient Menus63900
-Node: Running Blueprints programmatically64446
-Node: MCP Integration65033
-Node: Agent Skills66268
-Node: Directory Structure66631
-Node: Creating a Skill67658
-Node: How it works68033
-Node: Acknowledgments68424
-Node: Contributions69135
-Node: GNU Free Documentation License69521
+Node: Installation3853
+Node: Commands8867
+Node: Keymap16339
+Node: Configuration19173
+Node: Session Compaction29095
+Node: DLP for Tool Input/Output30733
+Node: SRT Filesystem Policy for Tools45634
+Node: Context Management51303
+Node: Transient Menus for Context Management52371
+Node: Managing the Context53985
+Node: Considerations54760
+Node: Minor modes55353
+Node: ellama-context-header-line-mode57341
+Node: ellama-context-header-line-global-mode58166
+Node: ellama-context-mode-line-mode58886
+Node: ellama-context-mode-line-global-mode59734
+Node: Ellama Session Header Line Mode60438
+Node: Enabling and Disabling61007
+Node: Customization61454
+Node: Ellama Session Mode Line Mode61742
+Node: Enabling and Disabling (1)62327
+Node: Customization (1)62774
+Node: Using Blueprints63068
+Node: Key Components of Ellama Blueprints63708
+Node: Creating and Managing Blueprints64315
+Node: Blueprints files65293
+Node: Variable Management65714
+Node: Keymap and Mode66167
+Node: Transient Menus67103
+Node: Running Blueprints programmatically67649
+Node: MCP Integration68236
+Node: Agent Skills69471
+Node: Directory Structure69834
+Node: Creating a Skill70861
+Node: How it works71236
+Node: Acknowledgments71627
+Node: Contributions72338
+Node: GNU Free Documentation License72724
 
 End Tag Table
 

--- a/tests/test-ellama.el
+++ b/tests/test-ellama.el
@@ -964,45 +964,110 @@ detailed comparison to help you decide:
           (ellama--session-auto-compact-needed-p
            session provider '(:input-tokens 95) "answer"))))))
 
+(ert-deftest test-ellama-session-store-response-token-count ()
+  (let* ((provider (make-llm-fake))
+         (session (ellama-test--compact-session provider)))
+    (should
+     (= 110
+        (ellama--session-store-response-token-count
+         session provider '(:input-tokens 90 :output-tokens 20) "answer")))
+    (should (= 110 (ellama--session-extra-get session :token-count)))))
+
 (ert-deftest test-ellama-session-compact-rewrites-prompt-and-shows-message ()
   (let* ((provider (make-llm-fake))
-         (summary-provider
-          (make-llm-fake :chat-action-func
-                         (lambda () "Summary of earlier durable facts.")))
          (session (ellama-test--compact-session provider))
          (prompt (ellama-session-prompt session))
-         (ellama-session-auto-compact-provider summary-provider)
+         (ellama-session-auto-compact-provider (make-llm-fake))
          (ellama-session-auto-compact-keep-last-turns 2)
          (ellama-session-auto-compact-show-message t))
-    (with-temp-buffer
-      (insert "assistant output")
+    (cl-letf (((symbol-function 'llm-chat-async)
+               (lambda (_provider _summary-prompt response-callback
+                                 _error-callback &optional _multi-output)
+                 (funcall response-callback
+                          '(:text "Summary of earlier durable facts."))
+                 'request)))
+      (with-temp-buffer
+        (insert "assistant output")
+        (should
+         (ellama--session-compact
+          session
+          :provider provider
+          :buffer (current-buffer)
+          :token-count 150))
+        (should
+         (string-match-p
+          "System context"
+          (llm-chat-prompt-context prompt)))
+        (should
+         (string-match-p
+          "Previous conversation summary:"
+          (llm-chat-prompt-context prompt)))
+        (should
+         (string-match-p
+          "Summary of earlier durable facts."
+          (llm-chat-prompt-context prompt)))
+        (should
+         (equal
+          (mapcar #'llm-chat-prompt-interaction-content
+                  (llm-chat-prompt-interactions prompt))
+          '("user 3" "assistant 3" "user 4" "assistant 4")))
+        (should
+         (string-match-p
+          "Ellama compacted conversation context"
+          (buffer-string)))))))
+
+(ert-deftest test-ellama-session-compact-keeps-interactions-added-in-flight ()
+  (let* ((provider (make-llm-fake))
+         (session (ellama-test--compact-session provider))
+         (prompt (ellama-session-prompt session))
+         (ellama-session-auto-compact-provider (make-llm-fake))
+         (ellama-session-auto-compact-keep-last-turns 2)
+         (ellama-session-auto-compact-show-message nil))
+    (cl-letf (((symbol-function 'llm-chat-async)
+               (lambda (_provider _summary-prompt response-callback
+                                 _error-callback &optional _multi-output)
+                 (llm-chat-prompt-append-response prompt "user 5")
+                 (llm-chat-prompt-append-response
+                  prompt "assistant 5" 'assistant)
+                 (funcall response-callback '(:text "Summary"))
+                 'request)))
       (should
        (ellama--session-compact
         session
-        :provider provider
-        :buffer (current-buffer)
-        :token-count 150))
-      (should
-       (string-match-p
-        "System context"
-        (llm-chat-prompt-context prompt)))
-      (should
-       (string-match-p
-        "Previous conversation summary:"
-        (llm-chat-prompt-context prompt)))
-      (should
-       (string-match-p
-        "Summary of earlier durable facts."
-        (llm-chat-prompt-context prompt)))
+        :provider provider))
       (should
        (equal
         (mapcar #'llm-chat-prompt-interaction-content
                 (llm-chat-prompt-interactions prompt))
-        '("user 3" "assistant 3" "user 4" "assistant 4")))
-      (should
-       (string-match-p
-        "Ellama compacted conversation context"
-        (buffer-string))))))
+        '("user 3" "assistant 3"
+          "user 4" "assistant 4"
+          "user 5" "assistant 5"))))))
+
+(ert-deftest test-ellama-session-compact-uses-stored-token-count ()
+  (let* ((provider (make-llm-fake))
+         (session (ellama-test--compact-session provider))
+         (ellama-session-auto-compact-provider (make-llm-fake))
+         (ellama-session-auto-compact-keep-last-turns 2)
+         (ellama-session-auto-compact-show-message t))
+    (ellama--session-extra-put session :token-count 144)
+    (cl-letf (((symbol-function 'llm-chat-async)
+               (lambda (_provider _summary-prompt response-callback
+                                 _error-callback &optional _multi-output)
+                 (funcall response-callback '(:text "Summary"))
+                 'request)))
+      (with-temp-buffer
+        (ellama--session-compact
+         session
+         :provider provider
+         :buffer (current-buffer))
+        (should
+         (string-match-p
+          "estimated context 144 ->"
+          (buffer-string)))
+        (should
+         (= 144
+            (ellama--session-extra-get
+             session :auto-compact-last-token-count)))))))
 
 (ert-deftest test-ellama-chat-writes-to-session-buffer ()
   (let* ((provider (make-llm-fake

--- a/tests/test-ellama.el
+++ b/tests/test-ellama.el
@@ -982,7 +982,7 @@ detailed comparison to help you decide:
          (ellama-session-auto-compact-show-message t))
     (cl-letf (((symbol-function 'llm-chat-async)
                (lambda (_provider _summary-prompt response-callback
-                                 _error-callback &optional _multi-output)
+                                  _error-callback &optional _multi-output)
                  (funcall response-callback
                           '(:text "Summary of earlier durable facts."))
                  'request)))
@@ -1021,7 +1021,7 @@ detailed comparison to help you decide:
          (ellama-session-auto-compact-show-message nil))
     (cl-letf (((symbol-function 'llm-chat-async)
                (lambda (_provider _summary-prompt response-callback
-                                 _error-callback &optional _multi-output)
+                                  _error-callback &optional _multi-output)
                  (llm-chat-prompt-append-response prompt "user 5")
                  (llm-chat-prompt-append-response
                   prompt "assistant 5" 'assistant)
@@ -1049,7 +1049,7 @@ detailed comparison to help you decide:
     (ellama--session-extra-put session :token-count 144)
     (cl-letf (((symbol-function 'llm-chat-async)
                (lambda (_provider _summary-prompt response-callback
-                                 _error-callback &optional _multi-output)
+                                  _error-callback &optional _multi-output)
                  (funcall response-callback '(:text "Summary"))
                  'request)))
       (with-temp-buffer
@@ -1076,7 +1076,7 @@ detailed comparison to help you decide:
          (ellama-session-auto-compact-show-message nil))
     (cl-letf (((symbol-function 'llm-chat-async)
                (lambda (_provider _summary-prompt response-callback
-                                 _error-callback &optional _multi-output)
+                                  _error-callback &optional _multi-output)
                  (funcall response-callback
                           `(:text ,(pop summaries)))
                  'request)))
@@ -1102,7 +1102,7 @@ detailed comparison to help you decide:
          (ellama-session-auto-compact-show-message nil))
     (cl-letf (((symbol-function 'llm-chat-async)
                (lambda (_provider _summary-prompt callback
-                                 _error-callback &optional _multi-output)
+                                  _error-callback &optional _multi-output)
                  (setq response-callback callback)
                  'request)))
       (with-temp-buffer

--- a/tests/test-ellama.el
+++ b/tests/test-ellama.el
@@ -999,18 +999,14 @@ detailed comparison to help you decide:
           "System context"
           (llm-chat-prompt-context prompt)))
         (should
-         (string-match-p
-          "Previous conversation summary:"
-          (llm-chat-prompt-context prompt)))
-        (should
-         (string-match-p
-          "Summary of earlier durable facts."
-          (llm-chat-prompt-context prompt)))
+         (equal "System context"
+                (llm-chat-prompt-context prompt)))
         (should
          (equal
           (mapcar #'llm-chat-prompt-interaction-content
                   (llm-chat-prompt-interactions prompt))
-          '("user 3" "assistant 3" "user 4" "assistant 4")))
+          '("Previous conversation summary:\n\nSummary of earlier durable facts."
+            "user 3" "assistant 3" "user 4" "assistant 4")))
         (should
          (string-match-p
           "Ellama compacted conversation context"
@@ -1039,7 +1035,8 @@ detailed comparison to help you decide:
        (equal
         (mapcar #'llm-chat-prompt-interaction-content
                 (llm-chat-prompt-interactions prompt))
-        '("user 3" "assistant 3"
+        '("Previous conversation summary:\n\nSummary"
+          "user 3" "assistant 3"
           "user 4" "assistant 4"
           "user 5" "assistant 5"))))))
 
@@ -1068,6 +1065,33 @@ detailed comparison to help you decide:
          (= 144
             (ellama--session-extra-get
              session :auto-compact-last-token-count)))))))
+
+(ert-deftest test-ellama-session-compact-replaces-previous-summary-interaction ()
+  (let* ((provider (make-llm-fake))
+         (session (ellama-test--compact-session provider))
+         (prompt (ellama-session-prompt session))
+         (summaries '("Summary one" "Summary two"))
+         (ellama-session-auto-compact-provider (make-llm-fake))
+         (ellama-session-auto-compact-keep-last-turns 1)
+         (ellama-session-auto-compact-show-message nil))
+    (cl-letf (((symbol-function 'llm-chat-async)
+               (lambda (_provider _summary-prompt response-callback
+                                 _error-callback &optional _multi-output)
+                 (funcall response-callback
+                          `(:text ,(pop summaries)))
+                 'request)))
+      (should (ellama--session-compact session :provider provider))
+      (llm-chat-prompt-append-response prompt "user 5")
+      (llm-chat-prompt-append-response prompt "assistant 5" 'assistant)
+      (should (ellama--session-compact session :provider provider))
+      (should
+       (equal
+        (mapcar #'llm-chat-prompt-interaction-content
+                (llm-chat-prompt-interactions prompt))
+        '("Previous conversation summary:\n\nSummary two"
+          "user 5" "assistant 5")))
+      (should (equal "System context"
+                     (llm-chat-prompt-context prompt))))))
 
 (ert-deftest test-ellama-session-compact-shows-compacting-lighter ()
   (let* ((provider (make-llm-fake))

--- a/tests/test-ellama.el
+++ b/tests/test-ellama.el
@@ -911,6 +911,99 @@ detailed comparison to help you decide:
       (when (buffer-live-p session-buffer)
         (kill-buffer session-buffer)))))
 
+(defun ellama-test--compact-session (provider)
+  "Return test session with PROVIDER and compactable history."
+  (let ((prompt (llm-make-chat-prompt "user 1" :context "System context")))
+    (llm-chat-prompt-append-response prompt "assistant 1" 'assistant)
+    (llm-chat-prompt-append-response prompt "user 2")
+    (llm-chat-prompt-append-response prompt "assistant 2" 'assistant)
+    (llm-chat-prompt-append-response prompt "user 3")
+    (llm-chat-prompt-append-response prompt "assistant 3" 'assistant)
+    (llm-chat-prompt-append-response prompt "user 4")
+    (llm-chat-prompt-append-response prompt "assistant 4" 'assistant)
+    (make-ellama-session
+     :id "compact-test"
+     :provider provider
+     :prompt prompt
+     :extra '(:uid "compact-test"))))
+
+(ert-deftest test-ellama-session-auto-compact-enabled-by-default ()
+  (should ellama-session-auto-compact-enabled))
+
+(ert-deftest test-ellama-session-auto-compact-needed-above-threshold ()
+  (let* ((provider (make-llm-fake))
+         (session (ellama-test--compact-session provider))
+         (ellama-session-auto-compact-enabled t)
+         (ellama-session-auto-compact-token-threshold 100))
+    (should
+     (= 110
+        (ellama--session-auto-compact-needed-p
+         session provider '(:input-tokens 90 :output-tokens 20) "answer")))
+    (should-not
+     (ellama--session-auto-compact-needed-p
+      session provider '(:input-tokens 60 :output-tokens 20) "answer"))))
+
+(ert-deftest test-ellama-session-auto-compact-ignores-missing-token-use ()
+  (let* ((provider (make-llm-fake))
+         (session (ellama-test--compact-session provider))
+         (ellama-session-auto-compact-enabled t)
+         (ellama-session-auto-compact-token-threshold 1))
+    (should-not
+     (ellama--session-auto-compact-needed-p
+      session provider '(:text "answer") "answer"))))
+
+(ert-deftest test-ellama-session-auto-compact-estimates-output-tokens ()
+  (let* ((provider (make-llm-fake))
+         (session (ellama-test--compact-session provider))
+         (ellama-session-auto-compact-enabled t)
+         (ellama-session-auto-compact-token-threshold 100))
+    (cl-letf (((symbol-function 'llm-count-tokens)
+               (lambda (_provider _text) 12)))
+      (should
+       (= 107
+          (ellama--session-auto-compact-needed-p
+           session provider '(:input-tokens 95) "answer"))))))
+
+(ert-deftest test-ellama-session-compact-rewrites-prompt-and-shows-message ()
+  (let* ((provider (make-llm-fake))
+         (summary-provider
+          (make-llm-fake :chat-action-func
+                         (lambda () "Summary of earlier durable facts.")))
+         (session (ellama-test--compact-session provider))
+         (prompt (ellama-session-prompt session))
+         (ellama-session-auto-compact-provider summary-provider)
+         (ellama-session-auto-compact-keep-last-turns 2)
+         (ellama-session-auto-compact-show-message t))
+    (with-temp-buffer
+      (insert "assistant output")
+      (should
+       (ellama--session-compact
+        session
+        :provider provider
+        :buffer (current-buffer)
+        :token-count 150))
+      (should
+       (string-match-p
+        "System context"
+        (llm-chat-prompt-context prompt)))
+      (should
+       (string-match-p
+        "Previous conversation summary:"
+        (llm-chat-prompt-context prompt)))
+      (should
+       (string-match-p
+        "Summary of earlier durable facts."
+        (llm-chat-prompt-context prompt)))
+      (should
+       (equal
+        (mapcar #'llm-chat-prompt-interaction-content
+                (llm-chat-prompt-interactions prompt))
+        '("user 3" "assistant 3" "user 4" "assistant 4")))
+      (should
+       (string-match-p
+        "Ellama compacted conversation context"
+        (buffer-string))))))
+
 (ert-deftest test-ellama-chat-writes-to-session-buffer ()
   (let* ((provider (make-llm-fake
                     :chat-action-func (lambda () "Chat answer")))

--- a/tests/test-ellama.el
+++ b/tests/test-ellama.el
@@ -1069,6 +1069,29 @@ detailed comparison to help you decide:
             (ellama--session-extra-get
              session :auto-compact-last-token-count)))))))
 
+(ert-deftest test-ellama-session-compact-shows-compacting-lighter ()
+  (let* ((provider (make-llm-fake))
+         (session (ellama-test--compact-session provider))
+         (response-callback nil)
+         (ellama-session-auto-compact-provider (make-llm-fake))
+         (ellama-session-auto-compact-keep-last-turns 2)
+         (ellama-session-auto-compact-show-message nil))
+    (cl-letf (((symbol-function 'llm-chat-async)
+               (lambda (_provider _summary-prompt callback
+                                 _error-callback &optional _multi-output)
+                 (setq response-callback callback)
+                 'request)))
+      (with-temp-buffer
+        (should-not ellama-compaction-mode)
+        (should
+         (ellama--session-compact
+          session
+          :provider provider
+          :buffer (current-buffer)))
+        (should ellama-compaction-mode)
+        (funcall response-callback '(:text "Summary"))
+        (should-not ellama-compaction-mode)))))
+
 (ert-deftest test-ellama-chat-writes-to-session-buffer ()
   (let* ((provider (make-llm-fake
                     :chat-action-func (lambda () "Chat answer")))

--- a/tests/test-ellama.el
+++ b/tests/test-ellama.el
@@ -1012,6 +1012,42 @@ detailed comparison to help you decide:
           "Ellama compacted conversation context"
           (buffer-string)))))))
 
+(ert-deftest test-ellama-session-compact-restores-mutated-system-context ()
+  (let* ((provider (make-llm-fake))
+         (session (ellama-test--compact-session provider))
+         (prompt (ellama-session-prompt session))
+         (summary-prompt-text nil)
+         (ellama-session-auto-compact-provider (make-llm-fake))
+         (ellama-session-auto-compact-keep-last-turns 2)
+         (ellama-session-auto-compact-show-message nil))
+    (push (make-llm-chat-prompt-interaction
+           :role 'system
+           :content "System context")
+          (llm-chat-prompt-interactions prompt))
+    (setf (llm-chat-prompt-context prompt) nil)
+    (cl-letf (((symbol-function 'llm-chat-async)
+               (lambda (_provider summary-prompt response-callback
+                                  _error-callback &optional _multi-output)
+                 (setq summary-prompt-text
+                       (llm-chat-prompt-to-text summary-prompt))
+                 (funcall response-callback
+                          '(:text "Summary without system message."))
+                 'request)))
+      (should (ellama--session-compact session :provider provider))
+      (should (equal "System context"
+                     (llm-chat-prompt-context prompt)))
+      (should-not (string-match-p "System context" summary-prompt-text))
+      (should-not
+       (cl-some
+        #'ellama--session-system-interaction-p
+        (llm-chat-prompt-interactions prompt)))
+      (should
+       (equal
+        (mapcar #'llm-chat-prompt-interaction-content
+                (llm-chat-prompt-interactions prompt))
+        '("Previous conversation summary:\n\nSummary without system message."
+          "user 3" "assistant 3" "user 4" "assistant 4"))))))
+
 (ert-deftest test-ellama-session-compact-keeps-interactions-added-in-flight ()
   (let* ((provider (make-llm-fake))
          (session (ellama-test--compact-session provider))


### PR DESCRIPTION
Add functionality to automatically summarize chat history when it reaches a certain token threshold. This manages context window limits by condensing older interactions into a summary while preserving recent turns.

- Added customization variables for threshold, target size, provider, and turn retention.
- Implemented logic to split history, calculate token usage, and trigger summarization.
- Added user-facing functions for manual session compaction.
- Integrated automatic compaction into the chat completion process.
- Added unit tests to verify the compaction logic.