### PR TITLE
Prevent duplicate session requests

### DIFF
--- a/NEWS.org
+++ b/NEWS.org
@@ -1,3 +1,8 @@
+* Version 1.19.3
+- Prevented duplicate session requests while a generation or compaction is
+  already active.  Repeating ~C-c C-c~ in a chat buffer now leaves the buffer
+  unchanged instead of sending the same prompt twice.
+
 * Version 1.19.2
 - Improved session compaction for short but oversized histories.  When
   ~ellama-session-auto-compact-keep-last-turns~ cannot be satisfied,
@@ -16,9 +21,6 @@
   being reused after compaction rewrites or replaces session buffers.
 - Wrapped inserted compaction notices using the same paragraph filling behavior
   as chat output, so long compaction messages no longer appear as one long line.
-- Prevented duplicate session requests while a generation or compaction is
-  already active.  Repeating ~C-c C-c~ in a chat buffer now leaves the buffer
-  unchanged instead of sending the same prompt twice.
 
 * Version 1.19.1
 - Stop installing global ~llm-provider-chat-request~ sanitizer advice.  Ellama

--- a/NEWS.org
+++ b/NEWS.org
@@ -16,6 +16,9 @@
   being reused after compaction rewrites or replaces session buffers.
 - Wrapped inserted compaction notices using the same paragraph filling behavior
   as chat output, so long compaction messages no longer appear as one long line.
+- Prevented duplicate session requests while a generation or compaction is
+  already active.  Repeating ~C-c C-c~ in a chat buffer now leaves the buffer
+  unchanged instead of sending the same prompt twice.
 
 * Version 1.19.1
 - Stop installing global ~llm-provider-chat-request~ sanitizer advice.  Ellama

--- a/README.org
+++ b/README.org
@@ -530,6 +530,9 @@ determine or estimate token usage and the session crosses the configured
 threshold.  Use ~ellama-session-auto-compact-token-threshold~ for an absolute
 token threshold, or leave it unset to use
 ~ellama-session-auto-compact-threshold-percent~ of the provider context limit.
+While a session request or compaction is still running, Ellama rejects another
+request for the same session.  This prevents accidental duplicate sends, for
+example by pressing ~C-c C-c~ twice in a chat buffer.
 
 You can compact sessions manually:
 

--- a/ellama.el
+++ b/ellama.el
@@ -6,7 +6,7 @@
 ;; URL: http://github.com/s-kostyaev/ellama
 ;; Keywords: help local tools
 ;; Package-Requires: ((emacs "28.1") (llm "0.30.2") (plz "0.8") (transient "0.7") (compat "29.1") (yaml "1.2.3"))
-;; Version: 1.19.2
+;; Version: 1.19.3
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;; Created: 8th Oct 2023
 

--- a/ellama.el
+++ b/ellama.el
@@ -1104,6 +1104,30 @@ CONTEXT will be ignored.  Use global context instead.
   (or (ellama--session-extra-get session :token-count)
       (ellama--session-extra-get session :auto-compact-last-token-count)))
 
+(defun ellama--session-compacting-p (session)
+  "Return non-nil when SESSION compaction is active."
+  (and (ellama-session-p session)
+       (ellama--session-extra-get session :auto-compact-in-progress)))
+
+(defun ellama--buffer-request-active-p (buffer)
+  "Return non-nil when BUFFER has an active LLM request."
+  (when-let ((buffer (and buffer (get-buffer buffer))))
+    (with-current-buffer buffer
+      ellama--current-request)))
+
+(defun ellama--session-request-active-p (session &optional buffer)
+  "Return non-nil when SESSION or BUFFER has an active request."
+  (or (ellama--session-compacting-p session)
+      (ellama--buffer-request-active-p buffer)
+      (when-let ((session-buffer
+                  (ellama--session-registered-buffer session)))
+        (ellama--buffer-request-active-p session-buffer))))
+
+(defun ellama--ensure-session-request-idle (session &optional buffer)
+  "Signal user error when SESSION or BUFFER has an active request."
+  (when (ellama--session-request-active-p session buffer)
+    (user-error "Ellama session request is already running")))
+
 (defun ellama-image-file-p (file-name)
   "Return non-nil when FILE-NAME is a supported image file."
   (and (stringp file-name)
@@ -3144,13 +3168,13 @@ inserted into the BUFFER."
                            (and
                             (ellama-session-p session)
                             (ellama--session-registered-buffer session))
-                           (and (buffer-live-p buffer) buffer))))
-                      (with-current-buffer target-buffer
-                        (ellama--run-done-callback donecb text)
-                        (when ellama-session-hide-org-quotes
-                          (ellama-collapse-org-quotes))
-                        (ellama--deactivate-current-request
-                         request-context))))))
+	                           (and (buffer-live-p buffer) buffer))))
+	                      (with-current-buffer target-buffer
+	                        (ellama--deactivate-current-request
+	                         request-context)
+	                        (ellama--run-done-callback donecb text)
+	                        (when ellama-session-hide-org-quotes
+	                          (ellama-collapse-org-quotes)))))))
             (if (and (not tool-result)
                      (ellama-session-p ellama--current-session))
                 (progn
@@ -3237,13 +3261,14 @@ failure (with BUFFER current).
                          (ellama-get-first-ollama-chat-model))))
          (max-tokens (or (plist-get args :max-tokens)
                          ellama-max-tokens))
-         (reasoning-buffer (get-buffer-create
-                            (concat (make-temp-name "*ellama-reasoning-")
-                                    "*")))
          (point (or (plist-get args :point)
                     (with-current-buffer buffer (point))))
          (replace-beg (plist-get args :replace-beg))
          (replace-end (plist-get args :replace-end))
+         (_ (ellama--ensure-session-request-idle session buffer))
+         (reasoning-buffer (get-buffer-create
+                            (concat (make-temp-name "*ellama-reasoning-")
+                                    "*")))
          (replace-region-p (and replace-beg replace-end))
          (filter (or (plist-get args :filter)
                      (ellama--default-stream-filter buffer)))
@@ -3758,6 +3783,7 @@ the full response text when the request completes (with BUFFER current)."
                      (if-let ((session-file (ellama-session-file session)))
                          (find-file-noselect session-file)
                        (get-buffer-create (ellama-session-id session)))))
+         (_ (ellama--ensure-session-request-idle session buffer))
          (_ (with-current-buffer buffer
               (setq ellama--current-session session)
               (unless ellama-session-mode
@@ -3846,6 +3872,7 @@ the full response text when the request completes (with BUFFER current)."
               (text (if (derived-mode-p 'org-mode)
                         (ellama-convert-org-to-md message)
                       message)))
+    (ellama--ensure-session-request-idle session (current-buffer))
     (goto-char (point-max))
     (insert "\n\n")
     (when (or ellama-context-global ellama-context-ephemeral)

--- a/ellama.info
+++ b/ellama.info
@@ -702,7 +702,10 @@ Ellama can determine or estimate token usage and the session crosses the
 configured threshold.  Use ‘ellama-session-auto-compact-token-threshold’
 for an absolute token threshold, or leave it unset to use
 ‘ellama-session-auto-compact-threshold-percent’ of the provider context
-limit.
+limit.  While a session request or compaction is still running, Ellama
+rejects another request for the same session.  This prevents accidental
+duplicate sends, for example by pressing ‘C-c C-c’ twice in a chat
+buffer.
 
 You can compact sessions manually:
 
@@ -2409,41 +2412,41 @@ Node: Keymap17562
 Node: Configuration20449
 Node: Session Provider Keys32489
 Node: Session Compaction34350
-Node: Image Input36429
-Node: Task Tool Subagents38574
-Node: DLP for Tool Input/Output40677
-Node: SRT Filesystem Policy for Tools55579
-Node: Context Management61248
-Node: Transient Menus for Context Management62316
-Node: Managing the Context63995
-Node: Considerations64770
-Node: Minor modes65363
-Node: ellama-context-header-line-mode67351
-Node: ellama-context-header-line-global-mode68176
-Node: ellama-context-mode-line-mode68896
-Node: ellama-context-mode-line-global-mode69744
-Node: Ellama Session Header Line Mode70448
-Node: Enabling and Disabling71017
-Node: Customization71464
-Node: Ellama Session Mode Line Mode71752
-Node: Enabling and Disabling (1)72337
-Node: Customization (1)72784
-Node: Using Blueprints73078
-Node: Key Components of Ellama Blueprints73718
-Node: Creating and Managing Blueprints74325
-Node: Blueprints files75303
-Node: Variable Management75724
-Node: Keymap and Mode76177
-Node: Transient Menus77113
-Node: Running Blueprints programmatically77659
-Node: MCP Integration78246
-Node: Agent Skills79481
-Node: Directory Structure79844
-Node: Creating a Skill80871
-Node: How it works81246
-Node: Acknowledgments81637
-Node: Contributions82348
-Node: GNU Free Documentation License82734
+Node: Image Input36644
+Node: Task Tool Subagents38789
+Node: DLP for Tool Input/Output40892
+Node: SRT Filesystem Policy for Tools55794
+Node: Context Management61463
+Node: Transient Menus for Context Management62531
+Node: Managing the Context64210
+Node: Considerations64985
+Node: Minor modes65578
+Node: ellama-context-header-line-mode67566
+Node: ellama-context-header-line-global-mode68391
+Node: ellama-context-mode-line-mode69111
+Node: ellama-context-mode-line-global-mode69959
+Node: Ellama Session Header Line Mode70663
+Node: Enabling and Disabling71232
+Node: Customization71679
+Node: Ellama Session Mode Line Mode71967
+Node: Enabling and Disabling (1)72552
+Node: Customization (1)72999
+Node: Using Blueprints73293
+Node: Key Components of Ellama Blueprints73933
+Node: Creating and Managing Blueprints74540
+Node: Blueprints files75518
+Node: Variable Management75939
+Node: Keymap and Mode76392
+Node: Transient Menus77328
+Node: Running Blueprints programmatically77874
+Node: MCP Integration78461
+Node: Agent Skills79696
+Node: Directory Structure80059
+Node: Creating a Skill81086
+Node: How it works81461
+Node: Acknowledgments81852
+Node: Contributions82563
+Node: GNU Free Documentation License82949
 
 End Tag Table
 

--- a/tests/test-ellama.el
+++ b/tests/test-ellama.el
@@ -242,6 +242,32 @@ STYLE controls partial message shape.  Default value is `word-leading'."
       (when (buffer-live-p reasoning-buffer)
         (kill-buffer reasoning-buffer)))))
 
+(ert-deftest test-ellama-response-handler-clears-request-before-done ()
+  (let ((request-active-in-done t)
+        (ellama-spinner-enabled nil)
+        request-context)
+    (with-temp-buffer
+      (setq-local ellama--change-group (prepare-change-group))
+      (activate-change-group ellama--change-group)
+      (setq request-context
+            (ellama--set-current-request 'request (list (current-buffer))))
+      (funcall
+       (ellama--response-handler
+        #'ignore
+        nil
+        (current-buffer)
+        (lambda (_text)
+          (setq request-active-in-done ellama--current-request))
+        #'ignore
+        'provider
+        'prompt
+        t
+        #'identity
+        request-context)
+       '(:text "answer"))
+      (should-not request-active-in-done)
+      (should-not ellama--current-request))))
+
 (ert-deftest test-ellama-format-tool-results-readable-alist ()
   (should
    (equal
@@ -1132,6 +1158,26 @@ detailed comparison to help you decide:
                            (file-name-nondirectory file-name)))
                   (buffer-string))))))))
 
+(ert-deftest test-ellama-chat-send-last-message-refuses-active-request ()
+  (let ((session (make-ellama-session
+                  :id "busy-chat"
+                  :provider (make-llm-fake)))
+        (ellama-context-global nil)
+        (ellama-context-ephemeral nil))
+    (with-temp-buffer
+      (org-mode)
+      (setq-local ellama--current-session session)
+      (setq-local ellama--current-request 'request)
+      (insert "** User:\nRepeat this")
+      (let ((before (buffer-string)))
+        (cl-letf (((symbol-function 'ellama-stream)
+                   (lambda (&rest _args)
+                     (ert-fail "Unexpected duplicate request"))))
+          (should-error
+           (ellama-chat-send-last-message)
+           :type 'user-error))
+        (should (equal before (buffer-string)))))))
+
 (ert-deftest test-ellama-stream-displays-session-buffer-on-generation ()
   (let* ((provider (make-llm-fake
                     :chat-action-func (lambda () "Chat answer")))
@@ -1161,6 +1207,42 @@ detailed comparison to help you decide:
           (should (eq displayed-buffer session-buffer)))
       (when (buffer-live-p session-buffer)
         (kill-buffer session-buffer)))))
+
+(ert-deftest test-ellama-stream-refuses-active-session-request ()
+  (let* ((provider (make-llm-fake))
+         (session (ellama-test--compact-session provider))
+         (prompt (ellama-session-prompt session)))
+    (with-temp-buffer
+      (setq-local ellama--current-session session)
+      (setq-local ellama--current-request 'request)
+      (cl-letf (((symbol-function 'llm-chat-streaming)
+                 (lambda (&rest _args)
+                   (ert-fail "Unexpected duplicate request"))))
+        (should-error
+         (ellama-stream "new request" :session session)
+         :type 'user-error))
+      (should-not
+       (member "new request"
+               (mapcar #'llm-chat-prompt-interaction-content
+                       (llm-chat-prompt-interactions prompt)))))))
+
+(ert-deftest test-ellama-stream-refuses-session-compaction ()
+  (let* ((provider (make-llm-fake))
+         (session (ellama-test--compact-session provider))
+         (prompt (ellama-session-prompt session)))
+    (ellama--session-extra-put session :auto-compact-in-progress t)
+    (with-temp-buffer
+      (setq-local ellama--current-session session)
+      (cl-letf (((symbol-function 'llm-chat-streaming)
+                 (lambda (&rest _args)
+                   (ert-fail "Unexpected request during compaction"))))
+        (should-error
+         (ellama-stream "new request" :session session)
+         :type 'user-error))
+      (should-not
+       (member "new request"
+               (mapcar #'llm-chat-prompt-interaction-content
+                       (llm-chat-prompt-interactions prompt)))))))
 
 (defun ellama-test--compact-session (provider)
   "Return test session with PROVIDER and compactable history."


### PR DESCRIPTION
## Summary
- reject new requests for a session while generation or compaction is already active
- clear request state before running completion callbacks so chained requests can continue
- document the duplicate request guard in README/NEWS and refresh the Info manual

## Tests
- make build
- make test
- make check-compile-warnings
- make checkdocs
- make refill-readme
- make manual
- make refill-news