### PR TITLE
Fix NEWS refill target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,10 +113,11 @@ manual:
 format-elisp:
 	emacs -batch --eval "(setq load-prefer-newer t)" --eval "(let ((files (append (file-expand-wildcards \"ellama*.el\") (file-expand-wildcards \"tests/*.el\")))) (package-initialize) (require 'transient) (dolist (file files) (with-current-buffer (find-file-noselect file) (emacs-lisp-mode) (indent-region (point-min) (point-max)) (untabify (point-min) (point-max)) (delete-trailing-whitespace) (save-buffer))))"
 
-refill-org := "(setq load-prefer-newer t) (with-current-buffer (find-file-noselect \"FILE\") (package-initialize) (require (quote org)) (require (quote org-element)) (setq fill-column 80) (save-excursion (org-with-wide-buffer (cl-loop for el in (reverse (org-element-map (org-element-parse-buffer) (quote (paragraph quote-block item)) (quote identity))) do (goto-char (org-element-property :contents-begin el)) (org-fill-paragraph)))) (save-buffer))"
+refill-org := "(progn (setq load-prefer-newer t) (with-current-buffer (find-file-noselect \"FILE\") (package-initialize) (require (quote org)) (require (quote org-element)) (setq fill-column 80) (save-excursion (org-with-wide-buffer (cl-loop for el in (reverse (org-element-map (org-element-parse-buffer) (quote (paragraph quote-block item)) (quote identity))) do (goto-char (org-element-property :contents-begin el)) (org-fill-paragraph)))) (save-buffer)))"
+refill-news-org := "(progn (setq load-prefer-newer t) (package-initialize) (require (quote org)) (require (quote org-element)) (with-current-buffer (find-file-noselect \"./NEWS.org\") (setq fill-column 80) (save-excursion (save-restriction (goto-char (point-min)) (org-narrow-to-subtree) (cl-loop for el in (reverse (org-element-map (org-element-parse-buffer) (quote (paragraph quote-block item)) (quote identity))) do (goto-char (or (org-element-property :contents-begin el) (org-element-property :begin el))) (org-fill-paragraph)))) (save-buffer)))"
 
 refill-news:
-	emacs -batch --eval $(subst FILE,./NEWS.org,$(refill-org))
+	emacs -batch --eval $(refill-news-org)
 
 refill-readme:
 	emacs -batch --eval $(subst FILE,./README.org,$(refill-org))

--- a/NEWS.org
+++ b/NEWS.org
@@ -1,9 +1,17 @@
 * Version 1.21.0
-- Added project-local before and after shell hook support around mutating edit tools, including per-hook output visibility, failure reporting, hook environment context, and independent sectioned output budgets.
-- Added root .codex hook scripts and ~.dir-locals.el~ configuration so edit tools block writes on main and run file-specific checks after edits. Added aggregate Makefile targets for Elisp, README, and NEWS validation.
-- Updated ~grep~ and ~grep_in_file~ to pass ~-i~ unless ~case_sensitive~ is explicitly set.
-- Removed hook details, skill paths, and automatically checked style guidance from AGENTS.md. Moved release-specific changelog workflow details into the project-local changelog skill.
-- Changed the MELPA CI glob from all top-level .el files to ~ellama*.el~ so ~.dir-locals.el~ is not loaded as a package source file.
+- Added project-local before and after shell hook support around mutating edit
+  tools, including per-hook output visibility, failure reporting, hook
+  environment context, and independent sectioned output budgets.
+- Added root .codex hook scripts and ~.dir-locals.el~ configuration so edit
+  tools block writes on main and run file-specific checks after edits. Added
+  aggregate Makefile targets for Elisp, README, and NEWS validation.
+- Updated ~grep~ and ~grep_in_file~ to pass ~-i~ unless ~case_sensitive~ is
+  explicitly set.
+- Removed hook details, skill paths, and automatically checked style guidance
+  from AGENTS.md. Moved release-specific changelog workflow details into the
+  project-local changelog skill.
+- Changed the MELPA CI glob from all top-level .el files to ~ellama*.el~ so
+  ~.dir-locals.el~ is not loaded as a package source file.
 * Version 1.20.0
 - Add ~balanced-edit~ evaluation profile to validate edits in real Emacs
   buffers.


### PR DESCRIPTION
## Summary
- wrap Org refill eval forms in progn so Emacs runs the refill body
- make refill-news narrow to the latest NEWS release section before filling
- reflow the current NEWS entry to 80 columns

## Checks
- make check-news
- git diff --check