### PR TITLE
Avoid global llm request sanitizer advice

### DIFF
--- a/NEWS.org
+++ b/NEWS.org
@@ -1,3 +1,10 @@
+* Version 1.19.1
+- Stop installing global ~llm-provider-chat-request~ sanitizer advice.  Ellama
+  now avoids rewriting request payloads from unrelated ~llm~ clients after
+  Ellama is loaded.
+- Require ~llm~ 0.30.2 so Ellama can rely on upstream JSON serialization and
+  OpenAI-compatible tool-call argument fixes instead of a global compatibility
+  workaround.
 * Version 1.19.0
 - Add an evaluation harness for comparing agent tool designs with local
   models.  The new suite covers numbered read output, line-range editing, trace

--- a/ellama.el
+++ b/ellama.el
@@ -2862,11 +2862,6 @@ REASONING-BUFFER is a buffer for reasoning."
   "Return provider chat REQUEST with JSON-safe strings."
   (ellama--json-safe-value request))
 
-(advice-remove 'llm-provider-chat-request
-               #'ellama--sanitize-provider-chat-request)
-(advice-add 'llm-provider-chat-request
-            :filter-return #'ellama--sanitize-provider-chat-request)
-
 (defun ellama--collect-openai-streaming-tool-uses (data)
   "Return parsed OpenAI streaming tool-call chunks from DATA."
   (let* ((calls (append data nil))

--- a/ellama.el
+++ b/ellama.el
@@ -6,7 +6,7 @@
 ;; URL: http://github.com/s-kostyaev/ellama
 ;; Keywords: help local tools
 ;; Package-Requires: ((emacs "28.1") (llm "0.30.2") (plz "0.8") (transient "0.7") (compat "29.1") (yaml "1.2.3"))
-;; Version: 1.19.0
+;; Version: 1.19.1
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;; Created: 8th Oct 2023
 

--- a/ellama.el
+++ b/ellama.el
@@ -2858,10 +2858,6 @@ REASONING-BUFFER is a buffer for reasoning."
           (ellama--json-safe-value (cdr value))))
    (t value)))
 
-(defun ellama--sanitize-provider-chat-request (request)
-  "Return provider chat REQUEST with JSON-safe strings."
-  (ellama--json-safe-value request))
-
 (defun ellama--collect-openai-streaming-tool-uses (data)
   "Return parsed OpenAI streaming tool-call chunks from DATA."
   (let* ((calls (append data nil))

--- a/ellama.el
+++ b/ellama.el
@@ -5,7 +5,7 @@
 ;; Author: Sergey Kostyaev <sskostyaev@gmail.com>
 ;; URL: http://github.com/s-kostyaev/ellama
 ;; Keywords: help local tools
-;; Package-Requires: ((emacs "28.1") (llm "0.24.0") (plz "0.8") (transient "0.7") (compat "29.1") (yaml "1.2.3"))
+;; Package-Requires: ((emacs "28.1") (llm "0.30.2") (plz "0.8") (transient "0.7") (compat "29.1") (yaml "1.2.3"))
 ;; Version: 1.19.0
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;; Created: 8th Oct 2023

--- a/tests/test-ellama.el
+++ b/tests/test-ellama.el
@@ -1517,7 +1517,7 @@ detailed comparison to help you decide:
     (should (multibyte-string-p normalized))
     (should (json-serialize normalized))))
 
-(ert-deftest test-ellama-sanitize-provider-chat-request-decodes-arguments ()
+(ert-deftest test-ellama-json-safe-value-decodes-arguments ()
   (let* ((arguments (encode-coding-string
                      (json-serialize
                       '((content . "├── research_plan.md")
@@ -1525,7 +1525,7 @@ detailed comparison to help you decide:
                      'utf-8-unix))
          (request `(:messages [(:tool_calls
                                 [(:function (:arguments ,arguments))])]))
-         (sanitized (ellama--sanitize-provider-chat-request request))
+         (sanitized (ellama--json-safe-value request))
          (sanitized-arguments
           (plist-get
            (plist-get
@@ -1538,18 +1538,23 @@ detailed comparison to help you decide:
     (should (multibyte-string-p sanitized-arguments))
     (should (json-serialize sanitized))))
 
-(ert-deftest test-ellama-sanitize-provider-chat-request-keeps-dotted-pairs ()
+(ert-deftest test-ellama-json-safe-value-keeps-dotted-pairs ()
   (let* ((request '(:model "qwen3.6-plus"
                            :enable_search t
                            :search_options ((search_strategy . "agent"))))
-         (sanitized (ellama--sanitize-provider-chat-request request)))
+         (sanitized (ellama--json-safe-value request)))
     (should (equal sanitized request))
     (should (json-serialize sanitized))))
 
 (ert-deftest test-ellama-does-not-advise-provider-chat-request ()
-  (should-not
-   (advice-member-p #'ellama--sanitize-provider-chat-request
-                    'llm-provider-chat-request)))
+  (let (ellama-advice)
+    (advice-mapc
+     (lambda (advice _props)
+       (when (and (symbolp advice)
+                  (string-prefix-p "ellama-" (symbol-name advice)))
+         (push advice ellama-advice)))
+     'llm-provider-chat-request)
+    (should-not ellama-advice)))
 
 (ert-deftest test-ellama-collect-openai-streaming-tool-uses-uses-max-index ()
   (let* ((data

--- a/tests/test-ellama.el
+++ b/tests/test-ellama.el
@@ -1546,6 +1546,11 @@ detailed comparison to help you decide:
     (should (equal sanitized request))
     (should (json-serialize sanitized))))
 
+(ert-deftest test-ellama-does-not-advise-provider-chat-request ()
+  (should-not
+   (advice-member-p #'ellama--sanitize-provider-chat-request
+                    'llm-provider-chat-request)))
+
 (ert-deftest test-ellama-collect-openai-streaming-tool-uses-uses-max-index ()
   (let* ((data
           [((index . 0)


### PR DESCRIPTION
## Summary
- remove Ellama's global advice on llm-provider-chat-request
- remove the now-unused request sanitizer wrapper
- keep JSON-safe normalization for Ellama's own prompt/tool-use handling
- add regression coverage for JSON-safe dotted pairs and for not installing Ellama advice globally
- raise the minimum llm dependency to 0.30.2, which already contains the upstream JSON/tool-call fixes this workaround used to cover
- add NEWS.org changelog for 1.19.1 and bump ellama.el version

Fixes #413

## Tests
- focused ERT tests for tool-use normalization, JSON-safe values, and advice scope
- make refill-news
- make build
- make test
- make check-compile-warnings
- make checkdocs