### PR TITLE
Add changelog skill pointer

### DIFF
--- a/.codex/skills/changelog
+++ b/.codex/skills/changelog
@@ -1,0 +1,1 @@
+../../skills/changelog

--- a/.codex/skills/commit-message
+++ b/.codex/skills/commit-message
@@ -1,0 +1,1 @@
+../../skills/commit-message

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,23 @@
 6. **Export manual**: `make manual`
 7. **Refill readme**: `make refill-readme`
 
+Before committing changes, run all make targets appropriate for the changed
+files:
+
+- Always run `make build`, `make test`, `make check-compile-warnings`, and
+  `make checkdocs` for Elisp changes.
+- Run `make format-elisp` when formatting changed Elisp files.
+- Run `make refill-readme` after changing `README.org`.
+- Run `make manual` after changing `README.org` or manual generation code.
+- Run `make refill-news` after changing `NEWS.org`.
+- Run specialized integration targets when touching their area, for example
+  `make test-srt-integration` or `make test-srt-integration-linux` for SRT
+  integration changes.
+
+After making changes and before committing, use the project-local
+`commit-message` skill to write the commit message from the final diff:
+`.codex/skills/commit-message/SKILL.md`.
+
 ## Code Style Guidelines
 
 - **Imports**: Keep `require`s grouped at the file top.
@@ -42,7 +59,6 @@
 
 Just one backslash (\) in front of quotes.
 
-3. Do not use git, util requested by user explicitly.
-4. ALWAYS use `oq` skill to see content of `.org` files (for example
+3. ALWAYS use `oq` skill to see content of `.org` files (for example
    ./README.org and ./NEWS.org) isntead of `read_file` tool. README.org and
    NEWS.org are big enough, you NEED to use `oq` skill with it.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,24 @@ After making changes and before committing, use the project-local
 `commit-message` skill to write the commit message from the final diff:
 `.codex/skills/commit-message/SKILL.md`.
 
+## Git Workflow
+
+1. Check the current branch before starting work. If it is `main`, create a
+   new branch before making changes.
+2. Observe the code and plan the change. Ask the user for explanations when the
+   requested behavior, release scope, or expected workflow is unclear.
+3. Make the requested changes.
+4. Run all appropriate checks from the Build / Lint / Test section.
+5. Fix any findings and rerun the relevant checks. Repeat until the checks pass.
+6. Commit the implementation using the project-local `commit-message` skill,
+   then push the branch.
+7. Continue with additional implementation/check/fix/commit/push iterations
+   when the task requires more work.
+8. Update documentation after the implementation is stable.
+9. Generate the changelog using the project-local `changelog` skill, update the
+   version in `ellama.el`, commit those generated release changes with the
+   exact commit message `Bump version`, and push.
+
 ## Code Style Guidelines
 
 - **Imports**: Keep `require`s grouped at the file top.

--- a/NEWS.org
+++ b/NEWS.org
@@ -19,6 +19,14 @@
 - Removed hardcoded default values for temperature and context length, ensuring
   parameters are directly retrieved from the provider.
 - Update documentation.
+* Version 1.14.2
+- Add project-local skill pointers for changelog and commit-message workflows.
+  This makes repository-specific Codex skills discoverable from ~.codex/skills~.
+- Add a ~commit-message~ skill for concise commit message generation from diffs.
+- Update agent instructions to document the project commit workflow.  The
+  workflow now covers pre-commit checks, branch creation from ~main~, iterative
+  check/fix/commit/push cycles, documentation updates, changelog generation,
+  version bumps, and when to ask for clarification.
 * Version 1.14.0
 - Implement automatic session context compaction. This feature automatically
   summarizes chat history when it reaches a certain token threshold to manage

--- a/NEWS.org
+++ b/NEWS.org
@@ -1,3 +1,11 @@
+* Version 1.14.2
+- Add project-local skill pointers for changelog and commit-message workflows.
+  This makes repository-specific Codex skills discoverable from ~.codex/skills~.
+- Add a ~commit-message~ skill for concise commit message generation from diffs.
+- Update agent instructions to document the project commit workflow.  The
+  workflow now covers pre-commit checks, branch creation from ~main~, iterative
+  check/fix/commit/push cycles, documentation updates, changelog generation,
+  version bumps, and when to ask for clarification.
 * Version 1.14.1
 - Refactor transient model handling and provider construction. Generalize
   transient model handling to support multiple provider types beyond Ollama,
@@ -19,14 +27,6 @@
 - Removed hardcoded default values for temperature and context length, ensuring
   parameters are directly retrieved from the provider.
 - Update documentation.
-* Version 1.14.2
-- Add project-local skill pointers for changelog and commit-message workflows.
-  This makes repository-specific Codex skills discoverable from ~.codex/skills~.
-- Add a ~commit-message~ skill for concise commit message generation from diffs.
-- Update agent instructions to document the project commit workflow.  The
-  workflow now covers pre-commit checks, branch creation from ~main~, iterative
-  check/fix/commit/push cycles, documentation updates, changelog generation,
-  version bumps, and when to ask for clarification.
 * Version 1.14.0
 - Implement automatic session context compaction. This feature automatically
   summarizes chat history when it reaches a certain token threshold to manage

--- a/ellama.el
+++ b/ellama.el
@@ -6,7 +6,7 @@
 ;; URL: http://github.com/s-kostyaev/ellama
 ;; Keywords: help local tools
 ;; Package-Requires: ((emacs "28.1") (llm "0.24.0") (plz "0.8") (transient "0.7") (compat "29.1") (yaml "1.2.3"))
-;; Version: 1.14.1
+;; Version: 1.14.2
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;; Created: 8th Oct 2023
 

--- a/skills/commit-message/SKILL.md
+++ b/skills/commit-message/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: commit-message
+description: Use this skill when writing a concise commit message from a diff.
+---
+
+# Commit Message
+
+Write a concise commit message based on the provided diff.
+
+Use this exact format:
+
+```text
+Short title describing major changes in functionality
+
+Detailed description of all changes.
+```
+
+Rules:
+
+- Reply with the commit message only.
+- Do not wrap the commit message in quotes.
+- Keep the first line concise.
+- Add one blank line after the first line.
+- Use the body to summarize the meaningful changes shown in the diff.
+
+Example:
+
+```text
+Improve abc
+
+Improved the feature abd by adding a new module xyz.
+```


### PR DESCRIPTION
Added a new skill entry in `.codex/skills/changelog` that points to the central changelog skill.