### PR TITLE
Add edit tool shell hooks

### DIFF
--- a/.codex/hooks/post-edit.sh
+++ b/.codex/hooks/post-edit.sh
@@ -1,0 +1,41 @@
+#!/bin/sh
+set -eu
+
+file=${ELLAMA_FILE_NAME:-}
+
+if [ -z "$file" ]; then
+	printf '%s\n' "Missing ELLAMA_FILE_NAME for edit hook."
+	exit 1
+fi
+
+case "$file" in
+	"$PWD"/*) rel=${file#"$PWD"/} ;;
+	*) rel=$file ;;
+esac
+
+run_check() {
+	target=$1
+	output=$(mktemp)
+	if make "$target" >"$output" 2>&1; then
+		rm -f "$output"
+		printf '%s\n' "$target passed for $rel."
+	else
+		status=$?
+		printf '%s\n\n' "$target failed for $rel."
+		cat "$output"
+		rm -f "$output"
+		exit "$status"
+	fi
+}
+
+case "$rel" in
+	*.el)
+		run_check check-elisp
+		;;
+	README.org)
+		run_check check-readme
+		;;
+	NEWS.org)
+		run_check check-news
+		;;
+esac

--- a/.codex/hooks/pre-edit.sh
+++ b/.codex/hooks/pre-edit.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+set -eu
+
+branch=$(git symbolic-ref --quiet --short HEAD 2>/dev/null \
+	|| git rev-parse --short HEAD 2>/dev/null \
+	|| printf '%s' unknown)
+
+if [ "$branch" = "main" ]; then
+	cat <<'EOF'
+Edit blocked: current branch is main.
+
+Instruction: create and switch to a feature branch first, then retry the edit.
+Suggested command: git switch -c <branch-name>
+EOF
+	exit 1
+fi

--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,0 +1,5 @@
+((nil . ((ellama-tools-edit-before-shell-commands
+          . ((:command ".codex/hooks/pre-edit.sh")))
+         (ellama-tools-edit-after-shell-commands
+          . ((:command ".codex/hooks/post-edit.sh"
+             :show-output t))))))

--- a/.github/workflows/melpa.yml
+++ b/.github/workflows/melpa.yml
@@ -35,7 +35,7 @@ jobs:
         check:
           - melpa
         file:
-          - '*.el'
+          - 'ellama*.el'
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       - uses: actions/checkout@v4

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,82 +1,43 @@
 # AGENTS.md – Agentic Coding Quick Reference
 
-## Build / Lint / Test
+## Automated Edit Hooks
 
-1. **Build**: `make build`
-2. **Run unit tests** (ERT): `make test`
-		If it fails, run `make test-detailed` to see fail reasons.
-3. **Check native compilation warnings**: `make check-compile-warnings`
-4. **Check docstrings and style docs**: `make checkdocs`
-5. **Format Elisp files**: `make format-elisp`
-6. **Export manual**: `make manual`
-7. **Refill readme**: `make refill-readme`
+Project-local edit hooks are configured in `.dir-locals.el` and implemented in
+`.codex/hooks/`.
 
-Before committing changes, run all make targets appropriate for the changed
-files:
+- The pre-edit hook blocks edits on `main`; create and switch to a feature
+  branch before retrying.
+- The post-edit hook runs the relevant project checks for changed Elisp and
+  Org files.  Follow the hook output when a check fails.
 
-- Always run `make build`, `make test`, `make check-compile-warnings`, and
-  `make checkdocs` for Elisp changes.
-- Run `make format-elisp` when formatting changed Elisp files.
-- Run `make refill-readme` after changing `README.org`.
-- Run `make manual` after changing `README.org` or manual generation code.
-- Run `make refill-news` after changing `NEWS.org`.
-- Run specialized integration targets when touching their area, for example
-  `make test-srt-integration` or `make test-srt-integration-linux` for SRT
-  integration changes.
+## Git Workflow
 
 After making changes and before committing, use the project-local
 `commit-message` skill to write the commit message from the final diff:
 `.codex/skills/commit-message/SKILL.md`.
 
-## Git Workflow
-
-1. Check the current branch before starting work. If it is `main`, create a
-   new branch before making changes.
-2. Observe the code and plan the change. Ask the user for explanations when the
-   requested behavior, release scope, or expected workflow is unclear.
-3. Make the requested changes.
-4. Run all appropriate checks from the Build / Lint / Test section.
-5. Fix any findings and rerun the relevant checks. Repeat until the checks pass.
-6. Commit the implementation using the project-local `commit-message` skill,
-   then push the branch.
-7. Continue with additional implementation/check/fix/commit/push iterations
-   when the task requires more work.
-8. Update documentation after the implementation is stable.
-9. Generate the changelog using the project-local `changelog` skill, update the
-   version in `ellama.el`, commit those generated release changes with the
-   exact commit message `Bump version`, and push.
+For release work, use the project-local `changelog` skill, update the version in
+`ellama.el`, commit generated release changes with the exact commit message
+`Bump version`, and push.
 
 ## Code Style Guidelines
 
-- **Imports**: Keep `require`s grouped at the file top.
-- **Formatting**: Use 2‑space indentation, no trailing whitespace, line length ≤80 chars.
-- **Types**: Prefer symbols (`'my-symbol`) and strings; keyword arguments for optional params.
-- **Naming**: Use `kebab-case`, all symbols in a package should be prefixed with
-  `ellama-`, in subpackages `ellama-{subpackage}-`, e.g. `ellama-blueprint-`.
-	  - In `ellama-tools.el` in tool spec use `snake_case`.
-- **Error handling**: Wrap risky calls in `(condition-case err ...)` and signal with `(error "msg")` when appropriate.
-- **Docstrings**: One‑line summary, then optional details; keep under 80 chars
-  per line. Do not add empty lines. If there are multiple sentences on one line,
-  sentences should be separated by two spaces.
-  Use base verb form in function docstrings (no `-s`), e.g. `contain` not
-  `contains`, `return` not `returns`.
-- **Comments**: Prefix with `;;` for buffer comments; avoid inline `#` clutter.
+- Keep `require`s grouped at the file top.
+- Use 2-space indentation, no trailing whitespace, line length <= 80 chars.
+- Prefer symbols (`'my-symbol`) and strings; keyword arguments for optional
+  params.
+- Use `kebab-case`; symbols should be prefixed with `ellama-`, or
+  `ellama-{subpackage}-` in subpackages.  In `ellama-tools.el` tool specs use
+  `snake_case`.
+- Wrap risky calls in `(condition-case err ...)` and signal with `(error "msg")`
+  when appropriate.
+- Function docstrings use base verb form, for example `contain` and `return`.
+- Comments use `;;` for buffer comments.
 
 ## Operation Guidelines
 
 1. ALWAYS use available tools to make user requested action. Carefully fill all
    required fields.
-2. Double quotes escaping:
-
-"maingame": {
-  "day1": {
-    "text1": "Tag 1",
-     "text2": "Heute startet unsere Rundreise \" Example text\". Jeden Tag wird ein neues Reiseziel angesteuert bis wir.</strong> "
-  }
-}
-
-Just one backslash (\) in front of quotes.
-
-3. ALWAYS use `oq` skill to see content of `.org` files (for example
-   ./README.org and ./NEWS.org) isntead of `read_file` tool. README.org and
-   NEWS.org are big enough, you NEED to use `oq` skill with it.
+2. Double quotes escaping: use one backslash (`\`) before quotes.
+3. ALWAYS use the `oq` skill to inspect `.org` files such as `README.org` and
+   `NEWS.org`; they are large enough that structure-first queries are required.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,37 +1,19 @@
 # AGENTS.md – Agentic Coding Quick Reference
 
-## Automated Edit Hooks
-
-Project-local edit hooks are configured in `.dir-locals.el` and implemented in
-`.codex/hooks/`.
-
-- The pre-edit hook blocks edits on `main`; create and switch to a feature
-  branch before retrying.
-- The post-edit hook runs the relevant project checks for changed Elisp and
-  Org files.  Follow the hook output when a check fails.
-
 ## Git Workflow
 
-After making changes and before committing, use the project-local
-`commit-message` skill to write the commit message from the final diff:
-`.codex/skills/commit-message/SKILL.md`.
+Before committing, use the project-local `commit-message` skill.
 
-For release work, use the project-local `changelog` skill, update the version in
-`ellama.el`, commit generated release changes with the exact commit message
-`Bump version`, and push.
+For release work, use the project-local `changelog` skill.
 
 ## Code Style Guidelines
 
 - Keep `require`s grouped at the file top.
-- Use 2-space indentation, no trailing whitespace, line length <= 80 chars.
-- Prefer symbols (`'my-symbol`) and strings; keyword arguments for optional
-  params.
 - Use `kebab-case`; symbols should be prefixed with `ellama-`, or
   `ellama-{subpackage}-` in subpackages.  In `ellama-tools.el` tool specs use
   `snake_case`.
 - Wrap risky calls in `(condition-case err ...)` and signal with `(error "msg")`
   when appropriate.
-- Function docstrings use base verb form, for example `contain` and `return`.
 - Comments use `;;` for buffer comments.
 
 ## Operation Guidelines

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Makefile for ellama project
 
-.PHONY: build test test-detailed test-integration test-srt-integration docker-build-srt-parity test-srt-integration-linux check-compile-warnings checkdocs manual format-elisp refill-news refill-readme
+.PHONY: build test test-detailed test-integration test-srt-integration docker-build-srt-parity test-srt-integration-linux check-compile-warnings checkdocs manual format-elisp refill-news refill-readme check-elisp check-readme check-news
 
 SRT_PARITY_DOCKER_IMAGE ?= ellama-srt-parity:latest
 SRT_PARITY_DOCKERFILE ?= docker/srt-parity-linux.Dockerfile
@@ -120,3 +120,9 @@ refill-news:
 
 refill-readme:
 	emacs -batch --eval $(subst FILE,./README.org,$(refill-org))
+
+check-elisp: format-elisp build test check-compile-warnings checkdocs
+
+check-readme: refill-readme manual
+
+check-news: refill-news

--- a/NEWS.org
+++ b/NEWS.org
@@ -1,3 +1,9 @@
+* Version 1.21.0
+- Added project-local before and after shell hook support around mutating edit tools, including per-hook output visibility, failure reporting, hook environment context, and independent sectioned output budgets.
+- Added root .codex hook scripts and ~.dir-locals.el~ configuration so edit tools block writes on main and run file-specific checks after edits. Added aggregate Makefile targets for Elisp, README, and NEWS validation.
+- Updated ~grep~ and ~grep_in_file~ to pass ~-i~ unless ~case_sensitive~ is explicitly set.
+- Removed hook details, skill paths, and automatically checked style guidance from AGENTS.md. Moved release-specific changelog workflow details into the project-local changelog skill.
+- Changed the MELPA CI glob from all top-level .el files to ~ellama*.el~ so ~.dir-locals.el~ is not loaded as a package source file.
 * Version 1.20.0
 - Add ~balanced-edit~ evaluation profile to validate edits in real Emacs
   buffers.

--- a/README.org
+++ b/README.org
@@ -438,6 +438,10 @@ generated text string.
 - ~ellama-tools-read-file-default-mode~: Default mode for the ~read_file~
   tool. Use ~auto~ to read text files as text and supported image files as
   media, ~text~ to force text reading, or ~image~ to force image handling.
+- ~ellama-tools-edit-before-shell-commands~: Shell hook plists to run before
+  mutating edit tools write files.
+- ~ellama-tools-edit-after-shell-commands~: Shell hook plists to run after
+  mutating edit tools write files.
 - ~ellama-tools-use-srt~: Run shell-based tools (~shell_command~, ~grep~ and
   ~grep_in_file~) via the external ~srt~ sandbox runtime. Disabled by default.
   If enabled, non-shell file tools also perform local filesystem checks derived
@@ -653,6 +657,46 @@ Template resolution is intentionally scoped:
 
 This keeps large prompts out of the main agent context while still letting
 skills bundle reusable task prompts next to their ~SKILL.md~ files.
+
+** Edit Tool Shell Hooks
+
+Projects can define shell commands that run around mutating edit tools:
+~write_file~, ~append_file~, ~prepend_file~ and ~edit_file~.  Hooks are read
+from the target file buffer, so project-local values from ~.dir-locals.el~
+apply to the file being edited.
+
+Each hook entry is a plist with a required ~:command~ string.  A non-zero exit
+status is always returned to the agent.  Successful hook output is returned
+only when that hook has ~:show-output t~ and produced non-empty output.
+
+Before hooks run after access checks and syntax validation, but before the file
+is written.  A failing before hook blocks the edit.  After hooks run after a
+successful write; failure is reported to the agent and does not roll back the
+edit.
+
+Example project-local configuration:
+
+#+BEGIN_SRC emacs-lisp
+  ((nil . ((ellama-tools-edit-before-shell-commands
+            . ((:command "git diff --quiet")))
+           (ellama-tools-edit-after-shell-commands
+            . ((:command "make format-elisp" :show-output t)
+               (:command "make test"))))))
+#+END_SRC
+
+Hook commands run from the target file's project root, or from the file
+directory when no project is found.  The command environment includes:
+
+- ~ELLAMA_HOOK_PHASE~: ~before~ or ~after~
+- ~ELLAMA_EDIT_OPERATION~: ~write~, ~append~, ~prepend~ or ~edit~
+- ~ELLAMA_TOOL_NAME~: tool name such as ~write_file~
+- ~ELLAMA_FILE_NAME~: absolute target file name
+- ~ELLAMA_PROJECT_ROOT~: directory used as hook working directory
+- ~ELLAMA_HOOK_NAME~: optional ~:name~ value
+
+Hook diagnostics use their own output line budget instead of sharing one limit
+with the main tool result.  Hook output is operational feedback and is not
+scanned by tool output DLP.
 
 ** DLP for Tool Input/Output
 

--- a/ellama-eval.el
+++ b/ellama-eval.el
@@ -363,16 +363,22 @@ in one short sentence."
       #'ellama-tools-grep-tool
       '((:name "dir" :type string :description "Directory to search in.")
         (:name "search_string" :type string
-               :description "String to search for."))
-      "Grep SEARCH-STRING in directory files."))
+               :description "String to search for.")
+        (:name "case_sensitive" :type boolean :optional t
+               :description
+               "When non-nil, match case sensitively. Defaults to false."))
+      "Grep SEARCH-STRING in directory files. Case-insensitive by default."))
     ("grep_in_file"
      (ellama-eval--tool-spec
       "grep_in_file"
       #'ellama-tools-grep-in-file-tool
       '((:name "search_string" :type string
                :description "String to search for.")
-        (:name "file" :type string :description "File to search in."))
-      "Grep SEARCH-STRING in FILE."))
+        (:name "file" :type string :description "File to search in.")
+        (:name "case_sensitive" :type boolean :optional t
+               :description
+               "When non-nil, match case sensitively. Defaults to false."))
+      "Grep SEARCH-STRING in FILE. Case-insensitive by default."))
     ("directory_tree"
      (ellama-eval--tool-spec
       "directory_tree"

--- a/ellama-tools.el
+++ b/ellama-tools.el
@@ -127,6 +127,26 @@ prose that happens to contain unmatched delimiter characters."
   :type '(repeat symbol)
   :group 'ellama)
 
+(defcustom ellama-tools-edit-before-shell-commands nil
+  "Project-local shell commands to run before edit tools mutate files.
+Each entry must be a plist with a required `:command' string.  When
+`:show-output' is non-nil, successful hook output is returned to the agent.
+Failing hooks are always returned to the agent and block the edit."
+  :type '(repeat (plist :options ((:command string)
+                                  (:show-output boolean)
+                                  (:name string))))
+  :group 'ellama)
+
+(defcustom ellama-tools-edit-after-shell-commands nil
+  "Project-local shell commands to run after edit tools mutate files.
+Each entry must be a plist with a required `:command' string.  When
+`:show-output' is non-nil, successful hook output is returned to the agent.
+Failing hooks are always returned to the agent and do not roll back the edit."
+  :type '(repeat (plist :options ((:command string)
+                                  (:show-output boolean)
+                                  (:name string))))
+  :group 'ellama)
+
 (defcustom ellama-tools-use-srt nil
   "Run shell-based tools via `srt'.
 When non-nil, `shell_command', `grep' and `grep_in_file' run inside the
@@ -196,6 +216,10 @@ The guard applies before output is sent back to the LLM."
   "Save full overflowing output to a temp file when source is unknown."
   :type 'boolean
   :group 'ellama)
+
+(defconst ellama-tools--output-sections-property
+  'ellama-tools-output-sections
+  "Text property storing independently processed output sections.")
 
 (defcustom ellama-tools-subagent-continue-prompt "Task not marked complete. Continue working. If you are done, YOU MUST use the `report_result` tool."
   "Prompt sent to sub-agent to keep the loop going."
@@ -694,6 +718,76 @@ TOOL-METADATA may provide tool identity details for DLP scans."
     (ellama-tools--apply-output-line-budget
      tool-name dlp-filtered output-context)))
 
+(defun ellama-tools--make-output-section
+    (kind text &optional scan-output output-context)
+  "Return output section plist with KIND and TEXT.
+SCAN-OUTPUT controls whether DLP scan is applied to the section.
+OUTPUT-CONTEXT controls line-budget source notices."
+  (list :kind kind
+        :text text
+        :scan-output scan-output
+        :output-context output-context))
+
+(defun ellama-tools--sectioned-output (sections)
+  "Return a string containing independently processed SECTIONS.
+SECTIONS are stored as a text property for the output wrapper."
+  (let* ((texts (delq nil
+                      (mapcar (lambda (section)
+                                (let ((text (plist-get section :text)))
+                                  (and (stringp text)
+                                       (not (string-empty-p text))
+                                       text)))
+                              sections)))
+         (text (string-join texts "\n\n")))
+    (when (> (length text) 0)
+      (put-text-property
+       0 (length text) ellama-tools--output-sections-property sections text))
+    text))
+
+(defun ellama-tools--output-sections (text)
+  "Return output sections stored on TEXT, or nil."
+  (and (stringp text)
+       (> (length text) 0)
+       (get-text-property 0 ellama-tools--output-sections-property text)))
+
+(defun ellama-tools--postprocess-output-section
+    (tool-name section &optional tool-metadata)
+  "Apply output guards to SECTION for TOOL-NAME.
+TOOL-METADATA may provide tool identity details for DLP scans."
+  (let* ((kind (or (plist-get section :kind) 'section))
+         (text (or (plist-get section :text) ""))
+         (scan-output (plist-get section :scan-output))
+         (output-context (plist-get section :output-context))
+         (section-tool-name (format "%s/%s" tool-name kind))
+         (dlp-filtered
+          (if (and scan-output ellama-tools-dlp-enabled)
+              (ellama-tools--dlp-handle-output-string
+               section-tool-name text tool-metadata)
+            text)))
+    (ellama-tools--apply-output-line-budget
+     section-tool-name dlp-filtered output-context)))
+
+(defun ellama-tools--postprocess-output-sections
+    (tool-name sections &optional tool-metadata)
+  "Apply output guards to SECTIONS for TOOL-NAME independently."
+  (string-join
+   (mapcar (lambda (section)
+             (ellama-tools--postprocess-output-section
+              tool-name section tool-metadata))
+           sections)
+   "\n\n"))
+
+(defun ellama-tools--postprocess-output-result
+    (tool-name result &optional output-context tool-metadata)
+  "Apply output guards to RESULT for TOOL-NAME.
+Sectioned strings are processed section by section.  Plain strings keep the
+historical single-budget behavior."
+  (if-let* ((sections (ellama-tools--output-sections result)))
+      (ellama-tools--postprocess-output-sections
+       tool-name sections tool-metadata)
+    (ellama-tools--postprocess-output-string
+     tool-name result output-context tool-metadata)))
+
 (defconst ellama-tools--dlp-input-max-walk-depth 24
   "Maximum nested depth traversed when scanning structured tool inputs.")
 
@@ -1078,7 +1172,7 @@ Return one of symbols `allow', `redact' or `block'."
   (lambda (result)
     (funcall callback
              (if (stringp result)
-                 (ellama-tools--postprocess-output-string
+                 (ellama-tools--postprocess-output-result
                   tool-name result output-context tool-metadata)
                result))))
 
@@ -1110,7 +1204,7 @@ return nil."
         (if (not ellama-tools-dlp-enabled)
             (let ((result (apply func wrapped-args)))
               (if (and (not async) (stringp result))
-                  (ellama-tools--postprocess-output-string
+                  (ellama-tools--postprocess-output-result
                    tool-name result output-context tool-metadata)
                 result))
           (let* ((decision (ellama-tools--dlp-input-decision
@@ -1136,7 +1230,7 @@ return nil."
                                   tool-name))
                        (let ((result (apply func wrapped-args)))
                          (if (and (not async) (stringp result))
-                             (ellama-tools--postprocess-output-string
+                             (ellama-tools--postprocess-output-result
                               tool-name result output-context tool-metadata)
                            result))))
                  (ellama-tools--dlp-return-message
@@ -1151,7 +1245,7 @@ return nil."
                             tool-name))
                  (let ((result (apply func wrapped-args)))
                    (if (and (not async) (stringp result))
-                       (ellama-tools--postprocess-output-string
+                       (ellama-tools--postprocess-output-result
                         tool-name result output-context tool-metadata)
                      result))))
               ('warn-strong
@@ -1168,13 +1262,13 @@ return nil."
                               tool-name))
                    (let ((result (apply func wrapped-args)))
                      (if (and (not async) (stringp result))
-                         (ellama-tools--postprocess-output-string
+                         (ellama-tools--postprocess-output-result
                           tool-name result output-context tool-metadata)
                        result)))))
               (_
                (let ((result (apply func wrapped-args)))
                  (if (and (not async) (stringp result))
-                     (ellama-tools--postprocess-output-string
+                     (ellama-tools--postprocess-output-result
                       tool-name result output-context tool-metadata)
                    result))))))))))
 
@@ -2077,6 +2171,201 @@ ORIGINAL, OLD-FRAGMENT and NEW-FRAGMENT provide optional diagnostic context."
       " after syntax validation"
     ""))
 
+(defun ellama-tools--edit-shell-hooks-buffer (file-name)
+  "Return buffer used to read edit shell hooks for FILE-NAME."
+  (find-file-noselect file-name))
+
+(defun ellama-tools--edit-shell-hooks-for-file (file-name phase)
+  "Return configured edit shell hooks for FILE-NAME and PHASE."
+  (with-current-buffer (ellama-tools--edit-shell-hooks-buffer file-name)
+    (if (eq phase 'before)
+        ellama-tools-edit-before-shell-commands
+      ellama-tools-edit-after-shell-commands)))
+
+(defun ellama-tools--edit-project-root (file-name)
+  "Return project root used for edit shell hooks on FILE-NAME."
+  (let* ((expanded (expand-file-name file-name))
+         (dir (or (file-name-directory expanded) default-directory))
+         (default-directory (file-name-as-directory dir)))
+    (if-let* ((project (project-current nil)))
+        (project-root project)
+      default-directory)))
+
+(defun ellama-tools--edit-shell-hook-normalize (spec)
+  "Return normalized edit shell hook SPEC."
+  (cond
+   ((stringp spec)
+    (list :command spec :show-output nil))
+   ((and (plistp spec)
+         (stringp (plist-get spec :command)))
+    spec)
+   (t
+    (list :error
+          (format "Invalid edit shell hook configuration: %S" spec)))))
+
+(defun ellama-tools--edit-shell-hook-env
+    (phase file-name operation tool-name root spec)
+  "Return process environment for edit shell hook SPEC.
+PHASE is `before' or `after'.  FILE-NAME, OPERATION, TOOL-NAME and ROOT
+describe the edit."
+  (append
+   (list
+    (format "ELLAMA_HOOK_PHASE=%s" phase)
+    (format "ELLAMA_EDIT_OPERATION=%s" operation)
+    (format "ELLAMA_TOOL_NAME=%s" tool-name)
+    (format "ELLAMA_FILE_NAME=%s" (expand-file-name file-name))
+    (format "ELLAMA_PROJECT_ROOT=%s" root)
+    (format "ELLAMA_HOOK_NAME=%s" (or (plist-get spec :name) "")))
+   process-environment))
+
+(defun ellama-tools--run-edit-shell-hook
+    (phase file-name operation tool-name spec)
+  "Run edit shell hook SPEC for PHASE and FILE-NAME.
+OPERATION and TOOL-NAME describe the edit.  Return result plist."
+  (let* ((hook (ellama-tools--edit-shell-hook-normalize spec))
+         (command (plist-get hook :command))
+         (error-message (plist-get hook :error))
+         (root (ellama-tools--edit-project-root file-name)))
+    (if error-message
+        (list :phase phase
+              :status 1
+              :output error-message
+              :show-output t)
+      (let* ((default-directory (file-name-as-directory root))
+             (process-environment
+              (ellama-tools--edit-shell-hook-env
+               phase file-name operation tool-name root hook))
+             (argv (ellama-tools--command-argv
+                    shell-file-name
+                    shell-command-switch
+                    (concat "exec 2>&1; " command)))
+             status
+             output)
+        (condition-case err
+            (with-temp-buffer
+              (setq status
+                    (apply #'call-process
+                           (car argv) nil t nil (cdr argv)))
+              (setq output
+                    (string-trim-right (buffer-string) "\n")))
+          (error
+           (setq status 1)
+           (setq output
+                 (format "Failed to run edit shell hook: %s"
+                         (error-message-string err)))))
+        (list :phase phase
+              :command command
+              :name (plist-get hook :name)
+              :status status
+              :output output
+              :show-output (plist-get hook :show-output))))))
+
+(defun ellama-tools--edit-shell-hook-failed-p (result)
+  "Return non-nil when edit shell hook RESULT fail."
+  (not (equal (plist-get result :status) 0)))
+
+(defun ellama-tools--format-edit-shell-hook-result (result)
+  "Return user-facing text for edit shell hook RESULT."
+  (let* ((phase (if (eq (plist-get result :phase) 'before)
+                    "Before"
+                  "After"))
+         (name (plist-get result :name))
+         (command (plist-get result :command))
+         (status (plist-get result :status))
+         (output (or (plist-get result :output) ""))
+         (failed-p (ellama-tools--edit-shell-hook-failed-p result))
+         (subject (if (and (stringp name) (not (string-empty-p name)))
+                      (format "%s edit hook `%s`" phase name)
+                    (format "%s edit hook" phase))))
+    (string-join
+     (delq nil
+           (list
+            (if failed-p
+                (format "%s failed with exit status %s:" subject status)
+              (format "%s completed:" subject))
+            (when command
+              (format "Command: %s" command))
+            (unless (string-empty-p output)
+              output)))
+     "\n\n")))
+
+(defun ellama-tools--edit-shell-hook-visible-p (result)
+  "Return non-nil when edit shell hook RESULT should be returned."
+  (or (ellama-tools--edit-shell-hook-failed-p result)
+      (and (plist-get result :show-output)
+           (not (string-empty-p (or (plist-get result :output) ""))))))
+
+(defun ellama-tools--edit-shell-hook-section (_tool-name result)
+  "Return output section for edit shell hook RESULT."
+  (ellama-tools--make-output-section
+   (if (eq (plist-get result :phase) 'before)
+       'edit-before-hook
+     'edit-after-hook)
+   (ellama-tools--format-edit-shell-hook-result result)
+   nil))
+
+(defun ellama-tools--run-edit-shell-hooks
+    (phase file-name operation tool-name)
+  "Run edit shell hooks for PHASE and FILE-NAME.
+OPERATION and TOOL-NAME describe the edit.  Before hooks stop on the first
+failure.  After hooks run all commands."
+  (let ((hooks (ellama-tools--edit-shell-hooks-for-file file-name phase))
+        sections
+        failed)
+    (catch 'blocked
+      (dolist (hook hooks)
+        (let ((result (ellama-tools--run-edit-shell-hook
+                       phase file-name operation tool-name hook)))
+          (when (ellama-tools--edit-shell-hook-visible-p result)
+            (push (ellama-tools--edit-shell-hook-section tool-name result)
+                  sections))
+          (when (ellama-tools--edit-shell-hook-failed-p result)
+            (setq failed t)
+            (when (eq phase 'before)
+              (throw 'blocked nil))))))
+    (list :failed failed :sections (nreverse sections))))
+
+(defun ellama-tools--refresh-file-buffer-after-hooks (file-name)
+  "Refresh unmodified visiting buffer for FILE-NAME after shell hooks."
+  (let ((expanded (expand-file-name file-name)))
+    (when-let* ((buffer (get-file-buffer expanded)))
+      (with-current-buffer buffer
+        (when (and (not (buffer-modified-p))
+                   (file-exists-p expanded))
+          (revert-buffer t t t))))))
+
+(defun ellama-tools--edit-output
+    (main-message before-sections after-sections)
+  "Return edit output with MAIN-MESSAGE and hook sections.
+BEFORE-SECTIONS and AFTER-SECTIONS are visible shell hook output sections."
+  (let ((sections
+         (append
+          before-sections
+          (list (ellama-tools--make-output-section
+                 'tool-result main-message t))
+          after-sections)))
+    (if (or before-sections after-sections)
+        (ellama-tools--sectioned-output sections)
+      main-message)))
+
+(defun ellama-tools--run-edit-with-shell-hooks
+    (tool-name operation file-name edit-fn success-message)
+  "Run edit shell hooks around EDIT-FN for FILE-NAME.
+TOOL-NAME and OPERATION describe the edit.  SUCCESS-MESSAGE is returned on
+successful edit, optionally combined with visible hook output."
+  (let* ((before (ellama-tools--run-edit-shell-hooks
+                  'before file-name operation tool-name))
+         (before-sections (plist-get before :sections)))
+    (if (plist-get before :failed)
+        (ellama-tools--sectioned-output before-sections)
+      (funcall edit-fn)
+      (let* ((after (ellama-tools--run-edit-shell-hooks
+                     'after file-name operation tool-name))
+             (after-sections (plist-get after :sections)))
+        (ellama-tools--refresh-file-buffer-after-hooks file-name)
+        (ellama-tools--edit-output
+         success-message before-sections after-sections)))))
+
 (defun ellama-tools--current-file-content (file-name)
   "Return current FILE-NAME content, or an empty string when missing.
 Prefer an existing visiting buffer so append and prepend preserve unsaved
@@ -2105,12 +2394,15 @@ buffer contents, matching their historical behavior."
                  (rejection (plist-get decision :rejection)))
             (if rejection
                 rejection
-              (ellama-tools--write-file-buffer-content file-name content)
-              (format "Wrote %d characters to %s%s."
-                      (length content)
-                      file-name
-                      (ellama-tools--balanced-edit-success-suffix
-                       decision))))
+              (ellama-tools--run-edit-with-shell-hooks
+               "write_file" "write" file-name
+               (lambda ()
+                 (ellama-tools--write-file-buffer-content file-name content))
+               (format "Wrote %d characters to %s%s."
+                       (length content)
+                       file-name
+                       (ellama-tools--balanced-edit-success-suffix
+                        decision)))))
         (file-error
          (format "Cannot write %s: %s"
                  file-name
@@ -2152,12 +2444,15 @@ buffer contents, matching their historical behavior."
                  (rejection (plist-get decision :rejection)))
             (if rejection
                 rejection
-              (ellama-tools--write-file-buffer-content file-name candidate)
-              (format "Appended %d characters to %s%s."
-                      (length content)
-                      file-name
-                      (ellama-tools--balanced-edit-success-suffix
-                       decision))))
+              (ellama-tools--run-edit-with-shell-hooks
+               "append_file" "append" file-name
+               (lambda ()
+                 (ellama-tools--write-file-buffer-content file-name candidate))
+               (format "Appended %d characters to %s%s."
+                       (length content)
+                       file-name
+                       (ellama-tools--balanced-edit-success-suffix
+                        decision)))))
         (file-error
          (format "Cannot append to %s: %s"
                  file-name
@@ -2199,12 +2494,15 @@ buffer contents, matching their historical behavior."
                  (rejection (plist-get decision :rejection)))
             (if rejection
                 rejection
-              (ellama-tools--write-file-buffer-content file-name candidate)
-              (format "Prepended %d characters to %s%s."
-                      (length content)
-                      file-name
-                      (ellama-tools--balanced-edit-success-suffix
-                       decision))))
+              (ellama-tools--run-edit-with-shell-hooks
+               "prepend_file" "prepend" file-name
+               (lambda ()
+                 (ellama-tools--write-file-buffer-content file-name candidate))
+               (format "Prepended %d characters to %s%s."
+                       (length content)
+                       file-name
+                       (ellama-tools--balanced-edit-success-suffix
+                        decision)))))
         (file-error
          (format "Cannot prepend to %s: %s"
                  file-name
@@ -2359,12 +2657,15 @@ Replace OLDCONTENT with NEWCONTENT."
                  (rejection (plist-get decision :rejection)))
             (if rejection
                 rejection
-              (ellama-tools--write-file-buffer-content
-               file-name candidate)
-              (format "Edited %s%s."
-                      file-name
-                      (ellama-tools--balanced-edit-success-suffix
-                       decision))))))))
+              (ellama-tools--run-edit-with-shell-hooks
+               "edit_file" "edit" file-name
+               (lambda ()
+                 (ellama-tools--write-file-buffer-content
+                  file-name candidate))
+               (format "Edited %s%s."
+                       file-name
+                       (ellama-tools--balanced-edit-success-suffix
+                        decision)))))))))
 
 (ellama-tools-define-tool
  '(:function

--- a/ellama-tools.el
+++ b/ellama-tools.el
@@ -2756,8 +2756,14 @@ CALLBACK – function called once with the result string."
    :description
    "Execute shell command CMD."))
 
-(defun ellama-tools-grep-tool (dir search-string)
-  "Grep SEARCH-STRING in DIR files."
+(defun ellama-tools--grep-case-args (case-sensitive)
+  "Return grep arguments for CASE-SENSITIVE matching."
+  (unless case-sensitive
+    '("-i")))
+
+(defun ellama-tools-grep-tool (dir search-string &optional case-sensitive)
+  "Grep SEARCH-STRING in DIR files.
+Match case-insensitively unless CASE-SENSITIVE is non-nil."
   (let ((search-dir (expand-file-name dir)))
     (json-encode
      (cond
@@ -2768,9 +2774,12 @@ CALLBACK – function called once with the result string."
       (t
        (let ((default-directory (file-name-as-directory search-dir)))
          (ellama-tools--grep-output
-          (ellama-tools--call-command
-           "find" "." "-type" "f" "-exec"
-           "grep" "--color=never" "-nH" "-e" search-string "{}" "+")
+          (apply
+           #'ellama-tools--call-command
+           (append
+            (list "find" "." "-type" "f" "-exec" "grep" "--color=never")
+            (ellama-tools--grep-case-args case-sensitive)
+            (list "-nH" "-e" search-string "{}" "+")))
           (format "No matches for %S in %s."
                   search-string
                   search-dir))))))))
@@ -2792,12 +2801,22 @@ CALLBACK – function called once with the result string."
      :type
      string
      :description
-     "String to search for."))
+     "String to search for.")
+    (:name
+     "case_sensitive"
+     :type
+     boolean
+     :optional
+     t
+     :description
+     "When non-nil, match case sensitively. Defaults to false."))
    :description
-   "Grep SEARCH-STRING in directory files."))
+   "Grep SEARCH-STRING in directory files. Case-insensitive by default."))
 
-(defun ellama-tools-grep-in-file-tool (search-string file)
-  "Grep SEARCH-STRING in FILE."
+(defun ellama-tools-grep-in-file-tool (search-string file
+                                                     &optional case-sensitive)
+  "Grep SEARCH-STRING in FILE.
+Match case-insensitively unless CASE-SENSITIVE is non-nil."
   (or (ellama-tools--tool-check-file-access file 'read)
       (json-encode
        (cond
@@ -2808,8 +2827,12 @@ CALLBACK – function called once with the result string."
         (t
          (let ((truename (file-truename file)))
            (ellama-tools--grep-output
-            (ellama-tools--call-command
-             "grep" "--color=never" "-nh" search-string truename)
+            (apply
+             #'ellama-tools--call-command
+             (append
+              (list "grep" "--color=never")
+              (ellama-tools--grep-case-args case-sensitive)
+              (list "-nh" search-string truename)))
             (format "No matches for %S in %s."
                     search-string truename))))))))
 
@@ -2817,9 +2840,13 @@ CALLBACK – function called once with the result string."
  '(:function
    ellama-tools-grep-in-file-tool
    :name "grep_in_file"
-   :args ((:name "search_string" :type string :description "String to search for.")
-          (:name "file" :type string :description "File to search in."))
-   :description "Grep SEARCH-STRING in FILE."))
+   :args ((:name "search_string" :type string
+                 :description "String to search for.")
+          (:name "file" :type string :description "File to search in.")
+          (:name "case_sensitive" :type boolean :optional t
+                 :description
+                 "When non-nil, match case sensitively. Defaults to false."))
+   :description "Grep SEARCH-STRING in FILE. Case-insensitive by default."))
 
 (defun ellama-tools-now-tool ()
   "Return current date, time and timezone."

--- a/ellama.el
+++ b/ellama.el
@@ -6,7 +6,7 @@
 ;; URL: http://github.com/s-kostyaev/ellama
 ;; Keywords: help local tools
 ;; Package-Requires: ((emacs "28.1") (llm "0.30.2") (plz "0.8") (transient "0.7") (compat "29.1") (yaml "1.2.3"))
-;; Version: 1.20.0
+;; Version: 1.21.0
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;; Created: 8th Oct 2023
 

--- a/ellama.info
+++ b/ellama.info
@@ -79,6 +79,7 @@ Configuration
 * Session Compaction::
 * Image Input::
 * Task Tool Subagents::
+* Edit Tool Shell Hooks::
 * DLP for Tool Input/Output::
 * SRT Filesystem Policy for Tools::
 
@@ -588,6 +589,10 @@ argument generated text string.
      ‘read_file’ tool.  Use ‘auto’ to read text files as text and
      supported image files as media, ‘text’ to force text reading, or
      ‘image’ to force image handling.
+   • ‘ellama-tools-edit-before-shell-commands’: Shell hook plists to run
+     before mutating edit tools write files.
+   • ‘ellama-tools-edit-after-shell-commands’: Shell hook plists to run
+     after mutating edit tools write files.
    • ‘ellama-tools-use-srt’: Run shell-based tools (‘shell_command’,
      ‘grep’ and ‘grep_in_file’) via the external ‘srt’ sandbox runtime.
      Disabled by default.  If enabled, non-shell file tools also perform
@@ -640,6 +645,7 @@ argument generated text string.
 * Session Compaction::
 * Image Input::
 * Task Tool Subagents::
+* Edit Tool Shell Hooks::
 * DLP for Tool Input/Output::
 * SRT Filesystem Policy for Tools::
 
@@ -787,7 +793,7 @@ Tool calls can request image handling explicitly:
      }
 
 
-File: ellama.info,  Node: Task Tool Subagents,  Next: DLP for Tool Input/Output,  Prev: Image Input,  Up: Configuration
+File: ellama.info,  Node: Task Tool Subagents,  Next: Edit Tool Shell Hooks,  Prev: Image Input,  Up: Configuration
 
 4.4 Task Tool Subagents
 =======================
@@ -838,9 +844,52 @@ letting skills bundle reusable task prompts next to their ‘SKILL.md’
 files.
 
 
-File: ellama.info,  Node: DLP for Tool Input/Output,  Next: SRT Filesystem Policy for Tools,  Prev: Task Tool Subagents,  Up: Configuration
+File: ellama.info,  Node: Edit Tool Shell Hooks,  Next: DLP for Tool Input/Output,  Prev: Task Tool Subagents,  Up: Configuration
 
-4.5 DLP for Tool Input/Output
+4.5 Edit Tool Shell Hooks
+=========================
+
+Projects can define shell commands that run around mutating edit tools:
+‘write_file’, ‘append_file’, ‘prepend_file’ and ‘edit_file’.  Hooks are
+read from the target file buffer, so project-local values from
+‘.dir-locals.el’ apply to the file being edited.
+
+Each hook entry is a plist with a required ‘:command’ string.  A
+non-zero exit status is always returned to the agent.  Successful hook
+output is returned only when that hook has ‘:show-output t’ and produced
+non-empty output.
+
+Before hooks run after access checks and syntax validation, but before
+the file is written.  A failing before hook blocks the edit.  After
+hooks run after a successful write; failure is reported to the agent and
+does not roll back the edit.
+
+Example project-local configuration:
+
+     ((nil . ((ellama-tools-edit-before-shell-commands
+               . ((:command "git diff --quiet")))
+              (ellama-tools-edit-after-shell-commands
+               . ((:command "make format-elisp" :show-output t)
+                  (:command "make test"))))))
+
+Hook commands run from the target file's project root, or from the file
+directory when no project is found.  The command environment includes:
+
+   • ‘ELLAMA_HOOK_PHASE’: ‘before’ or ‘after’
+   • ‘ELLAMA_EDIT_OPERATION’: ‘write’, ‘append’, ‘prepend’ or ‘edit’
+   • ‘ELLAMA_TOOL_NAME’: tool name such as ‘write_file’
+   • ‘ELLAMA_FILE_NAME’: absolute target file name
+   • ‘ELLAMA_PROJECT_ROOT’: directory used as hook working directory
+   • ‘ELLAMA_HOOK_NAME’: optional ‘:name’ value
+
+Hook diagnostics use their own output line budget instead of sharing one
+limit with the main tool result.  Hook output is operational feedback
+and is not scanned by tool output DLP.
+
+
+File: ellama.info,  Node: DLP for Tool Input/Output,  Next: SRT Filesystem Policy for Tools,  Prev: Edit Tool Shell Hooks,  Up: Configuration
+
+4.6 DLP for Tool Input/Output
 =============================
 
 Ellama includes an optional DLP (Data Loss Prevention) layer for tool
@@ -1166,7 +1215,7 @@ Troubleshooting:
 
 File: ellama.info,  Node: SRT Filesystem Policy for Tools,  Prev: DLP for Tool Input/Output,  Up: Configuration
 
-4.6 SRT Filesystem Policy for Tools
+4.7 SRT Filesystem Policy for Tools
 ===================================
 
 When ‘ellama-tools-use-srt’ is non-nil, the ‘srt’ settings file is the
@@ -2406,47 +2455,48 @@ their use in free software.
 
 Tag Table:
 Node: Top1379
-Node: Installation3919
-Node: Commands8933
-Node: Keymap17562
-Node: Configuration20449
-Node: Session Provider Keys32489
-Node: Session Compaction34350
-Node: Image Input36644
-Node: Task Tool Subagents38789
-Node: DLP for Tool Input/Output40892
-Node: SRT Filesystem Policy for Tools55794
-Node: Context Management61463
-Node: Transient Menus for Context Management62531
-Node: Managing the Context64210
-Node: Considerations64985
-Node: Minor modes65578
-Node: ellama-context-header-line-mode67566
-Node: ellama-context-header-line-global-mode68391
-Node: ellama-context-mode-line-mode69111
-Node: ellama-context-mode-line-global-mode69959
-Node: Ellama Session Header Line Mode70663
-Node: Enabling and Disabling71232
-Node: Customization71679
-Node: Ellama Session Mode Line Mode71967
-Node: Enabling and Disabling (1)72552
-Node: Customization (1)72999
-Node: Using Blueprints73293
-Node: Key Components of Ellama Blueprints73933
-Node: Creating and Managing Blueprints74540
-Node: Blueprints files75518
-Node: Variable Management75939
-Node: Keymap and Mode76392
-Node: Transient Menus77328
-Node: Running Blueprints programmatically77874
-Node: MCP Integration78461
-Node: Agent Skills79696
-Node: Directory Structure80059
-Node: Creating a Skill81086
-Node: How it works81461
-Node: Acknowledgments81852
-Node: Contributions82563
-Node: GNU Free Documentation License82949
+Node: Installation3945
+Node: Commands8959
+Node: Keymap17588
+Node: Configuration20475
+Node: Session Provider Keys32787
+Node: Session Compaction34648
+Node: Image Input36942
+Node: Task Tool Subagents39087
+Node: Edit Tool Shell Hooks41186
+Node: DLP for Tool Input/Output43170
+Node: SRT Filesystem Policy for Tools58074
+Node: Context Management63743
+Node: Transient Menus for Context Management64811
+Node: Managing the Context66490
+Node: Considerations67265
+Node: Minor modes67858
+Node: ellama-context-header-line-mode69846
+Node: ellama-context-header-line-global-mode70671
+Node: ellama-context-mode-line-mode71391
+Node: ellama-context-mode-line-global-mode72239
+Node: Ellama Session Header Line Mode72943
+Node: Enabling and Disabling73512
+Node: Customization73959
+Node: Ellama Session Mode Line Mode74247
+Node: Enabling and Disabling (1)74832
+Node: Customization (1)75279
+Node: Using Blueprints75573
+Node: Key Components of Ellama Blueprints76213
+Node: Creating and Managing Blueprints76820
+Node: Blueprints files77798
+Node: Variable Management78219
+Node: Keymap and Mode78672
+Node: Transient Menus79608
+Node: Running Blueprints programmatically80154
+Node: MCP Integration80741
+Node: Agent Skills81976
+Node: Directory Structure82339
+Node: Creating a Skill83366
+Node: How it works83741
+Node: Acknowledgments84132
+Node: Contributions84843
+Node: GNU Free Documentation License85229
 
 End Tag Table
 

--- a/skills/changelog/SKILL.md
+++ b/skills/changelog/SKILL.md
@@ -5,17 +5,17 @@ description: Use this skill to generate changelog.
 
 # Generating changelog
 
-Call shell_command tool with "git --no-pager log --reverse main..HEAD" argument. Based on
-the output write changelog in org-mode list format. Use org quoting
+Call shell_command tool with "git --no-pager log --reverse main..HEAD" argument.
+Based on the output write changelog in org-mode list format. Use org quoting
 (~quoted-text~) instead of markdown quoting (`quoted-text`). Every changelog
 element should be ended with full stop. Changelog shouldn't be too short or too
 long, use detailed description for major changes and concise description for
 minor changes.
 
-Call shell_command tools with "git --no-pager tag -l --points-at=main" argument to see
-previously released version. Based on this information and minority/majority of
-the changes you can fill version variable. If you are not sure, ask the user
-using ask_user tool with your variants of the version.
+Call shell_command tools with "git --no-pager tag -l --points-at=main" argument
+to see previously released version. Based on this information and
+minority/majority of the changes you can fill version variable. If you are not
+sure, ask the user using ask_user tool with your variants of the version.
 
 Write it to ./NEWS.org using prepend_file tool
 with header:
@@ -35,3 +35,7 @@ Example:
 ```
 
 After all of that call shell_command tool with "make refill-news" argument.
+
+After generating the changelog, update the version in ellama.el, commit the
+generated release changes with the exact commit message "Bump version", and
+push.

--- a/skills/changelog/SKILL.md
+++ b/skills/changelog/SKILL.md
@@ -34,8 +34,6 @@ Example:
 - Some fix in ~ellama-example-command~ description.
 ```
 
-After all of that call shell_command tool with "make refill-news" argument.
-
 After generating the changelog, update the version in ellama.el, commit the
 generated release changes with the exact commit message "Bump version", and
 push.

--- a/tests/test-ellama-tools.el
+++ b/tests/test-ellama-tools.el
@@ -2085,6 +2085,144 @@ Return list with result and prompt."
       (when (file-exists-p file)
         (delete-file file)))))
 
+(ert-deftest test-ellama-tools-edit-after-hook-shows-enabled-output ()
+  (ellama-test--ensure-local-ellama-tools)
+  (let ((file (make-temp-file "ellama-after-hook-show-"))
+        (ellama-tools-edit-before-shell-commands nil)
+        (ellama-tools-edit-after-shell-commands
+         '((:command "printf after-ok" :show-output t))))
+    (unwind-protect
+        (let ((msg (ellama-tools-write-file-tool file "x")))
+          (should (string-match-p "Wrote 1 characters" msg))
+          (should (string-match-p "After edit hook completed" msg))
+          (should (string-match-p "after-ok" msg))
+          (with-temp-buffer
+            (insert-file-contents file)
+            (should (equal (buffer-string) "x"))))
+      (when-let* ((buffer (get-file-buffer file)))
+        (kill-buffer buffer))
+      (when (file-exists-p file)
+        (delete-file file)))))
+
+(ert-deftest test-ellama-tools-edit-after-hook-hides-success-by-default ()
+  (ellama-test--ensure-local-ellama-tools)
+  (let ((file (make-temp-file "ellama-after-hook-hide-"))
+        (ellama-tools-edit-before-shell-commands nil)
+        (ellama-tools-edit-after-shell-commands
+         '((:command "printf hidden"))))
+    (unwind-protect
+        (let ((msg (ellama-tools-write-file-tool file "x")))
+          (should (string-match-p "Wrote 1 characters" msg))
+          (should-not (string-match-p "After edit hook completed" msg))
+          (should-not (string-match-p "hidden" msg)))
+      (when-let* ((buffer (get-file-buffer file)))
+        (kill-buffer buffer))
+      (when (file-exists-p file)
+        (delete-file file)))))
+
+(ert-deftest test-ellama-tools-edit-after-hook-failure-keeps-edit ()
+  (ellama-test--ensure-local-ellama-tools)
+  (let ((file (make-temp-file "ellama-after-hook-fail-"))
+        (ellama-tools-edit-before-shell-commands nil)
+        (ellama-tools-edit-after-shell-commands
+         '((:command "printf after-fail; exit 3"))))
+    (unwind-protect
+        (let ((msg (ellama-tools-write-file-tool file "x")))
+          (should (string-match-p "Wrote 1 characters" msg))
+          (should (string-match-p
+                   "After edit hook failed with exit status 3" msg))
+          (should (string-match-p "after-fail" msg))
+          (with-temp-buffer
+            (insert-file-contents file)
+            (should (equal (buffer-string) "x"))))
+      (when-let* ((buffer (get-file-buffer file)))
+        (kill-buffer buffer))
+      (when (file-exists-p file)
+        (delete-file file)))))
+
+(ert-deftest test-ellama-tools-edit-before-hook-failure-blocks-edit ()
+  (ellama-test--ensure-local-ellama-tools)
+  (let ((file (make-temp-file "ellama-before-hook-fail-"))
+        (ellama-tools-edit-before-shell-commands
+         '((:command "printf before-fail; exit 4")))
+        (ellama-tools-edit-after-shell-commands nil))
+    (unwind-protect
+        (progn
+          (with-temp-file file
+            (insert "old"))
+          (let ((msg (ellama-tools-write-file-tool file "new")))
+            (should (string-match-p
+                     "Before edit hook failed with exit status 4" msg))
+            (should (string-match-p "before-fail" msg))
+            (should-not (string-match-p "Wrote 3 characters" msg)))
+          (with-temp-buffer
+            (insert-file-contents file)
+            (should (equal (buffer-string) "old"))))
+      (when-let* ((buffer (get-file-buffer file)))
+        (kill-buffer buffer))
+      (when (file-exists-p file)
+        (delete-file file)))))
+
+(ert-deftest test-ellama-tools-edit-before-hook-shows-enabled-output ()
+  (ellama-test--ensure-local-ellama-tools)
+  (let ((file (make-temp-file "ellama-before-hook-show-"))
+        (ellama-tools-edit-before-shell-commands
+         '((:command "printf before-ok" :show-output t)))
+        (ellama-tools-edit-after-shell-commands nil))
+    (unwind-protect
+        (let ((msg (ellama-tools-write-file-tool file "x")))
+          (should (string-match-p "Before edit hook completed" msg))
+          (should (string-match-p "before-ok" msg))
+          (should (string-match-p "Wrote 1 characters" msg)))
+      (when-let* ((buffer (get-file-buffer file)))
+        (kill-buffer buffer))
+      (when (file-exists-p file)
+        (delete-file file)))))
+
+(ert-deftest test-ellama-tools-edit-hook-receives-context ()
+  (ellama-test--ensure-local-ellama-tools)
+  (let* ((dir (make-temp-file "ellama-hook-context-" t))
+         (file (expand-file-name "note.txt" dir))
+         (hook-command
+          (concat
+           "printf \"%s|%s|%s\" "
+           "\"$ELLAMA_EDIT_OPERATION\" "
+           "\"$ELLAMA_TOOL_NAME\" \"$PWD\""))
+         (ellama-tools-edit-before-shell-commands nil)
+         (ellama-tools-edit-after-shell-commands
+          `((:command ,hook-command :show-output t))))
+    (unwind-protect
+        (let ((msg (ellama-tools-write-file-tool file "x")))
+          (should (string-match-p "write|write_file" msg))
+          (should (string-match-p (regexp-quote dir) msg)))
+      (when-let* ((buffer (get-file-buffer file)))
+        (kill-buffer buffer))
+      (when (file-exists-p file)
+        (delete-file file))
+      (when (file-directory-p dir)
+        (delete-directory dir)))))
+
+(ert-deftest test-ellama-tools-edit-hook-output-has-separate-budget ()
+  (ellama-test--ensure-local-ellama-tools)
+  (let ((file (make-temp-file "ellama-hook-budget-"))
+        (ellama-tools-edit-before-shell-commands nil)
+        (ellama-tools-edit-after-shell-commands
+         '((:command "printf 'line1\\nline2\\n'" :show-output t)))
+        (ellama-tools-output-line-budget-enabled t)
+        (ellama-tools-output-line-budget-max-lines 1)
+        (ellama-tools-output-line-budget-max-line-length 200)
+        (ellama-tools-output-line-budget-save-overflow-file nil))
+    (unwind-protect
+        (let* ((raw (ellama-tools-write-file-tool file "x"))
+               (msg (ellama-tools--postprocess-output-result
+                     "write_file" raw nil nil)))
+          (should (string-match-p "Wrote 1 characters" msg))
+          (should (string-match-p "\\[ELLAMA OUTPUT TRUNCATED\\]" msg)))
+      (when-let* ((buffer (get-file-buffer file)))
+        (kill-buffer buffer))
+      (when (file-exists-p file)
+        (delete-file file)))))
+
 (ert-deftest test-ellama-tools-append-uses-visiting-buffer-content ()
   (ellama-test--ensure-local-ellama-tools)
   (let ((file (make-temp-file "ellama-append-buffer-")))

--- a/tests/test-ellama-tools.el
+++ b/tests/test-ellama-tools.el
@@ -675,7 +675,22 @@ Return list with result and prompt."
                      "\"a:1:match\"")))
     (should (equal captured
                    '("find" "." "-type" "f" "-exec"
-                     "grep" "--color=never" "-nH" "-e" "match" "{}" "+")))))
+                     "grep" "--color=never" "-i" "-nH" "-e"
+                     "match" "{}" "+")))))
+
+(ert-deftest test-ellama-tools-grep-tool-can-match-case-sensitively ()
+  (ellama-test--ensure-local-ellama-tools)
+  (let (captured)
+    (cl-letf (((symbol-function 'ellama-tools--call-command)
+               (lambda (&rest args)
+                 (setq captured args)
+                 '(0 . "a:1:Match\n"))))
+      (should (equal (ellama-tools-grep-tool default-directory "Match" t)
+                     "\"a:1:Match\"")))
+    (should (equal captured
+                   '("find" "." "-type" "f" "-exec"
+                     "grep" "--color=never" "-nH" "-e"
+                     "Match" "{}" "+")))))
 
 (ert-deftest test-ellama-tools-grep-tool-explains-no-matches ()
   (ellama-test--ensure-local-ellama-tools)
@@ -708,6 +723,19 @@ Return list with result and prompt."
       (when (file-exists-p dir)
         (delete-directory dir t)))))
 
+(ert-deftest test-ellama-tools-grep-tool-matches-case-insensitively ()
+  (ellama-test--ensure-local-ellama-tools)
+  (let* ((dir (make-temp-file "ellama-grep-ignore-case-" t))
+         (file (expand-file-name "sample.txt" dir)))
+    (unwind-protect
+        (progn
+          (with-temp-file file
+            (insert "Needle\n"))
+          (should (equal (ellama-tools-grep-tool dir "needle")
+                         "\"./sample.txt:1:Needle\"")))
+      (when (file-exists-p dir)
+        (delete-directory dir t)))))
+
 (ert-deftest test-ellama-tools-grep-in-file-tool-uses-shared-command-helper ()
   (ellama-test--ensure-local-ellama-tools)
   (let ((file (make-temp-file "ellama-grep-in-file-"))
@@ -727,6 +755,28 @@ Return list with result and prompt."
       (when (file-exists-p file)
         (delete-file file)))
     (should (equal captured
+                   (list "grep" "--color=never" "-i" "-nh"
+                         "hello" truename)))))
+
+(ert-deftest test-ellama-tools-grep-in-file-tool-can-match-case-sensitively ()
+  (ellama-test--ensure-local-ellama-tools)
+  (let ((file (make-temp-file "ellama-grep-in-file-"))
+        truename
+        captured)
+    (unwind-protect
+        (progn
+          (with-temp-file file
+            (insert "hello\n"))
+          (setq truename (file-truename file))
+          (cl-letf (((symbol-function 'ellama-tools--call-command)
+                     (lambda (&rest args)
+                       (setq captured args)
+                       '(0 . "1:hello\n"))))
+            (should (equal (ellama-tools-grep-in-file-tool "hello" file t)
+                           "\"1:hello\""))))
+      (when (file-exists-p file)
+        (delete-file file)))
+    (should (equal captured
                    (list "grep" "--color=never" "-nh"
                          "hello" truename)))))
 
@@ -741,6 +791,18 @@ Return list with result and prompt."
             (insert "haystack\n"))
           (should (equal (ellama-tools-grep-in-file-tool "needle" file)
                          (json-encode expected))))
+      (when (file-exists-p file)
+        (delete-file file)))))
+
+(ert-deftest test-ellama-tools-grep-in-file-tool-matches-case-insensitively ()
+  (ellama-test--ensure-local-ellama-tools)
+  (let ((file (make-temp-file "ellama-grep-in-file-")))
+    (unwind-protect
+        (progn
+          (with-temp-file file
+            (insert "Needle\n"))
+          (should (equal (ellama-tools-grep-in-file-tool "needle" file)
+                         "\"1:Needle\"")))
       (when (file-exists-p file)
         (delete-file file)))))
 


### PR DESCRIPTION
## Summary
- add before/after shell hooks around mutating edit tools with per-hook output policy
- add project-local .codex hook scripts and .dir-locals.el wiring
- move branch/check automation out of AGENTS.md and trim agent instructions

## Checks
- make format-elisp
- make refill-readme
- make manual
- make build
- make test
- make check-compile-warnings
- make checkdocs
- direct hook checks for NEWS.org, README.org, and ellama.el