### PR TITLE
Add agent tool evaluation harness

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,7 @@ build:
 	emacs -batch \
 		--eval "(package-initialize)" \
 		--eval "(require 'cl-lib)" \
+		--eval "(setq load-prefer-newer t)" \
 		--eval "(setq load-path (cl-remove-if (lambda (dir) (string-match-p \"/elpa/org-[^/]+/?$$\" dir)) (cons (expand-file-name \".\") load-path)))" \
 		-f batch-byte-compile ellama*.el
 
@@ -30,6 +31,7 @@ test:
 	emacs -Q -batch \
 		--eval "(package-initialize)" \
 		--eval "(require 'cl-lib)" \
+		--eval "(setq load-prefer-newer t)" \
 		--eval "(setq load-path (cl-remove-if (lambda (dir) (string-match-p \"/elpa/org-[^/]+/?$$\" dir)) load-path))" \
 		-l ellama.el \
 		-l tests/test-ellama.el \
@@ -48,6 +50,7 @@ test-detailed:
 	emacs -Q -batch \
 		--eval "(package-initialize)" \
 		--eval "(require 'cl-lib)" \
+		--eval "(setq load-prefer-newer t)" \
 		--eval "(setq load-path (cl-remove-if (lambda (dir) (string-match-p \"/elpa/org-[^/]+/?$$\" dir)) load-path))" \
 		-l ellama.el \
 		-l tests/test-ellama.el \
@@ -67,6 +70,7 @@ test-integration:
 	emacs -Q -batch \
 		--eval "(package-initialize)" \
 		--eval "(require 'cl-lib)" \
+		--eval "(setq load-prefer-newer t)" \
 		--eval "(setq load-path (cl-remove-if (lambda (dir) (string-match-p \"/elpa/org-[^/]+/?$$\" dir)) load-path))" \
 		-l ellama.el \
 		-l tests/integration-test-ellama.el \
@@ -74,6 +78,7 @@ test-integration:
 
 test-srt-integration:
 	ELLAMA_SRT_INTEGRATION=1 emacs -batch --eval "(package-initialize)" \
+		--eval "(setq load-prefer-newer t)" \
 		-l tests/test-ellama-tools-srt-integration.el \
 		--eval "(ert-run-tests-batch-and-exit \"test-ellama-tools-srt-integration-\")"
 
@@ -88,10 +93,11 @@ test-srt-integration-linux: docker-build-srt-parity
 		make test-srt-integration
 
 check-compile-warnings:
-	emacs --batch --eval "(package-initialize)" --eval "(setq native-comp-eln-load-path (list default-directory))" -L . -f batch-native-compile $(ELLAMA_COMPILE_ORDER)
+	emacs --batch --eval "(package-initialize)" --eval "(setq load-prefer-newer t)" --eval "(setq native-comp-eln-load-path (list default-directory))" -L . -f batch-native-compile $(ELLAMA_COMPILE_ORDER)
 
 checkdocs:
 	emacs -Q -batch \
+		--eval "(setq load-prefer-newer t)" \
 		--eval "(require 'checkdoc)" \
 		--eval "(let* ((files (append (file-expand-wildcards \"ellama*.el\") (file-expand-wildcards \"tests/*.el\"))) (checkdoc-autofix-flag 'never) (checkdoc-diagnostic-buffer \"*ellama checkdoc errors*\") (issues 0)) (dolist (file files) (with-current-buffer (find-file-noselect file) (checkdoc-current-buffer t))) (when (get-buffer checkdoc-diagnostic-buffer) (with-current-buffer checkdoc-diagnostic-buffer (goto-char (point-min)) (while (re-search-forward \"^\\\\(.*\\\\):\\\\([0-9]+\\\\): \\\\(.*\\\\)$$\" nil t) (setq issues (1+ issues)) (princ (format \"%s:%s: %s\\n\" (match-string 1) (match-string 2) (match-string 3))))) (kill-buffer checkdoc-diagnostic-buffer)) (if (> issues 0) (progn (princ (format \"checkdocs: %d issue(s)\\n\" issues)) (kill-emacs 1)) (princ \"checkdocs: OK\\n\")))"
 
@@ -99,14 +105,15 @@ manual:
 	emacs -batch --eval "(package-initialize)" \
 		--eval "(require 'project)" \
 		--eval "(require 'cl-lib)" \
+		--eval "(setq load-prefer-newer t)" \
 		--eval "(setq load-path (cl-remove-if (lambda (dir) (string-match-p \"/elpa/org-[^/]+/?$$\" dir)) load-path))" \
 		-l ellama-manual.el \
 		--eval "(ellama-manual-export)"
 
 format-elisp:
-	emacs -batch --eval "(let ((files (append (file-expand-wildcards \"ellama*.el\") (file-expand-wildcards \"tests/*.el\")))) (package-initialize) (require 'transient) (dolist (file files) (with-current-buffer (find-file-noselect file) (emacs-lisp-mode) (indent-region (point-min) (point-max)) (untabify (point-min) (point-max)) (delete-trailing-whitespace) (save-buffer))))"
+	emacs -batch --eval "(setq load-prefer-newer t)" --eval "(let ((files (append (file-expand-wildcards \"ellama*.el\") (file-expand-wildcards \"tests/*.el\")))) (package-initialize) (require 'transient) (dolist (file files) (with-current-buffer (find-file-noselect file) (emacs-lisp-mode) (indent-region (point-min) (point-max)) (untabify (point-min) (point-max)) (delete-trailing-whitespace) (save-buffer))))"
 
-refill-org := "(with-current-buffer (find-file-noselect \"FILE\") (package-initialize) (require (quote org)) (require (quote org-element)) (setq fill-column 80) (save-excursion (org-with-wide-buffer (cl-loop for el in (reverse (org-element-map (org-element-parse-buffer) (quote (paragraph quote-block item)) (quote identity))) do (goto-char (org-element-property :contents-begin el)) (org-fill-paragraph)))) (save-buffer))"
+refill-org := "(setq load-prefer-newer t) (with-current-buffer (find-file-noselect \"FILE\") (package-initialize) (require (quote org)) (require (quote org-element)) (setq fill-column 80) (save-excursion (org-with-wide-buffer (cl-loop for el in (reverse (org-element-map (org-element-parse-buffer) (quote (paragraph quote-block item)) (quote identity))) do (goto-char (org-element-property :contents-begin el)) (org-fill-paragraph)))) (save-buffer))"
 
 refill-news:
 	emacs -batch --eval $(subst FILE,./NEWS.org,$(refill-org))

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ ELLAMA_COMPILE_ORDER = \
 	ellama-tools.el \
 	ellama-skills.el \
 	ellama.el \
+	ellama-eval.el \
 	ellama-context.el \
 	ellama-transient.el \
 	ellama-blueprint.el \
@@ -32,6 +33,7 @@ test:
 		--eval "(setq load-path (cl-remove-if (lambda (dir) (string-match-p \"/elpa/org-[^/]+/?$$\" dir)) load-path))" \
 		-l ellama.el \
 		-l tests/test-ellama.el \
+		-l tests/test-ellama-eval.el \
 		-l tests/test-ellama-context.el \
 		-l tests/test-ellama-tools.el \
 		-l tests/test-ellama-tools-dlp.el \
@@ -49,6 +51,7 @@ test-detailed:
 		--eval "(setq load-path (cl-remove-if (lambda (dir) (string-match-p \"/elpa/org-[^/]+/?$$\" dir)) load-path))" \
 		-l ellama.el \
 		-l tests/test-ellama.el \
+		-l tests/test-ellama-eval.el \
 		-l tests/test-ellama-context.el \
 		-l tests/test-ellama-tools.el \
 		-l tests/test-ellama-tools-dlp.el \

--- a/NEWS.org
+++ b/NEWS.org
@@ -1,3 +1,26 @@
+* Version 1.19.0
+- Add an evaluation harness for comparing agent tool designs with local
+  models.  The new suite covers numbered read output, line-range editing, trace
+  collection, JSONL export, profile comparisons, summaries, and interactive
+  nonblocking runs.
+- Improve evaluation reliability by stabilizing JSONL output paths, avoiding
+  active buffer overwrites, serializing nested result data correctly, counting
+  worker steps consistently, and relaxing docstring checks so valid
+  implementation edits are not rejected for harmless wording changes.
+- Improve tool output for local models by rendering single-entry
+  ~directory_tree~ results without misleading branch prefixes and by formatting
+  tool-result alists as readable named blocks instead of raw S-expressions.
+- Fix search and project tools by returning ~default-directory~ from
+  ~project_root~ when no project is detected, explaining empty ~grep~ results,
+  supporting string tool result names, and resolving relative grep directories
+  against the current buffer directory.
+- Fix subagent buffer insertion so continuation turns append to the worker
+  buffer, leave a blank line before each ~Main agent:~ prompt, and render
+  ~<think>~ blocks as Org quote blocks in Org buffers.
+- Prefer newer Elisp source files during batch jobs to prevent stale bytecode
+  from shadowing local edits in build, test, documentation, formatting, and
+  refill targets.
+
 * Version 1.18.0
 - Add optional Pandoc-backed Markdown to Org conversion.  Users can configure
   ~ellama-markdown-to-org-converter~ to use the builtin converter, Pandoc, or

--- a/ellama-eval.el
+++ b/ellama-eval.el
@@ -119,12 +119,12 @@ then return the clamped value multiplied by WEIGHT."
          :suite edit
          :system ,ellama-eval--coder-system
          :prompt
-         "Update `ellama-eval-guarded-join` so it reject both nil ITEMS and empty \
-ITEMS before calling `string-join`."
+         "Update `ellama-eval-guarded-join` so it reject both nil ITEMS and \
+non-list ITEMS before calling `string-join`."
          :files
          (("strings.el" . "(defun ellama-eval-guarded-join (items)\n  (if (null items)\n      \"\"\n    (string-join items \", \")))\n"))
          :expected-files
-         (("strings.el" . "(defun ellama-eval-guarded-join (items)\n  (if (or (null items) (equal items '()))\n      \"\"\n    (string-join items \", \")))\n")))
+         (("strings.el" . "(defun ellama-eval-guarded-join (items)\n  (if (or (null items) (not (listp items)))\n      \"\"\n    (string-join items \", \")))\n")))
     (:id "explore-locate-provider"
          :suite explore
          :system ,ellama-eval--explorer-system

--- a/ellama-eval.el
+++ b/ellama-eval.el
@@ -848,8 +848,8 @@ KEY is the property list key that contains VALUE."
 (defun ellama-eval--provider-candidates ()
   "Return interactive provider candidates for evaluation."
   (append
-   `(("coding provider" . ellama-coding-provider)
-     ("default model" . ellama-provider)
+   `(("default model" . ellama-provider)
+     ("coding provider" . ellama-coding-provider)
      ("ollama model" . (ellama-get-ollama-local-model)))
    ellama-providers))
 

--- a/ellama-eval.el
+++ b/ellama-eval.el
@@ -97,7 +97,9 @@ then return the clamped value multiplied by WEIGHT."
          (("sample.el" . "(defun ellama-eval-score-value (value limit weight)\n  \"Return VALUE scaled by WEIGHT, clamped to LIMIT.\"\n  (* (min value limit) weight))\n"))
          :ignore-docstrings t
          :file-regexps
-         (("sample.el" . ("\"[^\"]*VALUE[^\"]*LIMIT[^\"]*WEIGHT[^\"]*\""))))
+         (("sample.el" . ("\"[^\"]*VALUE[^\"]*\""))
+          ("sample.el" . ("\"[^\"]*LIMIT[^\"]*\""))
+          ("sample.el" . ("\"[^\"]*WEIGHT[^\"]*\""))))
     (:id "edit-update-target-branch"
          :suite edit
          :system ,ellama-eval--coder-system

--- a/ellama-eval.el
+++ b/ellama-eval.el
@@ -778,8 +778,20 @@ completed count, total count and the latest result."
 (defun ellama-eval--read-results-file ()
   "Read optional JSONL results file for the interactive command."
   (when (y-or-n-p "Write evaluation results to JSONL after completion? ")
-    (read-file-name "Evaluation JSONL file: " nil nil nil
-                    "ellama-eval-results.jsonl")))
+    (let* ((directory default-directory)
+           (default-file
+            (expand-file-name "ellama-eval-results.jsonl" directory))
+           (selected
+            (read-file-name "Evaluation JSONL file: "
+                            directory default-file nil
+                            "ellama-eval-results.jsonl"))
+           (expanded (expand-file-name selected directory)))
+      (when (and buffer-file-name
+                 (equal (file-truename expanded)
+                        (file-truename buffer-file-name)))
+        (user-error
+         "Refusing to overwrite the current buffer file with eval JSONL"))
+      expanded)))
 
 (defun ellama-eval--insert-summary-rows (rows)
   "Insert aggregate summary ROWS into the current buffer."

--- a/ellama-eval.el
+++ b/ellama-eval.el
@@ -1,0 +1,642 @@
+;;; ellama-eval.el --- Tool-use evaluation harness -*- lexical-binding: t; package-lint-main-file: "ellama.el"; -*-
+
+;; Copyright (C) 2023-2026  Free Software Foundation, Inc.
+
+;; Author: Sergey Kostyaev <sskostyaev@gmail.com>
+
+;; This file is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation; either version 3, or (at your option)
+;; any later version.
+
+;; This file is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with GNU Emacs.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Commentary:
+;;
+;; Experimental evaluation harness for comparing tool profiles with agents.
+;;
+
+;;; Code:
+
+(require 'cl-lib)
+(require 'json)
+(require 'seq)
+(require 'subr-x)
+(require 'ellama)
+(require 'ellama-tools)
+
+(defgroup ellama-eval nil
+  "Evaluation harness for Ellama agent and tool experiments."
+  :group 'ellama)
+
+(defcustom ellama-eval-timeout-seconds 180
+  "Maximum time to wait for one evaluation case."
+  :type 'integer
+  :group 'ellama-eval)
+
+(defcustom ellama-eval-keep-workspaces nil
+  "Keep temporary evaluation workspaces after each run."
+  :type 'boolean
+  :group 'ellama-eval)
+
+(defcustom ellama-eval-default-max-steps 12
+  "Default sub-agent step limit for evaluation cases."
+  :type 'integer
+  :group 'ellama-eval)
+
+(cl-defstruct ellama-eval--run-state
+  "Mutable state for one active evaluation run."
+  status result trace worker started-at)
+
+(defvar ellama-eval--active-run nil
+  "Current evaluation run state.
+Only one evaluation run is supported at a time.")
+
+(defconst ellama-eval--base-tool-names
+  '("read_file" "lines_range" "grep" "grep_in_file"
+    "directory_tree" "project_root")
+  "Tool names included in every hypothesis profile.")
+
+(defconst ellama-eval-hypothesis-profiles
+  '(baseline numbered-read line-edit numbered-line-edit)
+  "Profiles used by the line-edit and numbered-read hypothesis suite.")
+
+(defconst ellama-eval--coder-system
+  "You are a careful coding agent. Inspect the project, make the requested \
+change, then report the final result."
+  "System prompt for edit-oriented evaluation cases.")
+
+(defconst ellama-eval--explorer-system
+  "You are a careful code explorer. Inspect the project and answer the \
+question precisely without changing files."
+  "System prompt for read-oriented evaluation cases.")
+
+(defconst ellama-eval-hypothesis-cases
+  `((:id "edit-replace-function-body"
+         :suite edit
+         :system ,ellama-eval--coder-system
+         :prompt
+         "Update `ellama-eval-score-value` so it clamp VALUE to LIMIT with `min`, \
+then return the clamped value multiplied by WEIGHT."
+         :files
+         (("sample.el" . "(defun ellama-eval-score-value (value limit weight)\n  \"Return VALUE scaled by WEIGHT.\"\n  (* value weight))\n"))
+         :expected-files
+         (("sample.el" . "(defun ellama-eval-score-value (value limit weight)\n  \"Return VALUE scaled by WEIGHT.\"\n  (* (min value limit) weight))\n")))
+    (:id "edit-update-target-branch"
+         :suite edit
+         :system ,ellama-eval--coder-system
+         :prompt
+         "In `ellama-eval-route-status`, only the `stale` branch should return \
+`retry`. Leave the `failed` branch unchanged."
+         :files
+         (("router.el" . "(defun ellama-eval-route-status (status)\n  (cond\n   ((eq status 'ready) 'run)\n   ((eq status 'stale) 'skip)\n   ((eq status 'failed) 'skip)\n   (t 'ignore)))\n"))
+         :expected-files
+         (("router.el" . "(defun ellama-eval-route-status (status)\n  (cond\n   ((eq status 'ready) 'run)\n   ((eq status 'stale) 'retry)\n   ((eq status 'failed) 'skip)\n   (t 'ignore)))\n")))
+    (:id "edit-remove-obsolete-binding"
+         :suite edit
+         :system ,ellama-eval--coder-system
+         :prompt
+         "Remove the obsolete local variable `legacy-mode` from \
+`ellama-eval-build-request` and keep the returned plist behavior the same."
+         :files
+         (("request.el" . "(defun ellama-eval-build-request (payload kind)\n  (let ((legacy-mode nil)\n        (request-id (format \"%s-%s\" kind payload)))\n    (list :id request-id :payload payload)))\n"))
+         :expected-files
+         (("request.el" . "(defun ellama-eval-build-request (payload kind)\n  (let ((request-id (format \"%s-%s\" kind payload)))\n    (list :id request-id :payload payload)))\n")))
+    (:id "edit-expand-guard-clause"
+         :suite edit
+         :system ,ellama-eval--coder-system
+         :prompt
+         "Update `ellama-eval-guarded-join` so it reject both nil ITEMS and empty \
+ITEMS before calling `string-join`."
+         :files
+         (("strings.el" . "(defun ellama-eval-guarded-join (items)\n  (if (null items)\n      \"\"\n    (string-join items \", \")))\n"))
+         :expected-files
+         (("strings.el" . "(defun ellama-eval-guarded-join (items)\n  (if (or (null items) (equal items '()))\n      \"\"\n    (string-join items \", \")))\n")))
+    (:id "explore-locate-provider"
+         :suite explore
+         :system ,ellama-eval--explorer-system
+         :prompt
+         "Which function chooses the provider for a named role? Answer with the \
+function name only."
+         :files
+         (("tools.el" . "(defun ellama-eval-provider-for-role (role)\n  (alist-get role ellama-eval-role-providers nil nil #'string=))\n\n(defun ellama-eval-tools-for-role (role)\n  (alist-get role ellama-eval-role-tools nil nil #'string=))\n"))
+         :answer-regexps ("\\`ellama-eval-provider-for-role\\'"))
+    (:id "explore-identify-read-helper"
+         :suite explore
+         :system ,ellama-eval--explorer-system
+         :prompt
+         "What helper reads the file contents before the result is sanitized? \
+Answer with the helper name only."
+         :files
+         (("reader.el" . "(defun ellama-eval-read-file-tool (file)\n  (ellama-eval-sanitize\n   (ellama-eval-read-file-as-text file)))\n\n(defun ellama-eval-read-file-as-text (file)\n  (with-temp-buffer\n    (insert-file-contents file)\n    (buffer-string)))\n"))
+         :answer-regexps ("\\`ellama-eval-read-file-as-text\\'"))
+    (:id "explore-summarize-policy"
+         :suite explore
+         :system ,ellama-eval--explorer-system
+         :prompt
+         "State whether denied writes return nil or an explanatory string. Answer \
+in one short sentence."
+         :files
+         (("policy.el" . "(defun ellama-eval-check-write (path)\n  (if (ellama-eval-path-allowed-p path)\n      nil\n    (format \"Write denied for %s\" path)))\n"))
+         :answer-regexps ("string" "Write denied")))
+  "Built-in cases for the numbered-read and line-edit hypothesis.")
+
+(defun ellama-eval--tool-spec (name function args description)
+  "Return a tool plist for NAME, FUNCTION, ARGS and DESCRIPTION."
+  `(:function ,function
+              :name ,name
+              :args ,args
+              :description ,description))
+
+(defun ellama-eval--tool-spec-by-name (name)
+  "Return the baseline tool spec identified by NAME."
+  (pcase name
+    ("read_file"
+     (ellama-eval--tool-spec
+      "read_file"
+      #'ellama-tools-read-file-tool
+      '((:name "file_name" :type string :description "File name.")
+        (:name "mode" :type string :optional t
+               :enum ["auto" "text" "image"]
+               :description "Read mode: auto, text, or image."))
+      "Read the file FILE_NAME."))
+    ("lines_range"
+     (ellama-eval--tool-spec
+      "lines_range"
+      #'ellama-tools-lines-range-tool
+      '((:name "file_name" :type string
+               :description "Name of the file to get lines from.")
+        (:name "from" :type number :description "Starting line number.")
+        (:name "to" :type number :description "Ending line number."))
+      "Return content of file FILE_NAME lines in range FROM TO."))
+    ("grep"
+     (ellama-eval--tool-spec
+      "grep"
+      #'ellama-tools-grep-tool
+      '((:name "dir" :type string :description "Directory to search in.")
+        (:name "search_string" :type string
+               :description "String to search for."))
+      "Grep SEARCH-STRING in directory files."))
+    ("grep_in_file"
+     (ellama-eval--tool-spec
+      "grep_in_file"
+      #'ellama-tools-grep-in-file-tool
+      '((:name "search_string" :type string
+               :description "String to search for.")
+        (:name "file" :type string :description "File to search in."))
+      "Grep SEARCH-STRING in FILE."))
+    ("directory_tree"
+     (ellama-eval--tool-spec
+      "directory_tree"
+      #'ellama-tools-directory-tree-tool
+      '((:name "dir" :type string
+               :description "Directory path to generate tree for."))
+      "Return a string representing the directory tree under DIR."))
+    ("project_root"
+     (ellama-eval--tool-spec
+      "project_root"
+      #'ellama-tools-project-root-tool
+      nil
+      "Return current project root directory."))
+    ("edit_file"
+     (ellama-eval--tool-spec
+      "edit_file"
+      #'ellama-tools-edit-file-tool
+      '((:name "file_name" :type string :description "Name of the file.")
+        (:name "oldcontent" :type string
+               :description "Old content to be replaced.")
+        (:name "newcontent" :type string
+               :description "New content to replace with."))
+      "Edit file FILE_NAME. Replace OLDCONTENT with NEWCONTENT."))
+    ("edit_lines"
+     (ellama-eval--tool-spec
+      "edit_lines"
+      #'ellama-eval-edit-lines-tool
+      '((:name "file_name" :type string :description "Name of the file.")
+        (:name "from" :type number :description "Starting line number.")
+        (:name "to" :type number :description "Ending line number.")
+        (:name "replacement" :type string
+               :description "Replacement block for the line range."))
+      "Replace file FILE_NAME lines FROM through TO with REPLACEMENT."))
+    (_
+     (error "Unknown evaluation tool %s" name))))
+
+(defun ellama-eval--profile-numbered-read-p (profile)
+  "Return non-nil when PROFILE use numbered read output."
+  (memq profile '(numbered-read numbered-line-edit)))
+
+(defun ellama-eval--profile-line-edit-p (profile)
+  "Return non-nil when PROFILE use line-based editing."
+  (memq profile '(line-edit numbered-line-edit)))
+
+(defun ellama-eval--profile-tool-names (profile)
+  "Return tool names for PROFILE."
+  (unless (memq profile ellama-eval-hypothesis-profiles)
+    (error "Unknown evaluation profile %S" profile))
+  (append ellama-eval--base-tool-names
+          (list (if (ellama-eval--profile-line-edit-p profile)
+                    "edit_lines"
+                  "edit_file"))))
+
+(defun ellama-eval--replace-profile-read-specs (spec profile)
+  "Return SPEC adjusted for numbered read PROFILE."
+  (if (not (ellama-eval--profile-numbered-read-p profile))
+      spec
+    (pcase (plist-get spec :name)
+      ("read_file"
+       (plist-put (copy-sequence spec)
+                  :function #'ellama-eval-numbered-read-file-tool))
+      ("lines_range"
+       (plist-put (copy-sequence spec)
+                  :function #'ellama-eval-numbered-lines-range-tool))
+      (_
+       spec))))
+
+(defun ellama-eval--trace-tool-call (name args status result)
+  "Record a tool call with NAME, ARGS, STATUS and RESULT."
+  (when-let* ((state ellama-eval--active-run))
+    (push (list :name name
+                :args args
+                :status status
+                :result result
+                :finished-at (float-time))
+          (ellama-eval--run-state-trace state))))
+
+(defun ellama-eval--instrument-tool-spec (spec)
+  "Return SPEC with tool function wrapped for eval tracing."
+  (let ((name (plist-get spec :name))
+        (function (plist-get spec :function)))
+    (plist-put
+     (copy-sequence spec)
+     :function
+     (lambda (&rest args)
+       (condition-case err
+           (let ((result (apply function args)))
+             (ellama-eval--trace-tool-call name args 'ok result)
+             result)
+         (error
+          (ellama-eval--trace-tool-call
+           name args 'error (error-message-string err))
+          (signal (car err) (cdr err))))))))
+
+(defun ellama-eval--make-profile-tools (profile)
+  "Return instrumented `llm' tools for PROFILE."
+  (mapcar
+   (lambda (name)
+     (let* ((spec (ellama-eval--tool-spec-by-name name))
+            (read-spec
+             (ellama-eval--replace-profile-read-specs spec profile))
+            (instrumented
+             (ellama-eval--instrument-tool-spec read-spec)))
+       (apply #'llm-make-tool
+              (ellama-tools-wrap-with-confirm instrumented))))
+   (ellama-eval--profile-tool-names profile)))
+
+(defun ellama-eval--number-text-lines (text &optional first-line)
+  "Return TEXT with line numbers starting at FIRST-LINE."
+  (let ((line-number (or first-line 1))
+        lines)
+    (with-temp-buffer
+      (insert text)
+      (goto-char (point-min))
+      (while (not (eobp))
+        (push (format "%d | %s"
+                      line-number
+                      (buffer-substring-no-properties
+                       (line-beginning-position)
+                       (line-end-position)))
+              lines)
+        (setq line-number (1+ line-number))
+        (forward-line 1)))
+    (string-join (nreverse lines) "\n")))
+
+(defun ellama-eval-numbered-read-file-tool (file-name &optional mode)
+  "Read FILE-NAME and number text output lines.
+MODE follows the same contract as `ellama-tools-read-file-tool'."
+  (or (ellama-tools--tool-check-file-access file-name 'read)
+      (json-encode
+       (if (not (file-exists-p file-name))
+           (format "File %s doesn't exists." file-name)
+         (pcase (ellama-tools--read-file-mode mode)
+           ('auto
+            (if (ellama-image-file-p file-name)
+                (ellama-tools--read-image-file-tool file-name)
+              (ellama-eval--number-text-lines
+               (ellama-tools--read-file-as-text file-name))))
+           ('text
+            (ellama-eval--number-text-lines
+             (ellama-tools--read-file-as-text file-name)))
+           ('image
+            (ellama-tools--read-image-file-tool file-name))
+           (_
+            (format "Unsupported read_file mode %S. Use auto, text or image."
+                    mode)))))))
+
+(defun ellama-eval-numbered-lines-range-tool (file-name from to)
+  "Return numbered FILE-NAME content from line FROM through TO."
+  (or (ellama-tools--tool-check-file-access file-name 'read)
+      (json-encode
+       (with-current-buffer (find-file-noselect file-name)
+         (save-excursion
+           (let ((start (progn
+                          (goto-char (point-min))
+                          (forward-line (1- from))
+                          (beginning-of-line)
+                          (point)))
+                 (end (progn
+                        (goto-char (point-min))
+                        (forward-line (1- to))
+                        (end-of-line)
+                        (point))))
+             (ellama-eval--number-text-lines
+              (ellama-tools--sanitize-tool-text-output
+               (buffer-substring-no-properties start end)
+               (format "File %s" file-name))
+              from)))))))
+
+(defun ellama-eval--line-count ()
+  "Return line count for the current buffer."
+  (save-excursion
+    (goto-char (point-max))
+    (line-number-at-pos)))
+
+(defun ellama-eval-edit-lines-tool (file-name from to replacement)
+  "Replace FILE-NAME lines FROM through TO with REPLACEMENT."
+  (or (ellama-tools--tool-check-file-access file-name 'read)
+      (ellama-tools--tool-check-file-access file-name 'write)
+      (progn
+        (unless (and (integerp from)
+                     (integerp to)
+                     (<= 1 from)
+                     (<= from to))
+          (error "Line range must use positive integers with FROM <= TO"))
+        (with-temp-buffer
+          (insert-file-contents-literally file-name)
+          (let ((line-count (ellama-eval--line-count)))
+            (when (> to line-count)
+              (error "Line range %d-%d exceeds file line count %d"
+                     from to line-count)))
+          (goto-char (point-min))
+          (forward-line (1- from))
+          (let ((start (line-beginning-position))
+                end
+                suffix-p)
+            (goto-char (point-min))
+            (forward-line to)
+            (setq end (point))
+            (setq suffix-p (< end (point-max)))
+            (delete-region start end)
+            (goto-char start)
+            (insert replacement)
+            (when (and suffix-p
+                       (not (string-empty-p replacement))
+                       (not (string-suffix-p "\n" replacement)))
+              (insert "\n")))
+          (let ((coding-system-for-write 'raw-text))
+            (write-region (point-min) (point-max) file-name nil 'silent))))
+      (format "Replaced lines %d-%d in %s." from to file-name)))
+
+(defun ellama-eval--write-case-files (workspace files)
+  "Write FILES into WORKSPACE."
+  (dolist (entry files)
+    (let ((path (expand-file-name (car entry) workspace)))
+      (make-directory (file-name-directory path) t)
+      (with-temp-file path
+        (insert (cdr entry))))))
+
+(defun ellama-eval--read-file-string (file-name)
+  "Return FILE-NAME content, or nil when it does not exist."
+  (when (file-exists-p file-name)
+    (with-temp-buffer
+      (insert-file-contents-literally file-name)
+      (buffer-string))))
+
+(defun ellama-eval--file-checks (workspace expected-files)
+  "Return file check entries for WORKSPACE and EXPECTED-FILES."
+  (mapcar
+   (lambda (entry)
+     (let* ((relative (car entry))
+            (expected (cdr entry))
+            (actual
+             (ellama-eval--read-file-string
+              (expand-file-name relative workspace))))
+       (list :path relative
+             :expected expected
+             :actual actual
+             :matched (equal expected actual))))
+   expected-files))
+
+(defun ellama-eval--answer-checks (answer regexps)
+  "Return regexp check entries for ANSWER and REGEXPS."
+  (mapcar
+   (lambda (regexp)
+     (list :regexp regexp
+           :matched (and answer (string-match-p regexp answer))))
+   regexps))
+
+(defun ellama-eval--checks-pass-p (entries)
+  "Return non-nil when validation ENTRIES match."
+  (cl-every (lambda (entry) (plist-get entry :matched)) entries))
+
+(defun ellama-eval--tool-count (trace names)
+  "Count TRACE entries whose names appear in NAMES."
+  (cl-count-if
+   (lambda (entry)
+     (member (plist-get entry :name) names))
+   trace))
+
+(defun ellama-eval--run-status (state deadline)
+  "Return run status from STATE and DEADLINE."
+  (cond
+   ((not (eq (ellama-eval--run-state-status state) 'pending))
+    (ellama-eval--run-state-status state))
+   ((>= (float-time) deadline)
+    'timeout)
+   (t
+    'pending)))
+
+(defun ellama-eval--provider-role-plist (provider system tool-names)
+  "Return eval role plist for PROVIDER, SYSTEM and TOOL-NAMES."
+  (append (list :system system :tools tool-names)
+          (when provider (list :provider provider))))
+
+(defun ellama-eval--result-status
+    (run-status file-checks answer-checks)
+  "Return final evaluation status.
+RUN-STATUS is the execution status.  FILE-CHECKS and ANSWER-CHECKS contain
+oracle results."
+  (cond
+   ((eq run-status 'timeout) 'timeout)
+   ((and (ellama-eval--checks-pass-p file-checks)
+         (ellama-eval--checks-pass-p answer-checks))
+    'passed)
+   (t
+    'failed)))
+
+(defun ellama-eval-run-case (case profile &optional provider)
+  "Run CASE under PROFILE with optional PROVIDER."
+  (let* ((workspace (make-temp-file "ellama-eval-" t))
+         (files (plist-get case :files))
+         (expected-files (plist-get case :expected-files))
+         (answer-regexps (plist-get case :answer-regexps))
+         (system (or (plist-get case :system)
+                     ellama-eval--coder-system))
+         (tool-names (ellama-eval--profile-tool-names profile))
+         (tools (ellama-eval--make-profile-tools profile))
+         (state
+          (make-ellama-eval--run-state
+           :status 'pending
+           :trace nil
+           :started-at (float-time)))
+         (deadline (+ (float-time) ellama-eval-timeout-seconds))
+         (result nil)
+         (original-new-session (symbol-function 'ellama-new-session)))
+    (unwind-protect
+        (let ((default-directory workspace)
+              (ellama-eval--active-run state)
+              (ellama-tools-allow-all t)
+              (ellama-tools-allowed nil)
+              (ellama-tools-confirm-allowed (make-hash-table))
+              (ellama-tools-available tools)
+              (ellama-tools-enabled tools)
+              (ellama-tools-subagent-default-max-steps
+               (or (plist-get case :max-steps)
+                   ellama-eval-default-max-steps))
+              (ellama-tools-subagent-roles
+               `(("eval" . ,(ellama-eval--provider-role-plist
+                             provider system tool-names)))))
+          (ellama-eval--write-case-files workspace files)
+          (cl-letf (((symbol-function 'ellama-new-session)
+                     (lambda (role-provider prompt &optional ephemeral)
+                       (let ((session
+                              (funcall original-new-session
+                                       role-provider prompt ephemeral)))
+                         (setf (ellama-eval--run-state-worker state) session)
+                         session))))
+            (ellama-tools-task-tool
+             (lambda (task-result)
+               (setf (ellama-eval--run-state-result state) task-result)
+               (setf (ellama-eval--run-state-status state) 'completed))
+             (plist-get case :prompt)
+             "eval"))
+          (while (eq (ellama-eval--run-status state deadline) 'pending)
+            (accept-process-output nil 0.05))
+          (when (eq (ellama-eval--run-status state deadline) 'timeout)
+            (setf (ellama-eval--run-state-status state) 'timeout))
+          (let* ((trace (nreverse (ellama-eval--run-state-trace state)))
+                 (run-status (ellama-eval--run-state-status state))
+                 (file-checks
+                  (ellama-eval--file-checks workspace expected-files))
+                 (answer-checks
+                  (ellama-eval--answer-checks
+                   (ellama-eval--run-state-result state)
+                   answer-regexps))
+                 (status
+                  (ellama-eval--result-status
+                   run-status file-checks answer-checks))
+                 (worker (ellama-eval--run-state-worker state))
+                 (extra (and worker (ellama-session-extra worker))))
+            (setq result
+                  (list
+                   :case-id (plist-get case :id)
+                   :suite (plist-get case :suite)
+                   :profile profile
+                   :status status
+                   :success (eq status 'passed)
+                   :report-result (ellama-eval--run-state-result state)
+                   :elapsed-ms
+                   (round (* 1000
+                             (- (float-time)
+                                (ellama-eval--run-state-started-at state))))
+                   :steps (or (plist-get extra :step-count) 0)
+                   :tool-call-count (length trace)
+                   :read-call-count
+                   (ellama-eval--tool-count
+                    trace '("read_file" "lines_range"))
+                   :edit-call-count
+                   (ellama-eval--tool-count
+                    trace '("edit_file" "edit_lines"))
+                   :tool-trace trace
+                   :file-checks file-checks
+                   :answer-checks answer-checks
+                   :workspace (when ellama-eval-keep-workspaces workspace)))))
+      (unless (and ellama-eval-keep-workspaces
+                   (file-directory-p workspace))
+        (when (file-directory-p workspace)
+          (delete-directory workspace t))))
+    result))
+
+(defun ellama-eval-run-hypothesis-suite
+    (&optional provider profiles cases)
+  "Run the built-in hypothesis suite.
+PROVIDER overrides the provider used by the eval role.  PROFILES and CASES
+allow partial runs."
+  (let ((profiles (or profiles ellama-eval-hypothesis-profiles))
+        (cases (or cases ellama-eval-hypothesis-cases))
+        results)
+    (dolist (case cases)
+      (dolist (profile profiles)
+        (push (ellama-eval-run-case case profile provider) results)))
+    (nreverse results)))
+
+(defun ellama-eval-summarize-results (results)
+  "Return aggregate summary rows for RESULTS."
+  (let ((table (make-hash-table :test #'equal)))
+    (dolist (result results)
+      (let* ((key (list (plist-get result :suite)
+                        (plist-get result :profile)))
+             (row (or (gethash key table)
+                      (list :suite (car key)
+                            :profile (cadr key)
+                            :runs 0
+                            :passed 0
+                            :steps 0
+                            :tool-calls 0))))
+        (plist-put row :runs (1+ (plist-get row :runs)))
+        (when (plist-get result :success)
+          (plist-put row :passed (1+ (plist-get row :passed))))
+        (plist-put row :steps
+                   (+ (plist-get row :steps)
+                      (plist-get result :steps)))
+        (plist-put row :tool-calls
+                   (+ (plist-get row :tool-calls)
+                      (plist-get result :tool-call-count)))
+        (puthash key row table)))
+    (let (summary)
+      (maphash
+       (lambda (_key row)
+         (let ((runs (plist-get row :runs)))
+           (push (append row
+                         (list :success-rate
+                               (/ (float (plist-get row :passed)) runs)
+                               :mean-steps
+                               (/ (float (plist-get row :steps)) runs)
+                               :mean-tool-calls
+                               (/ (float (plist-get row :tool-calls)) runs)))
+                 summary)))
+       table)
+      (sort summary
+            (lambda (left right)
+              (string<
+               (format "%s/%s"
+                       (plist-get left :suite)
+                       (plist-get left :profile))
+               (format "%s/%s"
+                       (plist-get right :suite)
+                       (plist-get right :profile))))))))
+
+(defun ellama-eval-write-results-jsonl (results file-name)
+  "Write RESULTS as JSON lines to FILE-NAME."
+  (with-temp-file file-name
+    (dolist (result results)
+      (insert (json-encode result) "\n"))))
+
+(provide 'ellama-eval)
+
+;;; ellama-eval.el ends here

--- a/ellama-eval.el
+++ b/ellama-eval.el
@@ -92,9 +92,9 @@ question precisely without changing files."
          "Update `ellama-eval-score-value` so it clamp VALUE to LIMIT with `min`, \
 then return the clamped value multiplied by WEIGHT."
          :files
-         (("sample.el" . "(defun ellama-eval-score-value (value limit weight)\n  \"Return VALUE scaled by WEIGHT.\"\n  (* value weight))\n"))
+         (("sample.el" . "(defun ellama-eval-score-value (value limit weight)\n  \"Return VALUE scaled by WEIGHT, clamped to LIMIT.\"\n  (* value weight))\n"))
          :expected-files
-         (("sample.el" . "(defun ellama-eval-score-value (value limit weight)\n  \"Return VALUE scaled by WEIGHT.\"\n  (* (min value limit) weight))\n")))
+         (("sample.el" . "(defun ellama-eval-score-value (value limit weight)\n  \"Return VALUE scaled by WEIGHT, clamped to LIMIT.\"\n  (* (min value limit) weight))\n")))
     (:id "edit-update-target-branch"
          :suite edit
          :system ,ellama-eval--coder-system

--- a/ellama-eval.el
+++ b/ellama-eval.el
@@ -151,7 +151,7 @@ Answer with the helper name only."
 in one short sentence."
          :files
          (("policy.el" . "(defun ellama-eval-check-write (path)\n  (if (ellama-eval-path-allowed-p path)\n      nil\n    (format \"Write denied for %s\" path)))\n"))
-         :answer-regexps ("string" "Write denied")))
+         :answer-regexps ("string")))
   "Built-in cases for the numbered-read and line-edit hypothesis.")
 
 (defun ellama-eval--tool-spec (name function args description)
@@ -507,7 +507,8 @@ oracle results."
           (ellama-eval--result-status
            run-status file-checks answer-checks))
          (worker (ellama-eval--run-state-worker state))
-         (extra (and worker (ellama-session-extra worker))))
+         (extra (and worker (ellama-session-extra worker)))
+         (continuation-steps (or (plist-get extra :step-count) 0)))
     (list
      :case-id (plist-get case :id)
      :suite (plist-get case :suite)
@@ -519,7 +520,8 @@ oracle results."
      (round (* 1000
                (- (float-time)
                   (ellama-eval--run-state-started-at state))))
-     :steps (or (plist-get extra :step-count) 0)
+     :steps (if worker (1+ continuation-steps) continuation-steps)
+     :continuation-steps continuation-steps
      :tool-call-count (length trace)
      :read-call-count
      (ellama-eval--tool-count trace '("read_file" "lines_range"))
@@ -723,11 +725,55 @@ completed count, total count and the latest result."
                        (plist-get right :suite)
                        (plist-get right :profile))))))))
 
+(defun ellama-eval--plist-p (value)
+  "Return non-nil when VALUE is a property list."
+  (and (proper-list-p value)
+       (zerop (mod (length value) 2))
+       (cl-loop for (key _value) on value by #'cddr
+                always (keywordp key))))
+
+(defun ellama-eval--json-key (key)
+  "Return JSON object key string for plist KEY."
+  (if (keywordp key)
+      (substring (symbol-name key) 1)
+    (format "%s" key)))
+
+(defun ellama-eval--json-value (value &optional key)
+  "Return VALUE converted to a shape suitable for JSON encoding.
+KEY is the property list key that contains VALUE."
+  (cond
+   ((memq key '(:success :matched))
+    (if value t json-false))
+   ((memq key '(:tool-trace :file-checks :answer-checks))
+    (vconcat (mapcar #'ellama-eval--json-value value)))
+   ((ellama-eval--plist-p value)
+    (ellama-eval--json-object value))
+   ((proper-list-p value)
+    (vconcat (mapcar #'ellama-eval--json-value value)))
+   ((and (symbolp value) (not (memq value (list t json-false))))
+    (symbol-name value))
+   (t value)))
+
+(defun ellama-eval--json-object (plist)
+  "Return PLIST as a JSON object hash table."
+  (let ((object (make-hash-table :test #'equal)))
+    (while plist
+      (let ((key (pop plist))
+            (value (pop plist)))
+        (puthash (ellama-eval--json-key key)
+                 (ellama-eval--json-value value key)
+                 object)))
+    object))
+
+(defun ellama-eval--json-encode-result (result)
+  "Return RESULT encoded as JSON for JSONL output."
+  (json-encode (ellama-eval--json-value result)))
+
 (defun ellama-eval-write-results-jsonl (results file-name)
   "Write RESULTS as JSON lines to FILE-NAME."
   (with-temp-file file-name
     (dolist (result results)
-      (insert (json-encode result) "\n"))))
+      (insert (ellama-eval--json-encode-result result) "\n"))))
 
 (defun ellama-eval--provider-candidates ()
   "Return interactive provider candidates for evaluation."

--- a/ellama-eval.el
+++ b/ellama-eval.el
@@ -94,7 +94,10 @@ then return the clamped value multiplied by WEIGHT."
          :files
          (("sample.el" . "(defun ellama-eval-score-value (value limit weight)\n  \"Return VALUE scaled by WEIGHT, clamped to LIMIT.\"\n  (* value weight))\n"))
          :expected-files
-         (("sample.el" . "(defun ellama-eval-score-value (value limit weight)\n  \"Return VALUE scaled by WEIGHT, clamped to LIMIT.\"\n  (* (min value limit) weight))\n")))
+         (("sample.el" . "(defun ellama-eval-score-value (value limit weight)\n  \"Return VALUE scaled by WEIGHT, clamped to LIMIT.\"\n  (* (min value limit) weight))\n"))
+         :ignore-docstrings t
+         :file-regexps
+         (("sample.el" . ("\"[^\"]*VALUE[^\"]*LIMIT[^\"]*WEIGHT[^\"]*\""))))
     (:id "edit-update-target-branch"
          :suite edit
          :system ,ellama-eval--coder-system
@@ -424,20 +427,76 @@ MODE follows the same contract as `ellama-tools-read-file-tool'."
       (insert-file-contents-literally file-name)
       (buffer-string))))
 
-(defun ellama-eval--file-checks (workspace expected-files)
-  "Return file check entries for WORKSPACE and EXPECTED-FILES."
+(defun ellama-eval--strip-defun-docstrings (text)
+  "Return TEXT with top-level defun docstrings replaced."
+  (when text
+    (with-temp-buffer
+      (emacs-lisp-mode)
+      (insert text)
+      (goto-char (point-min))
+      (while (re-search-forward "^(defun\\_>" nil t)
+        (goto-char (match-beginning 0))
+        (condition-case nil
+            (progn
+              (forward-char 1)
+              (forward-sexp 1)
+              (skip-chars-forward " \t\r\n")
+              (forward-sexp 1)
+              (skip-chars-forward " \t\r\n")
+              (forward-sexp 1)
+              (skip-chars-forward " \t\r\n")
+              (when (eq (char-after) ?\")
+                (let ((start (point)))
+                  (forward-sexp 1)
+                  (delete-region start (point))
+                  (insert "\"<docstring>\""))))
+          (scan-error
+           (goto-char (line-end-position)))))
+      (buffer-string))))
+
+(defun ellama-eval--file-checks
+    (workspace expected-files &optional ignore-docstrings)
+  "Return file check entries for WORKSPACE and EXPECTED-FILES.
+When IGNORE-DOCSTRINGS is non-nil, ignore defun docstring wording."
   (mapcar
    (lambda (entry)
      (let* ((relative (car entry))
             (expected (cdr entry))
             (actual
              (ellama-eval--read-file-string
-              (expand-file-name relative workspace))))
+              (expand-file-name relative workspace)))
+            (expected-for-check
+             (if ignore-docstrings
+                 (ellama-eval--strip-defun-docstrings expected)
+               expected))
+            (actual-for-check
+             (if ignore-docstrings
+                 (ellama-eval--strip-defun-docstrings actual)
+               actual)))
        (list :path relative
              :expected expected
              :actual actual
-             :matched (equal expected actual))))
+             :ignore-docstrings (and ignore-docstrings t)
+             :matched (equal expected-for-check actual-for-check))))
    expected-files))
+
+(defun ellama-eval--file-regexp-checks (workspace file-regexps)
+  "Return file regexp check entries for WORKSPACE and FILE-REGEXPS."
+  (apply
+   #'append
+   (mapcar
+    (lambda (entry)
+      (let* ((relative (car entry))
+             (actual
+              (ellama-eval--read-file-string
+               (expand-file-name relative workspace))))
+        (mapcar
+         (lambda (regexp)
+           (list :path relative
+                 :regexp regexp
+                 :matched (and actual (string-match-p regexp actual))))
+         (cdr entry))))
+    file-regexps)))
 
 (defun ellama-eval--answer-checks (answer regexps)
   "Return regexp check entries for ANSWER and REGEXPS."
@@ -464,13 +523,14 @@ MODE follows the same contract as `ellama-tools-read-file-tool'."
           (when provider (list :provider provider))))
 
 (defun ellama-eval--result-status
-    (run-status file-checks answer-checks)
+    (run-status file-checks file-regexp-checks answer-checks)
   "Return final evaluation status.
-RUN-STATUS is the execution status.  FILE-CHECKS and ANSWER-CHECKS contain
-oracle results."
+RUN-STATUS is the execution status.  FILE-CHECKS, FILE-REGEXP-CHECKS
+and ANSWER-CHECKS contain oracle results."
   (cond
    ((eq run-status 'timeout) 'timeout)
    ((and (ellama-eval--checks-pass-p file-checks)
+         (ellama-eval--checks-pass-p file-regexp-checks)
          (ellama-eval--checks-pass-p answer-checks))
     'passed)
    (t
@@ -495,17 +555,22 @@ oracle results."
   (let* ((case (ellama-eval--run-state-case state))
          (workspace (ellama-eval--run-state-workspace state))
          (expected-files (plist-get case :expected-files))
+         (ignore-docstrings (plist-get case :ignore-docstrings))
+         (file-regexps (plist-get case :file-regexps))
          (answer-regexps (plist-get case :answer-regexps))
          (trace (nreverse (ellama-eval--run-state-trace state)))
          (file-checks
-          (ellama-eval--file-checks workspace expected-files))
+          (ellama-eval--file-checks
+           workspace expected-files ignore-docstrings))
+         (file-regexp-checks
+          (ellama-eval--file-regexp-checks workspace file-regexps))
          (answer-checks
           (ellama-eval--answer-checks
            (ellama-eval--run-state-result state)
            answer-regexps))
          (status
           (ellama-eval--result-status
-           run-status file-checks answer-checks))
+           run-status file-checks file-regexp-checks answer-checks))
          (worker (ellama-eval--run-state-worker state))
          (extra (and worker (ellama-session-extra worker)))
          (continuation-steps (or (plist-get extra :step-count) 0)))
@@ -529,6 +594,7 @@ oracle results."
      (ellama-eval--tool-count trace '("edit_file" "edit_lines"))
      :tool-trace trace
      :file-checks file-checks
+     :file-regexp-checks file-regexp-checks
      :answer-checks answer-checks
      :workspace (when ellama-eval-keep-workspaces workspace))))
 
@@ -727,7 +793,8 @@ completed count, total count and the latest result."
 
 (defun ellama-eval--plist-p (value)
   "Return non-nil when VALUE is a property list."
-  (and (proper-list-p value)
+  (and (consp value)
+       (proper-list-p value)
        (zerop (mod (length value) 2))
        (cl-loop for (key _value) on value by #'cddr
                 always (keywordp key))))
@@ -744,7 +811,8 @@ KEY is the property list key that contains VALUE."
   (cond
    ((memq key '(:success :matched))
     (if value t json-false))
-   ((memq key '(:tool-trace :file-checks :answer-checks))
+   ((memq key '(:tool-trace :file-checks
+                            :file-regexp-checks :answer-checks))
     (vconcat (mapcar #'ellama-eval--json-value value)))
    ((ellama-eval--plist-p value)
     (ellama-eval--json-object value))

--- a/ellama-eval.el
+++ b/ellama-eval.el
@@ -52,11 +52,18 @@
 
 (cl-defstruct ellama-eval--run-state
   "Mutable state for one active evaluation run."
-  status result trace worker started-at)
+  status result trace worker started-at workspace case profile callback
+  timeout-timer)
 
 (defvar ellama-eval--active-run nil
   "Current evaluation run state.
 Only one evaluation run is supported at a time.")
+
+(defvar ellama-eval-last-results nil
+  "Results from the most recent interactive evaluation suite.")
+
+(defconst ellama-eval--summary-buffer-name "*Ellama Eval Summary*"
+  "Name of the interactive evaluation summary buffer.")
 
 (defconst ellama-eval--base-tool-names
   '("read_file" "lines_range" "grep" "grep_in_file"
@@ -451,16 +458,6 @@ MODE follows the same contract as `ellama-tools-read-file-tool'."
      (member (plist-get entry :name) names))
    trace))
 
-(defun ellama-eval--run-status (state deadline)
-  "Return run status from STATE and DEADLINE."
-  (cond
-   ((not (eq (ellama-eval--run-state-status state) 'pending))
-    (ellama-eval--run-state-status state))
-   ((>= (float-time) deadline)
-    'timeout)
-   (t
-    'pending)))
-
 (defun ellama-eval--provider-role-plist (provider system tool-names)
   "Return eval role plist for PROVIDER, SYSTEM and TOOL-NAMES."
   (append (list :system system :tools tool-names)
@@ -479,12 +476,88 @@ oracle results."
    (t
     'failed)))
 
-(defun ellama-eval-run-case (case profile &optional provider)
-  "Run CASE under PROFILE with optional PROVIDER."
-  (let* ((workspace (make-temp-file "ellama-eval-" t))
-         (files (plist-get case :files))
+(defun ellama-eval--cancel-timeout-timer (state)
+  "Cancel timeout timer stored in STATE."
+  (when-let* ((timer (ellama-eval--run-state-timeout-timer state)))
+    (cancel-timer timer)
+    (setf (ellama-eval--run-state-timeout-timer state) nil)))
+
+(defun ellama-eval--cleanup-workspace (state)
+  "Delete STATE workspace unless retention is enabled."
+  (let ((workspace (ellama-eval--run-state-workspace state)))
+    (unless (and ellama-eval-keep-workspaces
+                 (file-directory-p workspace))
+      (when (file-directory-p workspace)
+        (delete-directory workspace t)))))
+
+(defun ellama-eval--build-result (state run-status)
+  "Build result plist for STATE and RUN-STATUS."
+  (let* ((case (ellama-eval--run-state-case state))
+         (workspace (ellama-eval--run-state-workspace state))
          (expected-files (plist-get case :expected-files))
          (answer-regexps (plist-get case :answer-regexps))
+         (trace (nreverse (ellama-eval--run-state-trace state)))
+         (file-checks
+          (ellama-eval--file-checks workspace expected-files))
+         (answer-checks
+          (ellama-eval--answer-checks
+           (ellama-eval--run-state-result state)
+           answer-regexps))
+         (status
+          (ellama-eval--result-status
+           run-status file-checks answer-checks))
+         (worker (ellama-eval--run-state-worker state))
+         (extra (and worker (ellama-session-extra worker))))
+    (list
+     :case-id (plist-get case :id)
+     :suite (plist-get case :suite)
+     :profile (ellama-eval--run-state-profile state)
+     :status status
+     :success (eq status 'passed)
+     :report-result (ellama-eval--run-state-result state)
+     :elapsed-ms
+     (round (* 1000
+               (- (float-time)
+                  (ellama-eval--run-state-started-at state))))
+     :steps (or (plist-get extra :step-count) 0)
+     :tool-call-count (length trace)
+     :read-call-count
+     (ellama-eval--tool-count trace '("read_file" "lines_range"))
+     :edit-call-count
+     (ellama-eval--tool-count trace '("edit_file" "edit_lines"))
+     :tool-trace trace
+     :file-checks file-checks
+     :answer-checks answer-checks
+     :workspace (when ellama-eval-keep-workspaces workspace))))
+
+(defun ellama-eval--finish-run (state run-status &optional task-result)
+  "Finalize STATE with RUN-STATUS and optional TASK-RESULT."
+  (when (eq (ellama-eval--run-state-status state) 'pending)
+    (when task-result
+      (setf (ellama-eval--run-state-result state) task-result))
+    (setf (ellama-eval--run-state-status state) run-status)
+    (ellama-eval--cancel-timeout-timer state)
+    (let ((result (ellama-eval--build-result state run-status))
+          (callback (ellama-eval--run-state-callback state)))
+      (when (eq ellama-eval--active-run state)
+        (setq ellama-eval--active-run nil))
+      (ellama-eval--cleanup-workspace state)
+      (when callback
+        (funcall callback result))
+      result)))
+
+(defun ellama-eval--timeout-run (state)
+  "Finalize STATE as timed out."
+  (ellama-eval--finish-run state 'timeout))
+
+(defun ellama-eval-start-case
+    (case profile callback &optional provider)
+  "Start CASE under PROFILE and call CALLBACK with its result.
+PROVIDER overrides the provider used by the eval role."
+  (when ellama-eval--active-run
+    (error "An Ellama evaluation run is already active"))
+  (let* ((workspace (make-temp-file "ellama-eval-" t))
+         (files (plist-get case :files))
          (system (or (plist-get case :system)
                      ellama-eval--coder-system))
          (tool-names (ellama-eval--profile-tool-names profile))
@@ -493,13 +566,18 @@ oracle results."
           (make-ellama-eval--run-state
            :status 'pending
            :trace nil
-           :started-at (float-time)))
-         (deadline (+ (float-time) ellama-eval-timeout-seconds))
-         (result nil)
+           :started-at (float-time)
+           :workspace workspace
+           :case case
+           :profile profile
+           :callback callback))
          (original-new-session (symbol-function 'ellama-new-session)))
-    (unwind-protect
+    (setq ellama-eval--active-run state)
+    (setf (ellama-eval--run-state-timeout-timer state)
+          (run-at-time ellama-eval-timeout-seconds nil
+                       #'ellama-eval--timeout-run state))
+    (condition-case err
         (let ((default-directory workspace)
-              (ellama-eval--active-run state)
               (ellama-tools-allow-all t)
               (ellama-tools-allowed nil)
               (ellama-tools-confirm-allowed (make-hash-table))
@@ -521,55 +599,27 @@ oracle results."
                          session))))
             (ellama-tools-task-tool
              (lambda (task-result)
-               (setf (ellama-eval--run-state-result state) task-result)
-               (setf (ellama-eval--run-state-status state) 'completed))
+               (ellama-eval--finish-run state 'completed task-result))
              (plist-get case :prompt)
              "eval"))
-          (while (eq (ellama-eval--run-status state deadline) 'pending)
-            (accept-process-output nil 0.05))
-          (when (eq (ellama-eval--run-status state deadline) 'timeout)
-            (setf (ellama-eval--run-state-status state) 'timeout))
-          (let* ((trace (nreverse (ellama-eval--run-state-trace state)))
-                 (run-status (ellama-eval--run-state-status state))
-                 (file-checks
-                  (ellama-eval--file-checks workspace expected-files))
-                 (answer-checks
-                  (ellama-eval--answer-checks
-                   (ellama-eval--run-state-result state)
-                   answer-regexps))
-                 (status
-                  (ellama-eval--result-status
-                   run-status file-checks answer-checks))
-                 (worker (ellama-eval--run-state-worker state))
-                 (extra (and worker (ellama-session-extra worker))))
-            (setq result
-                  (list
-                   :case-id (plist-get case :id)
-                   :suite (plist-get case :suite)
-                   :profile profile
-                   :status status
-                   :success (eq status 'passed)
-                   :report-result (ellama-eval--run-state-result state)
-                   :elapsed-ms
-                   (round (* 1000
-                             (- (float-time)
-                                (ellama-eval--run-state-started-at state))))
-                   :steps (or (plist-get extra :step-count) 0)
-                   :tool-call-count (length trace)
-                   :read-call-count
-                   (ellama-eval--tool-count
-                    trace '("read_file" "lines_range"))
-                   :edit-call-count
-                   (ellama-eval--tool-count
-                    trace '("edit_file" "edit_lines"))
-                   :tool-trace trace
-                   :file-checks file-checks
-                   :answer-checks answer-checks
-                   :workspace (when ellama-eval-keep-workspaces workspace)))))
-      (unless (and ellama-eval-keep-workspaces
-                   (file-directory-p workspace))
-        (when (file-directory-p workspace)
-          (delete-directory workspace t))))
+          state)
+      (error
+       (ellama-eval--cancel-timeout-timer state)
+       (when (eq ellama-eval--active-run state)
+         (setq ellama-eval--active-run nil))
+       (ellama-eval--cleanup-workspace state)
+       (signal (car err) (cdr err))))))
+
+(defun ellama-eval-run-case (case profile &optional provider)
+  "Run CASE under PROFILE with optional PROVIDER."
+  (let ((result :pending))
+    (ellama-eval-start-case
+     case profile
+     (lambda (case-result)
+       (setq result case-result))
+     provider)
+    (while (eq result :pending)
+      (accept-process-output nil 0.05))
     result))
 
 (defun ellama-eval-run-hypothesis-suite
@@ -584,6 +634,48 @@ allow partial runs."
       (dolist (profile profiles)
         (push (ellama-eval-run-case case profile provider) results)))
     (nreverse results)))
+
+(defun ellama-eval--hypothesis-jobs (profiles cases)
+  "Return ordered hypothesis jobs for PROFILES and CASES."
+  (let (jobs)
+    (dolist (case cases)
+      (dolist (profile profiles)
+        (push (list :case case :profile profile) jobs)))
+    (nreverse jobs)))
+
+(defun ellama-eval-run-hypothesis-suite-async
+    (provider profiles cases callback &optional progress-callback)
+  "Run the hypothesis suite asynchronously.
+PROVIDER, PROFILES and CASES mirror `ellama-eval-run-hypothesis-suite'.
+Call CALLBACK with all results.  Call PROGRESS-CALLBACK with partial results,
+completed count, total count and the latest result."
+  (let* ((profiles (or profiles ellama-eval-hypothesis-profiles))
+         (cases (or cases ellama-eval-hypothesis-cases))
+         (jobs (ellama-eval--hypothesis-jobs profiles cases))
+         (total (length jobs))
+         (completed 0)
+         results)
+    (cl-labels
+        ((start-next ()
+           (if (null jobs)
+               (funcall callback (nreverse results))
+             (let* ((job (pop jobs))
+                    (case (plist-get job :case))
+                    (profile (plist-get job :profile)))
+               (ellama-eval-start-case
+                case profile
+                (lambda (result)
+                  (push result results)
+                  (setq completed (1+ completed))
+                  (when progress-callback
+                    (funcall progress-callback
+                             (reverse results) completed total result))
+                  (run-at-time 0 nil #'start-next))
+                provider)))))
+      (when progress-callback
+        (funcall progress-callback nil 0 total nil))
+      (run-at-time 0 nil #'start-next)
+      total)))
 
 (defun ellama-eval-summarize-results (results)
   "Return aggregate summary rows for RESULTS."
@@ -636,6 +728,142 @@ allow partial runs."
   (with-temp-file file-name
     (dolist (result results)
       (insert (json-encode result) "\n"))))
+
+(defun ellama-eval--provider-candidates ()
+  "Return interactive provider candidates for evaluation."
+  (append
+   `(("coding provider" . ellama-coding-provider)
+     ("default model" . ellama-provider)
+     ("ollama model" . (ellama-get-ollama-local-model)))
+   ellama-providers))
+
+(defun ellama-eval--read-provider ()
+  "Read evaluation provider from the minibuffer."
+  (let* ((providers (ellama-eval--provider-candidates))
+         (choice
+          (completing-read
+           "Evaluation provider: "
+           (mapcar #'car providers)
+           nil t nil nil "coding provider")))
+    (eval (alist-get choice providers nil nil #'string=))))
+
+(defun ellama-eval--read-suite-selection ()
+  "Read suite selection from the minibuffer."
+  (intern
+   (completing-read
+    "Evaluation suite: "
+    '("all" "edit" "explore")
+    nil t nil nil "all")))
+
+(defun ellama-eval--cases-for-suite-selection (selection)
+  "Return cases selected by SELECTION."
+  (if (eq selection 'all)
+      ellama-eval-hypothesis-cases
+    (seq-filter
+     (lambda (case)
+       (eq (plist-get case :suite) selection))
+     ellama-eval-hypothesis-cases)))
+
+(defun ellama-eval--read-profile-selection ()
+  "Read evaluation profiles from the minibuffer."
+  (let* ((choices (mapcar #'symbol-name ellama-eval-hypothesis-profiles))
+         (selected
+          (completing-read-multiple
+           "Evaluation profiles, comma separated (empty means all): "
+           choices nil t)))
+    (if selected
+        (mapcar #'intern selected)
+      ellama-eval-hypothesis-profiles)))
+
+(defun ellama-eval--read-results-file ()
+  "Read optional JSONL results file for the interactive command."
+  (when (y-or-n-p "Write evaluation results to JSONL after completion? ")
+    (read-file-name "Evaluation JSONL file: " nil nil nil
+                    "ellama-eval-results.jsonl")))
+
+(defun ellama-eval--insert-summary-rows (rows)
+  "Insert aggregate summary ROWS into the current buffer."
+  (insert
+   (format "%-10s %-22s %8s %8s %10s %10s\n"
+           "Suite" "Profile" "Runs" "Passed" "MeanSteps" "MeanCalls"))
+  (insert (make-string 78 ?-) "\n")
+  (dolist (row rows)
+    (insert
+     (format "%-10s %-22s %8d %8d %10.2f %10.2f\n"
+             (plist-get row :suite)
+             (plist-get row :profile)
+             (plist-get row :runs)
+             (plist-get row :passed)
+             (plist-get row :mean-steps)
+             (plist-get row :mean-tool-calls)))))
+
+(defun ellama-eval--insert-result-rows (results)
+  "Insert per-run RESULTS into the current buffer."
+  (insert
+   (format "%-30s %-22s %-10s %7s %7s %9s\n"
+           "Case" "Profile" "Status" "Steps" "Calls" "Elapsed"))
+  (insert (make-string 92 ?-) "\n")
+  (dolist (result results)
+    (insert
+     (format "%-30s %-22s %-10s %7d %7d %8dms\n"
+             (plist-get result :case-id)
+             (plist-get result :profile)
+             (plist-get result :status)
+             (plist-get result :steps)
+             (plist-get result :tool-call-count)
+             (plist-get result :elapsed-ms)))))
+
+(defun ellama-eval--render-summary-buffer
+    (results completed total &optional results-file)
+  "Render RESULTS summary with COMPLETED and TOTAL progress.
+RESULTS-FILE is shown when JSONL export is configured."
+  (let ((buffer (get-buffer-create ellama-eval--summary-buffer-name)))
+    (with-current-buffer buffer
+      (let ((inhibit-read-only t))
+        (erase-buffer)
+        (insert "Ellama evaluation\n\n")
+        (insert (format "Progress: %d/%d completed\n" completed total))
+        (when results-file
+          (insert (format "JSONL target: %s\n" results-file)))
+        (insert "\n")
+        (if results
+            (progn
+              (insert "Aggregate summary\n\n")
+              (ellama-eval--insert-summary-rows
+               (ellama-eval-summarize-results results))
+              (insert "\nLatest results\n\n")
+              (ellama-eval--insert-result-rows results))
+          (insert "No completed cases yet.\n"))
+        (goto-char (point-min))
+        (special-mode)))
+    (display-buffer buffer)
+    buffer))
+
+;;;###autoload
+(defun ellama-eval-run-hypothesis-suite-interactive
+    (provider suite profiles results-file)
+  "Start the built-in hypothesis suite without blocking Emacs.
+PROVIDER is used for eval roles.  SUITE narrows the built-in cases.  PROFILES
+select experiment profiles.  RESULTS-FILE receives JSONL output when non-nil."
+  (interactive
+   (list (ellama-eval--read-provider)
+         (ellama-eval--read-suite-selection)
+         (ellama-eval--read-profile-selection)
+         (ellama-eval--read-results-file)))
+  (let ((cases (ellama-eval--cases-for-suite-selection suite)))
+    (ellama-eval-run-hypothesis-suite-async
+     provider profiles cases
+     (lambda (results)
+       (setq ellama-eval-last-results results)
+       (when results-file
+         (ellama-eval-write-results-jsonl results results-file))
+       (ellama-eval--render-summary-buffer
+        results (length results) (length results) results-file)
+       (message "Ellama evaluation finished: %d runs." (length results)))
+     (lambda (results completed total _latest)
+       (ellama-eval--render-summary-buffer
+        results completed total results-file)))
+    (message "Ellama evaluation started.")))
 
 (provide 'ellama-eval)
 

--- a/ellama-tools.el
+++ b/ellama-tools.el
@@ -2063,8 +2063,9 @@ CALLBACK – function called once with the result string."
 
 (defun ellama-tools-project-root-tool ()
   "Return current project root directory."
-  (when (project-current)
-    (project-root (project-current))))
+  (if-let* ((project (project-current nil)))
+      (project-root project)
+    (expand-file-name default-directory)))
 
 (ellama-tools-define-tool
  '(:function

--- a/ellama-tools.el
+++ b/ellama-tools.el
@@ -2495,15 +2495,22 @@ When the task is COMPLETE you MUST call `report_result` exactly once."
       (ellama-tools--set-session-extra
        session
        (plist-put extra :step-count (1+ steps)))
-      (ellama-stream
-       ellama-tools-subagent-continue-prompt
-       :buffer buffer
-       :session session
-       :tools tools
-       :system system
-       :on-done
-       (ellama-tools--make-subagent-loop-handler
-        session buffer system))))))
+      (let ((point (when (buffer-live-p buffer)
+                     (ellama-tools--insert-subagent-prompt
+                      buffer ellama-tools-subagent-continue-prompt))))
+        (apply
+         #'ellama-stream
+         ellama-tools-subagent-continue-prompt
+         (append
+          (list :buffer buffer
+                :session session
+                :tools tools
+                :system system
+                :on-done
+                (ellama-tools--make-subagent-loop-handler
+                 session buffer system))
+          (when point
+            (list :point point)))))))))
 
 (defun ellama-tools--make-subagent-loop-handler
     (session &optional buffer system)

--- a/ellama-tools.el
+++ b/ellama-tools.el
@@ -2028,7 +2028,8 @@ CALLBACK – function called once with the result string."
 
 (defun ellama-tools-grep-tool (dir search-string)
   "Grep SEARCH-STRING in DIR files."
-  (let ((default-directory dir))
+  (let* ((search-dir (expand-file-name dir))
+         (default-directory (file-name-as-directory search-dir)))
     (json-encode
      (ellama-tools--grep-output
       (ellama-tools--call-command
@@ -2036,7 +2037,7 @@ CALLBACK – function called once with the result string."
        "grep" "--color=never" "-nH" "-e" search-string "{}" "+")
       (format "No matches for %S in %s."
               search-string
-              (expand-file-name dir))))))
+              search-dir)))))
 
 (ellama-tools-define-tool
  '(:function

--- a/ellama-tools.el
+++ b/ellama-tools.el
@@ -1632,10 +1632,34 @@ Wrap command with `srt' when `ellama-tools-use-srt' is non-nil."
 
 (defun ellama-tools--call-command-to-string (program &rest args)
   "Run PROGRAM with ARGS and return stdout as a string."
+  (cdr (apply #'ellama-tools--call-command program args)))
+
+(defun ellama-tools--call-command (program &rest args)
+  "Run PROGRAM with ARGS and return cons of exit status and stdout."
   (let ((argv (apply #'ellama-tools--command-argv program args)))
     (with-temp-buffer
-      (apply #'call-process (car argv) nil t nil (cdr argv))
-      (buffer-string))))
+      (let ((status (apply #'call-process (car argv) nil t nil (cdr argv))))
+        (cons status (buffer-string))))))
+
+(defun ellama-tools--command-failure-output (program status output)
+  "Return diagnostic text for PROGRAM failure with STATUS and OUTPUT."
+  (let ((trimmed (string-trim-right output "\n")))
+    (if (string-empty-p trimmed)
+        (format "%s failed with exit status %s." program status)
+      (format "%s failed with exit status %s:\n%s"
+              program status trimmed))))
+
+(defun ellama-tools--grep-output (result no-matches-message)
+  "Return grep RESULT output or NO-MATCHES-MESSAGE."
+  (let ((status (car result))
+        (output (string-trim-right (cdr result) "\n")))
+    (cond
+     ((and (integerp status) (zerop status)) output)
+     ((and (integerp status)
+           (= status 1)
+           (string-empty-p output))
+      no-matches-message)
+     (t (ellama-tools--command-failure-output "grep" status output)))))
 
 (defun ellama-tools--read-file-mode (mode)
   "Return normalized read file MODE."
@@ -2006,11 +2030,13 @@ CALLBACK – function called once with the result string."
   "Grep SEARCH-STRING in DIR files."
   (let ((default-directory dir))
     (json-encode
-     (string-trim-right
-      (ellama-tools--call-command-to-string
+     (ellama-tools--grep-output
+      (ellama-tools--call-command
        "find" "." "-type" "f" "-exec"
        "grep" "--color=never" "-nH" "-e" search-string "{}" "+")
-      "\n"))))
+      (format "No matches for %S in %s."
+              search-string
+              (expand-file-name dir))))))
 
 (ellama-tools-define-tool
  '(:function
@@ -2036,8 +2062,12 @@ CALLBACK – function called once with the result string."
 (defun ellama-tools-grep-in-file-tool (search-string file)
   "Grep SEARCH-STRING in FILE."
   (json-encode
-   (ellama-tools--call-command-to-string
-    "grep" "--color=never" "-nh" search-string (file-truename file))))
+   (let ((truename (file-truename file)))
+     (ellama-tools--grep-output
+      (ellama-tools--call-command
+       "grep" "--color=never" "-nh" search-string truename)
+      (format "No matches for %S in %s."
+              search-string truename)))))
 
 (ellama-tools-define-tool
  '(:function

--- a/ellama-tools.el
+++ b/ellama-tools.el
@@ -1830,17 +1830,22 @@ DEPTH is the current recursion depth, used internally."
   (or (ellama-tools--tool-check-file-access dir 'list)
       (if (not (file-exists-p dir))
           (format "Directory %s doesn't exists" dir)
-        (let ((indent (make-string (* (or depth 0) 2) ? ))
-              (tree ""))
-          (dolist (f (sort (cl-remove-if
-                            (lambda (f)
-                              (string-prefix-p "." f))
-                            (directory-files dir))
-                           #'string-lessp))
+        (let* ((indent (make-string (* (or depth 0) 2) ? ))
+               (entries
+                (sort (cl-remove-if
+                       (lambda (f)
+                         (string-prefix-p "." f))
+                       (directory-files dir))
+                      #'string-lessp))
+               (single-entry-p (= (length entries) 1))
+               (tree ""))
+          (dolist (f entries)
             (let* ((full   (expand-file-name f dir))
                    (name   (file-name-nondirectory f))
                    (type   (if (file-directory-p full) "|-" "`-"))
-                   (line   (concat indent type name "\n")))
+                   (line   (concat indent
+                                   (unless single-entry-p type)
+                                   name "\n")))
               (setq tree (concat tree line))
               (when (file-directory-p full)
                 (setq tree (concat tree

--- a/ellama-tools.el
+++ b/ellama-tools.el
@@ -2428,7 +2428,12 @@ Return insertion point for sub-agent response."
       (goto-char (point-max))
       (let ((prefix (ellama-get-nick-prefix-for-mode)))
         (unless (bobp)
-          (insert "\n"))
+          (unless (bolp)
+            (insert "\n"))
+          (unless (save-excursion
+                    (forward-line -1)
+                    (looking-at-p "[[:space:]]*$"))
+            (insert "\n")))
         (insert prefix " Main agent:\n"
                 (ellama--fill-long-lines description) "\n\n"
                 prefix " " ellama-assistant-nick ":\n")

--- a/ellama.el
+++ b/ellama.el
@@ -1312,6 +1312,50 @@ CONTEXT will be ignored.  Use global context instead.
      "\n"))
    (t (format "%S" content))))
 
+(defun ellama--decode-json-string (value)
+  "Return decoded JSON string VALUE when possible."
+  (if (not (stringp value))
+      value
+    (condition-case nil
+        (let ((decoded (json-parse-string value)))
+          (if (stringp decoded) decoded value))
+      (json-parse-error value))))
+
+(defun ellama--format-tool-result-value (value)
+  "Return human-readable representation of tool result VALUE."
+  (let ((value (ellama--decode-json-string value)))
+    (cond
+     ((stringp value) value)
+     ((null value) "")
+     (t (format "%S" value)))))
+
+(defun ellama--indent-lines (text &optional prefix)
+  "Return TEXT with PREFIX inserted before each line."
+  (let ((prefix (or prefix "  ")))
+    (mapconcat (lambda (line) (concat prefix line))
+               (split-string text "\n")
+               "\n")))
+
+(defun ellama--format-tool-result-entry (entry)
+  "Return formatted tool result ENTRY."
+  (if (and (consp entry) (symbolp (car entry)))
+      (format "%s\n%s"
+              (symbol-name (car entry))
+              (ellama--indent-lines
+               (ellama--format-tool-result-value (cdr entry))))
+    (ellama--indent-lines
+     (ellama--format-tool-result-value entry))))
+
+(defun ellama--format-tool-results (tool-results)
+  "Return human-readable TOOL-RESULTS."
+  (string-join
+   (mapcar #'ellama--format-tool-result-entry
+           (if (and (listp tool-results)
+                    (not (stringp tool-results)))
+               tool-results
+             (list tool-results)))
+   "\n\n"))
+
 (defun ellama--session-compact-render-interaction (interaction)
   "Render INTERACTION for summary generation."
   (let ((role (llm-chat-prompt-interaction-role interaction))
@@ -1325,7 +1369,8 @@ CONTEXT will be ignored.  Use global context instead.
                     (capitalize (symbol-name role))
                     (ellama--session-compact-content-to-string content))
             (when tool-results
-              (format "Tool results:\n%S" tool-results))))
+              (format "Tool results:\n%s"
+                      (ellama--format-tool-results tool-results)))))
      "\n")))
 
 (defun ellama--session-compact-render-interactions (interactions)
@@ -2756,7 +2801,7 @@ REASONING-BUFFER is a buffer for reasoning."
               nil)))
         (when tool-results
           (format "\n<think>\n%s\n</think>\n"
-                  tool-results))
+                  (ellama--format-tool-results tool-results)))
         (when text
           (string-trim text)))))))
 

--- a/ellama.el
+++ b/ellama.el
@@ -1338,9 +1338,13 @@ CONTEXT will be ignored.  Use global context instead.
 
 (defun ellama--format-tool-result-entry (entry)
   "Return formatted tool result ENTRY."
-  (if (and (consp entry) (symbolp (car entry)))
+  (if (and (consp entry)
+           (or (symbolp (car entry))
+               (stringp (car entry))))
       (format "%s\n%s"
-              (symbol-name (car entry))
+              (if (symbolp (car entry))
+                  (symbol-name (car entry))
+                (car entry))
               (ellama--indent-lines
                (ellama--format-tool-result-value (cdr entry))))
     (ellama--indent-lines
@@ -1351,7 +1355,8 @@ CONTEXT will be ignored.  Use global context instead.
   (string-join
    (mapcar #'ellama--format-tool-result-entry
            (if (and (listp tool-results)
-                    (not (stringp tool-results)))
+                    (not (stringp tool-results))
+                    (proper-list-p tool-results))
                tool-results
              (list tool-results)))
    "\n\n"))

--- a/ellama.el
+++ b/ellama.el
@@ -3082,6 +3082,13 @@ session state, never the globally active session selection."
           (ellama--ensure-session-uid ellama--current-session)
           ellama--current-session))))
 
+(defun ellama--default-stream-filter (buffer)
+  "Return default stream insertion filter for BUFFER."
+  (with-current-buffer buffer
+    (if (derived-mode-p 'org-mode)
+        #'ellama--translate-markdown-to-org-filter
+      #'identity)))
+
 (defun ellama-stream (prompt &rest args)
   "Query ellama for PROMPT.
 ARGS contains keys for fine control.
@@ -3146,7 +3153,8 @@ failure (with BUFFER current).
          (replace-beg (plist-get args :replace-beg))
          (replace-end (plist-get args :replace-end))
          (replace-region-p (and replace-beg replace-end))
-         (filter (or (plist-get args :filter) #'identity))
+         (filter (or (plist-get args :filter)
+                     (ellama--default-stream-filter buffer)))
          (errcb (or (plist-get args :on-error)
                     (lambda (msg)
                       (error "Error calling the LLM: %s" msg))))

--- a/ellama.el
+++ b/ellama.el
@@ -6,7 +6,7 @@
 ;; URL: http://github.com/s-kostyaev/ellama
 ;; Keywords: help local tools
 ;; Package-Requires: ((emacs "28.1") (llm "0.24.0") (plz "0.8") (transient "0.7") (compat "29.1") (yaml "1.2.3"))
-;; Version: 1.18.0
+;; Version: 1.19.0
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;; Created: 8th Oct 2023
 

--- a/tests/test-ellama-eval.el
+++ b/tests/test-ellama-eval.el
@@ -101,6 +101,38 @@
         (should
          (= (plist-get result :tool-call-count) 0))))))
 
+(ert-deftest test-ellama-eval-run-case-can-ignore-docstring-wording ()
+  (let ((case
+         '(:id "docstring-case"
+               :suite edit
+               :prompt "Patch the file."
+               :files
+               (("sample.el" . "(defun sample (value limit weight)\n  \"Return VALUE scaled by WEIGHT, clamped to LIMIT.\"\n  (* value weight))\n"))
+               :expected-files
+               (("sample.el" . "(defun sample (value limit weight)\n  \"Return VALUE scaled by WEIGHT, clamped to LIMIT.\"\n  (* (min value limit) weight))\n"))
+               :ignore-docstrings t
+               :file-regexps
+               (("sample.el" . ("\"[^\"]*VALUE[^\"]*LIMIT[^\"]*WEIGHT[^\"]*\""))))))
+    (cl-letf (((symbol-function 'ellama-tools-task-tool)
+               (lambda (callback &optional _description _role
+                                 _template _template-base _arguments)
+                 (with-temp-file
+                     (expand-file-name "sample.el" default-directory)
+                   (insert
+                    "(defun sample (value limit weight)\n"
+                    "  \"Return VALUE clamped to LIMIT, multiplied by WEIGHT.\"\n"
+                    "  (* (min value limit) weight))\n"))
+                 (funcall callback "done")
+                 nil)))
+      (let* ((result (ellama-eval-run-case case 'baseline))
+             (file-check (car (plist-get result :file-checks)))
+             (regexp-check (car (plist-get result :file-regexp-checks))))
+        (should (eq (plist-get result :status) 'passed))
+        (should (plist-get result :success))
+        (should (plist-get file-check :ignore-docstrings))
+        (should (plist-get file-check :matched))
+        (should (plist-get regexp-check :matched))))))
+
 (ert-deftest test-ellama-eval-async-suite-calls-progress-and-completion ()
   (let ((completed nil)
         (progress nil)
@@ -198,13 +230,17 @@
                        (:name "read_file"
                               :args ("sample.el" nil)
                               :status ok
-                              :result "content"
+                              :result nil
                               :finished-at 2.0))
                       :file-checks
                       ((:path "sample.el"
                               :expected "expected"
                               :actual "actual"
                               :matched nil))
+                      :file-regexp-checks
+                      ((:path "sample.el"
+                              :regexp "VALUE"
+                              :matched t))
                       :answer-checks
                       ((:regexp "string"
                                 :matched t))
@@ -224,14 +260,24 @@
                    :false-object json-false))
                  (trace (alist-get 'tool-trace parsed))
                  (file-checks (alist-get 'file-checks parsed))
+                 (file-regexp-checks
+                  (alist-get 'file-regexp-checks parsed))
                  (answer-checks (alist-get 'answer-checks parsed)))
             (should (eq (alist-get 'success parsed) json-false))
+            (should (assq 'workspace parsed))
+            (should (null (alist-get 'workspace parsed)))
             (should (= (length trace) 2))
             (should (equal (alist-get 'name (car trace)) "grep"))
             (should (equal (alist-get 'args (car trace))
                            '("." "needle")))
+            (should (equal (alist-get 'args (cadr trace))
+                           '("sample.el" nil)))
+            (should (assq 'result (cadr trace)))
+            (should (null (alist-get 'result (cadr trace))))
             (should (eq (alist-get 'matched (car file-checks))
                         json-false))
+            (should (eq (alist-get 'matched (car file-regexp-checks))
+                        t))
             (should (eq (alist-get 'matched (car answer-checks))
                         t))))
       (when (file-exists-p file-name)

--- a/tests/test-ellama-eval.el
+++ b/tests/test-ellama-eval.el
@@ -1,0 +1,120 @@
+;;; test-ellama-eval.el --- Ellama eval tests -*- lexical-binding: t; package-lint-main-file: "../ellama.el"; -*-
+
+;; Copyright (C) 2023-2026  Free Software Foundation, Inc.
+
+;; Author: Sergey Kostyaev <sskostyaev@gmail.com>
+
+;; This file is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation; either version 3, or (at your option)
+;; any later version.
+
+;; This file is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with GNU Emacs.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Commentary:
+;;
+;; Ellama eval tests.
+;;
+
+;;; Code:
+
+(require 'cl-lib)
+(require 'ellama-eval)
+(require 'ert)
+
+(ert-deftest test-ellama-eval-number-text-lines ()
+  (should
+   (equal
+    (ellama-eval--number-text-lines "alpha\nbeta\n" 7)
+    "7 | alpha\n8 | beta")))
+
+(ert-deftest test-ellama-eval-edit-lines-tool-replaces-range ()
+  (let ((file (make-temp-file "ellama-eval-edit-lines-")))
+    (unwind-protect
+        (progn
+          (with-temp-file file
+            (insert "alpha\nbeta\ngamma\n"))
+          (should
+           (string-match-p
+            "Replaced lines 2-2"
+            (ellama-eval-edit-lines-tool file 2 2 "delta")))
+          (with-temp-buffer
+            (insert-file-contents file)
+            (should (equal (buffer-string) "alpha\ndelta\ngamma\n"))))
+      (when (file-exists-p file)
+        (delete-file file)))))
+
+(ert-deftest test-ellama-eval-profile-tools-switch-read-and-edit-shapes ()
+  (let ((ellama-tools-allow-all t)
+        (ellama-tools-allowed nil)
+        (ellama-tools-confirm-allowed (make-hash-table))
+        (baseline (ellama-eval--make-profile-tools 'baseline))
+        (numbered (ellama-eval--make-profile-tools 'numbered-line-edit)))
+    (should (member "edit_file" (mapcar #'llm-tool-name baseline)))
+    (should-not (member "edit_lines" (mapcar #'llm-tool-name baseline)))
+    (should (member "edit_lines" (mapcar #'llm-tool-name numbered)))
+    (should-not (member "edit_file" (mapcar #'llm-tool-name numbered)))
+    (let* ((tool
+            (seq-find
+             (lambda (item)
+               (string= (llm-tool-name item) "read_file"))
+             numbered))
+           (function (llm-tool-function tool))
+           (file (make-temp-file "ellama-eval-numbered-read-")))
+      (unwind-protect
+          (progn
+            (with-temp-file file
+              (insert "one\ntwo\n"))
+            (should
+             (equal
+              (json-parse-string (funcall function file "text"))
+              "1 | one\n2 | two")))
+        (when (file-exists-p file)
+          (delete-file file))))))
+
+(ert-deftest test-ellama-eval-run-case-scores-files-and-answer ()
+  (let ((case
+         '(:id "stub-case"
+               :suite edit
+               :prompt "Patch the file."
+               :files (("sample.el" . "before\n"))
+               :expected-files (("sample.el" . "after\n"))
+               :answer-regexps ("done"))))
+    (cl-letf (((symbol-function 'ellama-tools-task-tool)
+               (lambda (callback &optional _description _role
+                                 _template _template-base _arguments)
+                 (with-temp-file
+                     (expand-file-name "sample.el" default-directory)
+                   (insert "after\n"))
+                 (funcall callback "done")
+                 nil)))
+      (let ((result (ellama-eval-run-case case 'baseline)))
+        (should (eq (plist-get result :status) 'passed))
+        (should (plist-get result :success))
+        (should (equal (plist-get result :report-result) "done"))
+        (should
+         (= (plist-get result :tool-call-count) 0))))))
+
+(ert-deftest test-ellama-eval-summarize-results ()
+  (let* ((results
+          '((:suite edit :profile baseline :success t
+                    :steps 2 :tool-call-count 3)
+            (:suite edit :profile baseline :success nil
+                    :steps 4 :tool-call-count 5)))
+         (summary (ellama-eval-summarize-results results))
+         (row (car summary)))
+    (should (equal (plist-get row :runs) 2))
+    (should (equal (plist-get row :passed) 1))
+    (should (= (plist-get row :success-rate) 0.5))
+    (should (= (plist-get row :mean-steps) 3.0))
+    (should (= (plist-get row :mean-tool-calls) 4.0))))
+
+(provide 'test-ellama-eval)
+
+;;; test-ellama-eval.el ends here

--- a/tests/test-ellama-eval.el
+++ b/tests/test-ellama-eval.el
@@ -193,6 +193,48 @@
     (should (= (length all-cases)
                (length ellama-eval-hypothesis-cases)))))
 
+(ert-deftest test-ellama-eval-read-results-file-expands-relative-selection ()
+  (let* ((dir (make-temp-file "ellama-eval-results-dir-" t))
+         (default-directory dir)
+         (buffer-file-name (expand-file-name "active.el" dir))
+         captured-args)
+    (unwind-protect
+        (cl-letf (((symbol-function 'y-or-n-p)
+                   (lambda (&rest _args) t))
+                  ((symbol-function 'read-file-name)
+                   (lambda (&rest args)
+                     (setq captured-args args)
+                     "ellama-eval-results-baseline.jsonl")))
+          (should
+           (equal
+            (ellama-eval--read-results-file)
+            (expand-file-name "ellama-eval-results-baseline.jsonl" dir)))
+          (should
+           (equal (nth 1 captured-args) dir))
+          (should
+           (equal (nth 2 captured-args)
+                  (expand-file-name "ellama-eval-results.jsonl" dir))))
+      (when (file-directory-p dir)
+        (delete-directory dir t)))))
+
+(ert-deftest test-ellama-eval-read-results-file-refuses-current-buffer-file ()
+  (let* ((dir (make-temp-file "ellama-eval-results-dir-" t))
+         (default-directory dir)
+         (buffer-file-name (expand-file-name "active.el" dir)))
+    (unwind-protect
+        (progn
+          (with-temp-file buffer-file-name
+            (insert "keep me"))
+          (cl-letf (((symbol-function 'y-or-n-p)
+                     (lambda (&rest _args) t))
+                    ((symbol-function 'read-file-name)
+                     (lambda (&rest _args) buffer-file-name)))
+            (should-error
+             (ellama-eval--read-results-file)
+             :type 'user-error)))
+      (when (file-directory-p dir)
+        (delete-directory dir t)))))
+
 (provide 'test-ellama-eval)
 
 ;;; test-ellama-eval.el ends here

--- a/tests/test-ellama-eval.el
+++ b/tests/test-ellama-eval.el
@@ -181,6 +181,62 @@
       (when (buffer-live-p buffer)
         (kill-buffer buffer)))))
 
+(ert-deftest test-ellama-eval-write-results-jsonl-uses-arrays-and-booleans ()
+  (let* ((file-name (make-temp-file "ellama-eval-results-" nil ".jsonl"))
+         (results
+          '((:case-id "case"
+                      :suite edit
+                      :profile baseline
+                      :status failed
+                      :success nil
+                      :tool-trace
+                      ((:name "grep"
+                              :args ("." "needle")
+                              :status ok
+                              :result "match"
+                              :finished-at 1.0)
+                       (:name "read_file"
+                              :args ("sample.el" nil)
+                              :status ok
+                              :result "content"
+                              :finished-at 2.0))
+                      :file-checks
+                      ((:path "sample.el"
+                              :expected "expected"
+                              :actual "actual"
+                              :matched nil))
+                      :answer-checks
+                      ((:regexp "string"
+                                :matched t))
+                      :workspace nil))))
+    (unwind-protect
+        (progn
+          (ellama-eval-write-results-jsonl results file-name)
+          (let* ((json-false :false)
+                 (parsed
+                  (json-parse-string
+                   (with-temp-buffer
+                     (insert-file-contents file-name)
+                     (buffer-substring-no-properties
+                      (point-min) (line-end-position)))
+                   :object-type 'alist
+                   :array-type 'list
+                   :false-object json-false))
+                 (trace (alist-get 'tool-trace parsed))
+                 (file-checks (alist-get 'file-checks parsed))
+                 (answer-checks (alist-get 'answer-checks parsed)))
+            (should (eq (alist-get 'success parsed) json-false))
+            (should (= (length trace) 2))
+            (should (equal (alist-get 'name (car trace)) "grep"))
+            (should (equal (alist-get 'args (car trace))
+                           '("." "needle")))
+            (should (eq (alist-get 'matched (car file-checks))
+                        json-false))
+            (should (eq (alist-get 'matched (car answer-checks))
+                        t))))
+      (when (file-exists-p file-name)
+        (delete-file file-name)))))
+
 (ert-deftest test-ellama-eval-cases-for-suite-selection ()
   (let ((edit-cases (ellama-eval--cases-for-suite-selection 'edit))
         (all-cases (ellama-eval--cases-for-suite-selection 'all)))

--- a/tests/test-ellama-eval.el
+++ b/tests/test-ellama-eval.el
@@ -101,6 +101,55 @@
         (should
          (= (plist-get result :tool-call-count) 0))))))
 
+(ert-deftest test-ellama-eval-async-suite-calls-progress-and-completion ()
+  (let ((completed nil)
+        (progress nil)
+        (deadline (+ (float-time) 2.0)))
+    (cl-letf (((symbol-function 'ellama-eval-start-case)
+               (lambda (case profile callback &optional _provider)
+                 (funcall callback
+                          (list :case-id (plist-get case :id)
+                                :suite (plist-get case :suite)
+                                :profile profile
+                                :status 'passed
+                                :success t
+                                :steps 1
+                                :tool-call-count 2)))))
+      (ellama-eval-run-hypothesis-suite-async
+       nil '(baseline)
+       '((:id "one" :suite edit)
+         (:id "two" :suite explore))
+       (lambda (results)
+         (setq completed results))
+       (lambda (_results count total _latest)
+         (push (list count total) progress)))
+      (while (and (null completed)
+                  (< (float-time) deadline))
+        (accept-process-output nil 0.01))
+      (should (= (length completed) 2))
+      (should (equal (nreverse progress)
+                     '((0 2) (1 2) (2 2)))))))
+
+(ert-deftest test-ellama-eval-timeout-run-finalizes-state ()
+  (let* ((workspace (make-temp-file "ellama-eval-timeout-" t))
+         (callback-result nil)
+         (state
+          (make-ellama-eval--run-state
+           :status 'pending
+           :trace nil
+           :started-at (float-time)
+           :workspace workspace
+           :case '(:id "timeout" :suite edit)
+           :profile 'baseline
+           :callback (lambda (result)
+                       (setq callback-result result)))))
+    (let ((ellama-eval--active-run state))
+      (ellama-eval--timeout-run state)
+      (should (null ellama-eval--active-run)))
+    (should (eq (plist-get callback-result :status) 'timeout))
+    (should-not (plist-get callback-result :success))
+    (should-not (file-directory-p workspace))))
+
 (ert-deftest test-ellama-eval-summarize-results ()
   (let* ((results
           '((:suite edit :profile baseline :success t
@@ -114,6 +163,35 @@
     (should (= (plist-get row :success-rate) 0.5))
     (should (= (plist-get row :mean-steps) 3.0))
     (should (= (plist-get row :mean-tool-calls) 4.0))))
+
+(ert-deftest test-ellama-eval-render-summary-buffer ()
+  (let* ((results
+          '((:case-id "one" :suite edit :profile baseline :status passed
+                      :success t :steps 2 :tool-call-count 3
+                      :elapsed-ms 40)))
+         (buffer
+          (ellama-eval--render-summary-buffer results 1 4 "/tmp/out.jsonl")))
+    (unwind-protect
+        (with-current-buffer buffer
+          (let ((text (buffer-string)))
+            (should (string-match-p "Progress: 1/4 completed" text))
+            (should (string-match-p "JSONL target: /tmp/out.jsonl" text))
+            (should (string-match-p "Aggregate summary" text))
+            (should (string-match-p "one" text))))
+      (when (buffer-live-p buffer)
+        (kill-buffer buffer)))))
+
+(ert-deftest test-ellama-eval-cases-for-suite-selection ()
+  (let ((edit-cases (ellama-eval--cases-for-suite-selection 'edit))
+        (all-cases (ellama-eval--cases-for-suite-selection 'all)))
+    (should edit-cases)
+    (should
+     (cl-every
+      (lambda (case)
+        (eq (plist-get case :suite) 'edit))
+      edit-cases))
+    (should (= (length all-cases)
+               (length ellama-eval-hypothesis-cases)))))
 
 (provide 'test-ellama-eval)
 

--- a/tests/test-ellama-tools.el
+++ b/tests/test-ellama-tools.el
@@ -2213,34 +2213,47 @@ Return list with result and prompt."
                         :system system
                         :result-callback #'ignore))))
     (unwind-protect
-        (cl-letf (((symbol-function 'ellama-get-session-buffer)
-                   (lambda (id)
-                     (and (member id '("worker-loop" "worker-loop-uid"))
-                          worker-buffer)))
-                  ((symbol-function 'ellama-tools--set-session-extra)
-                   (lambda (_session extra)
-                     (setq updated-extra extra)))
-                  ((symbol-function 'ellama-stream)
-                   (lambda (prompt &rest args)
-                     (setq stream-call (list prompt args)))))
-          (with-temp-buffer
-            (let ((ellama--current-session nil))
-              (funcall
-               (ellama-tools--make-subagent-loop-handler
-                session worker-buffer system)
-               "ignored")))
-          (should (equal (plist-get updated-extra :step-count) 1))
-          (should (equal (car stream-call)
-                         ellama-tools-subagent-continue-prompt))
-          (should (eq (plist-get (cadr stream-call) :buffer)
-                      worker-buffer))
-          (should (eq (plist-get (cadr stream-call) :session)
-                      session))
-          (should (equal (plist-get (cadr stream-call) :tools)
-                         (list role-tool)))
-          (should (equal (plist-get (cadr stream-call) :system)
-                         system))
-          (should (functionp (plist-get (cadr stream-call) :on-done))))
+        (progn
+          (with-current-buffer worker-buffer
+            (insert "Previous response")
+            (goto-char (point-min)))
+          (cl-letf (((symbol-function 'ellama-get-session-buffer)
+                     (lambda (id)
+                       (and (member id '("worker-loop" "worker-loop-uid"))
+                            worker-buffer)))
+                    ((symbol-function 'ellama-tools--set-session-extra)
+                     (lambda (_session extra)
+                       (setq updated-extra extra)))
+                    ((symbol-function 'ellama-stream)
+                     (lambda (prompt &rest args)
+                       (setq stream-call (list prompt args)))))
+            (with-temp-buffer
+              (let ((ellama--current-session nil))
+                (funcall
+                 (ellama-tools--make-subagent-loop-handler
+                  session worker-buffer system)
+                 "ignored")))
+            (should (equal (plist-get updated-extra :step-count) 1))
+            (should (equal (car stream-call)
+                           ellama-tools-subagent-continue-prompt))
+            (should (eq (plist-get (cadr stream-call) :buffer)
+                        worker-buffer))
+            (should (eq (plist-get (cadr stream-call) :session)
+                        session))
+            (should (equal (plist-get (cadr stream-call) :tools)
+                           (list role-tool)))
+            (should (equal (plist-get (cadr stream-call) :system)
+                           system))
+            (should (functionp (plist-get (cadr stream-call) :on-done)))
+            (with-current-buffer worker-buffer
+              (should (string-match-p "Previous response"
+                                      (buffer-string)))
+              (should (string-match-p "Main agent:"
+                                      (buffer-string)))
+              (should (string-match-p "Task not marked complete"
+                                      (buffer-string)))
+              (should (= (plist-get (cadr stream-call) :point)
+                         (point-max))))))
       (when (buffer-live-p worker-buffer)
         (kill-buffer worker-buffer)))))
 

--- a/tests/test-ellama-tools.el
+++ b/tests/test-ellama-tools.el
@@ -670,15 +670,31 @@ Return list with result and prompt."
 (ert-deftest test-ellama-tools-grep-tool-uses-shared-command-helper ()
   (ellama-test--ensure-local-ellama-tools)
   (let (captured)
-    (cl-letf (((symbol-function 'ellama-tools--call-command-to-string)
+    (cl-letf (((symbol-function 'ellama-tools--call-command)
                (lambda (&rest args)
                  (setq captured args)
-                 "a:1:match\n")))
+                 '(0 . "a:1:match\n"))))
       (should (equal (ellama-tools-grep-tool default-directory "match")
                      "\"a:1:match\"")))
     (should (equal captured
                    '("find" "." "-type" "f" "-exec"
                      "grep" "--color=never" "-nH" "-e" "match" "{}" "+")))))
+
+(ert-deftest test-ellama-tools-grep-tool-explains-no-matches ()
+  (ellama-test--ensure-local-ellama-tools)
+  (let* ((dir (make-temp-file "ellama-grep-dir-" t))
+         (file (expand-file-name "a.txt" dir))
+         (expected (format "No matches for %S in %s."
+                           "needle"
+                           (expand-file-name dir))))
+    (unwind-protect
+        (progn
+          (with-temp-file file
+            (insert "haystack\n"))
+          (should (equal (ellama-tools-grep-tool dir "needle")
+                         (json-encode expected))))
+      (when (file-exists-p dir)
+        (delete-directory dir t)))))
 
 (ert-deftest test-ellama-tools-grep-in-file-tool-uses-shared-command-helper ()
   (ellama-test--ensure-local-ellama-tools)
@@ -690,17 +706,31 @@ Return list with result and prompt."
           (with-temp-file file
             (insert "hello\n"))
           (setq truename (file-truename file))
-          (cl-letf (((symbol-function 'ellama-tools--call-command-to-string)
+          (cl-letf (((symbol-function 'ellama-tools--call-command)
                      (lambda (&rest args)
                        (setq captured args)
-                       "1:hello\n")))
+                       '(0 . "1:hello\n"))))
             (should (equal (ellama-tools-grep-in-file-tool "hello" file)
-                           "\"1:hello\\n\""))))
+                           "\"1:hello\""))))
       (when (file-exists-p file)
         (delete-file file)))
     (should (equal captured
                    (list "grep" "--color=never" "-nh"
                          "hello" truename)))))
+
+(ert-deftest test-ellama-tools-grep-in-file-tool-explains-no-matches ()
+  (ellama-test--ensure-local-ellama-tools)
+  (let ((file (make-temp-file "ellama-grep-in-file-")))
+    (unwind-protect
+        (let ((expected (format "No matches for %S in %s."
+                                "needle"
+                                (file-truename file))))
+          (with-temp-file file
+            (insert "haystack\n"))
+          (should (equal (ellama-tools-grep-in-file-tool "needle" file)
+                         (json-encode expected))))
+      (when (file-exists-p file)
+        (delete-file file)))))
 
 (ert-deftest test-ellama-read-file-tool-rejects-binary-content ()
   (ellama-test--ensure-local-ellama-tools)

--- a/tests/test-ellama-tools.el
+++ b/tests/test-ellama-tools.el
@@ -106,10 +106,16 @@
     (should spinner-stop-called)))
 (defun ellama-test--ensure-local-ellama-tools ()
   "Load local `ellama-tools.el' from project root when needed."
-  (unless (and (fboundp 'ellama-tools--sanitize-tool-text-output)
-               (fboundp 'ellama-tools--command-argv)
-               (fboundp 'ellama-tools--task-description))
-    (load-file (expand-file-name "ellama-tools.el" ellama-test-root))))
+  (let ((loaded-file
+         (symbol-file 'ellama-tools-directory-tree-tool 'defun)))
+    (unless (and loaded-file
+                 (string-prefix-p
+                  (file-truename ellama-test-root)
+                  (file-truename loaded-file))
+                 (fboundp 'ellama-tools--sanitize-tool-text-output)
+                 (fboundp 'ellama-tools--command-argv)
+                 (fboundp 'ellama-tools--task-description))
+      (load-file (expand-file-name "ellama-tools.el" ellama-test-root)))))
 
 (defun ellama-test--clear-srt-policy-cache ()
   "Clear local `srt' policy cache for tool test helpers."
@@ -2018,6 +2024,20 @@ Return list with result and prompt."
           (should-not (string-match-p "\\.hidden" result))
           (should (< (string-match-p "a\\.txt" result)
                      (string-match-p "b\\.txt" result))))
+      (when (file-exists-p dir)
+        (delete-directory dir t)))))
+
+(ert-deftest test-ellama-tools-directory-tree-omits-prefix-for-single-entry ()
+  (ellama-test--ensure-local-ellama-tools)
+  (let* ((dir (make-temp-file "ellama-tree-single-" t))
+         (file (expand-file-name "only.txt" dir)))
+    (unwind-protect
+        (progn
+          (with-temp-file file
+            (insert "x"))
+          (should
+           (equal (ellama-tools-directory-tree-tool dir)
+                  "only.txt\n")))
       (when (file-exists-p dir)
         (delete-directory dir t)))))
 

--- a/tests/test-ellama-tools.el
+++ b/tests/test-ellama-tools.el
@@ -2263,6 +2263,8 @@ Return list with result and prompt."
             (with-current-buffer worker-buffer
               (should (string-match-p "Previous response"
                                       (buffer-string)))
+              (should (string-match-p "Previous response\n\n"
+                                      (buffer-string)))
               (should (string-match-p "Main agent:"
                                       (buffer-string)))
               (should (string-match-p "Task not marked complete"

--- a/tests/test-ellama-tools.el
+++ b/tests/test-ellama-tools.el
@@ -696,6 +696,21 @@ Return list with result and prompt."
       (when (file-exists-p dir)
         (delete-directory dir t)))))
 
+(ert-deftest test-ellama-tools-grep-tool-resolves-relative-dir ()
+  (ellama-test--ensure-local-ellama-tools)
+  (let* ((dir (make-temp-file "ellama-grep-relative-" t))
+         (file (expand-file-name "sample.el" dir))
+         (default-directory (file-name-as-directory dir)))
+    (unwind-protect
+        (progn
+          (with-temp-file file
+            (insert "(defun ellama-test-target () nil)\n"))
+          (should
+           (equal (ellama-tools-grep-tool "." "ellama-test-target")
+                  "\"./sample.el:1:(defun ellama-test-target () nil)\"")))
+      (when (file-exists-p dir)
+        (delete-directory dir t)))))
+
 (ert-deftest test-ellama-tools-grep-in-file-tool-uses-shared-command-helper ()
   (ellama-test--ensure-local-ellama-tools)
   (let ((file (make-temp-file "ellama-grep-in-file-"))

--- a/tests/test-ellama-tools.el
+++ b/tests/test-ellama-tools.el
@@ -2041,6 +2041,32 @@ Return list with result and prompt."
       (when (file-exists-p dir)
         (delete-directory dir t)))))
 
+(ert-deftest test-ellama-tools-project-root-falls-back-to-default-directory ()
+  (ellama-test--ensure-local-ellama-tools)
+  (let ((default-directory temporary-file-directory))
+    (cl-letf (((symbol-function 'project-current)
+               (lambda (&rest _args) nil)))
+      (should
+       (equal (ellama-tools-project-root-tool)
+              (expand-file-name temporary-file-directory))))))
+
+(ert-deftest test-ellama-tools-project-root-wrapped-never-returns-done ()
+  (ellama-test--ensure-local-ellama-tools)
+  (let ((default-directory temporary-file-directory)
+        (ellama-tools-allow-all t)
+        (ellama-tools-allowed nil)
+        (ellama-tools-confirm-allowed (make-hash-table)))
+    (cl-letf (((symbol-function 'project-current)
+               (lambda (&rest _args) nil)))
+      (let* ((tool-plist '(:function ellama-tools-project-root-tool
+                                     :name "project_root"
+                                     :args nil))
+             (wrapped (ellama-tools-wrap-with-confirm tool-plist))
+             (function (plist-get wrapped :function)))
+        (should
+         (equal (funcall function)
+                (expand-file-name temporary-file-directory)))))))
+
 (ert-deftest test-ellama-tools-move-file-success-and-error ()
   (ellama-test--ensure-local-ellama-tools)
   (let* ((src (make-temp-file "ellama-move-src-"))

--- a/tests/test-ellama.el
+++ b/tests/test-ellama.el
@@ -1490,8 +1490,8 @@ detailed comparison to help you decide:
 
 (ert-deftest test-ellama-sanitize-provider-chat-request-keeps-dotted-pairs ()
   (let* ((request '(:model "qwen3.6-plus"
-                    :enable_search t
-                    :search_options ((search_strategy . "agent"))))
+                           :enable_search t
+                           :search_options ((search_strategy . "agent"))))
          (sanitized (ellama--sanitize-provider-chat-request request)))
     (should (equal sanitized request))
     (should (json-serialize sanitized))))
@@ -2168,8 +2168,8 @@ region, season, or type)! 🍎🍊"))))
                           :key 'llm-key)
                :prompt (llm-make-chat-prompt "hello")
                :extra '(:dir "/tmp"
-                        :uid "symbol-key"
-                        :provider-symbol ellama-provider)))))
+                             :uid "symbol-key"
+                             :provider-symbol ellama-provider)))))
           (let* ((session (ellama--read-session-from-file file-name))
                  (key (llm-openai-compatible-key
                        (ellama-session-provider session))))

--- a/tests/test-ellama.el
+++ b/tests/test-ellama.el
@@ -242,6 +242,20 @@ STYLE controls partial message shape.  Default value is `word-leading'."
       (when (buffer-live-p reasoning-buffer)
         (kill-buffer reasoning-buffer)))))
 
+(ert-deftest test-ellama-format-tool-results-readable-alist ()
+  (should
+   (equal
+    (ellama--format-tool-results
+     '((grep_in_file . "90:first line\n97:second line")))
+    "grep_in_file\n  90:first line\n  97:second line")))
+
+(ert-deftest test-ellama-format-tool-results-decodes-json-string ()
+  (should
+   (equal
+    (ellama--format-tool-results
+     '((read_file . "\"one\\ntwo\"")))
+    "read_file\n  one\n  two")))
+
 (ert-deftest test-ellama-ask-about-add-selection-ephemeral ()
   (let (captured-ephemeral)
     (with-temp-buffer
@@ -1291,6 +1305,21 @@ detailed comparison to help you decide:
           "user 3" "assistant 3"
           "user 4" "assistant 4"
           "user 5" "assistant 5"))))))
+
+(ert-deftest test-ellama-session-compact-renders-tool-results-readably ()
+  (let* ((prompt (llm-make-chat-prompt "user"))
+         (interaction
+          (make-llm-chat-prompt-interaction
+           :role 'assistant
+           :content "assistant"
+           :tool-results
+           '((grep_in_file . "90:first line\n97:second line")))))
+    (push interaction (llm-chat-prompt-interactions prompt))
+    (let ((rendered
+           (ellama--session-compact-render-interaction interaction)))
+      (should (string-match-p "Tool results:" rendered))
+      (should (string-match-p "grep_in_file\n  90:first line" rendered))
+      (should-not (string-match-p "((grep_in_file" rendered)))))
 
 (ert-deftest test-ellama-session-compact-uses-stored-token-count ()
   (let* ((provider (make-llm-fake))

--- a/tests/test-ellama.el
+++ b/tests/test-ellama.el
@@ -249,6 +249,16 @@ STYLE controls partial message shape.  Default value is `word-leading'."
      '((grep_in_file . "90:first line\n97:second line")))
     "grep_in_file\n  90:first line\n  97:second line")))
 
+(ert-deftest test-ellama-format-tool-results-readable-string-name ()
+  (let ((entry (cons "grep" "\"./router.el:1:(defun route (status)\""))
+        (expected "grep\n  ./router.el:1:(defun route (status)"))
+    (should
+     (equal (ellama--format-tool-results (list entry))
+            expected))
+    (should
+     (equal (ellama--format-tool-results entry)
+            expected))))
+
 (ert-deftest test-ellama-format-tool-results-decodes-json-string ()
   (should
    (equal

--- a/tests/test-ellama.el
+++ b/tests/test-ellama.el
@@ -266,6 +266,17 @@ STYLE controls partial message shape.  Default value is `word-leading'."
      '((read_file . "\"one\\ntwo\"")))
     "read_file\n  one\n  two")))
 
+(ert-deftest test-ellama-default-stream-filter-translates-org-think ()
+  (with-temp-buffer
+    (org-mode)
+    (let ((result
+           (funcall
+            (ellama--default-stream-filter (current-buffer))
+            "<think>\ngrep\n  ./router.el:1:match\n</think>\n")))
+      (should (string-match-p "#\\+BEGIN_QUOTE" result))
+      (should (string-match-p "#\\+END_QUOTE" result))
+      (should-not (string-match-p "<think>" result)))))
+
 (ert-deftest test-ellama-ask-about-add-selection-ephemeral ()
   (let (captured-ephemeral)
     (with-temp-buffer


### PR DESCRIPTION
## Summary
- add an evaluation harness for comparing numbered read output and line-based editing profiles
- provide a nonblocking interactive eval runner with live summary output and JSONL export
- simplify single-entry directory tree rendering for local models
- prefer newer Elisp sources in batch Makefile jobs to avoid stale bytecode loads

## Verification
- make format-elisp
- make build
- make test
- make check-compile-warnings
- make checkdocs