### PR TITLE
Add read-before-write safety for mutating tools

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Makefile for ellama project
 
-.PHONY: build test test-detailed test-integration test-srt-integration docker-build-srt-parity test-srt-integration-linux check-compile-warnings checkdocs manual format-elisp refill-news refill-readme check-elisp check-readme check-news
+.PHONY: build test test-detailed test-integration test-srt-integration docker-build-srt-parity test-srt-integration-linux check-compile-warnings checkdocs manual format-elisp install-git-hooks refill-news refill-readme check-elisp check-readme check-news
 
 SRT_PARITY_DOCKER_IMAGE ?= ellama-srt-parity:latest
 SRT_PARITY_DOCKERFILE ?= docker/srt-parity-linux.Dockerfile
@@ -112,6 +112,12 @@ manual:
 
 format-elisp:
 	emacs -batch --eval "(setq load-prefer-newer t)" --eval "(let ((files (append (file-expand-wildcards \"ellama*.el\") (file-expand-wildcards \"tests/*.el\")))) (package-initialize) (require 'transient) (dolist (file files) (with-current-buffer (find-file-noselect file) (emacs-lisp-mode) (indent-region (point-min) (point-max)) (untabify (point-min) (point-max)) (delete-trailing-whitespace) (save-buffer))))"
+
+install-git-hooks:
+	mkdir -p .git/hooks
+	cp scripts/git-hooks/pre-commit .git/hooks/pre-commit
+	cp scripts/git-hooks/pre-push .git/hooks/pre-push
+	chmod +x .git/hooks/pre-commit .git/hooks/pre-push
 
 refill-org := "(progn (setq load-prefer-newer t) (with-current-buffer (find-file-noselect \"FILE\") (package-initialize) (require (quote org)) (require (quote org-element)) (setq fill-column 80) (save-excursion (org-with-wide-buffer (cl-loop for el in (reverse (org-element-map (org-element-parse-buffer) (quote (paragraph quote-block item)) (quote identity))) do (goto-char (org-element-property :contents-begin el)) (org-fill-paragraph)))) (save-buffer)))"
 refill-news-org := "(progn (setq load-prefer-newer t) (package-initialize) (require (quote org)) (require (quote org-element)) (with-current-buffer (find-file-noselect \"./NEWS.org\") (setq fill-column 80) (save-excursion (save-restriction (goto-char (point-min)) (org-narrow-to-subtree) (cl-loop for el in (reverse (org-element-map (org-element-parse-buffer) (quote (paragraph quote-block item)) (quote identity))) do (goto-char (or (org-element-property :contents-begin el) (org-element-property :begin el))) (org-fill-paragraph)))) (save-buffer)))"

--- a/NEWS.org
+++ b/NEWS.org
@@ -1,3 +1,23 @@
+* Version 1.22.0
+
+- Added read-before-write safety for mutating tools. Session-local read tracking
+  now requires that existing files be read before being overwritten; the first
+  overwrite attempt of an existing file is refused with instructions to read the
+  file first, and the second attempt is allowed for deliberate overwrites. This
+  applies to ~write-file~, ~append-to-file~, ~prepend-to-file~, ~move-file~, and
+  ~edit-file~ tools. Also enhances output truncation messages with concrete next
+  tool call suggestions including specific line ranges via ~lines_range~.
+
+- Added git hooks to prevent commits and pushes to the ~main~ branch. Created
+  pre-commit and pre-push hooks that block operations when on ~main~, providing
+  clear error messages and instructions to use feature branches instead. Added
+  ~install-git-hooks~ Makefile target to automate hook installation.
+
+- Fixed read-before-write CI failures by using direct ~ellama-session~ struct
+  slot assignment for tool session extra updates, ensuring read-before-write
+  bookkeeping works on older Emacs versions. Updated the output line budget test
+  to assert the new concrete ~lines_range~ hint instead of the removed generic
+  wording.
 * Version 1.21.0
 - Added project-local before and after shell hook support around mutating edit
   tools, including per-hook output visibility, failure reporting, hook

--- a/ellama-tools.el
+++ b/ellama-tools.el
@@ -85,6 +85,86 @@ PAIRS is a flat plist of keys and values."
       (setq extra (plist-put extra (pop pairs) (pop pairs))))
     extra))
 
+(defun ellama-tools--active-session ()
+  "Return the active Ellama session for tool bookkeeping."
+  (cond
+   ((and (boundp 'ellama--current-session)
+         (ellama-session-p ellama--current-session))
+    ellama--current-session)
+   ((ellama-session-p ellama-tools--current-session)
+    ellama-tools--current-session)))
+
+(defun ellama-tools--existing-file-key (file-name)
+  "Return canonical key for existing FILE-NAME."
+  (when (and (file-exists-p file-name)
+             (not (file-directory-p file-name)))
+    (file-truename file-name)))
+
+(defun ellama-tools--session-list-extra (session key)
+  "Return list value for SESSION extra KEY."
+  (let ((value (and (ellama-session-p session)
+                    (plist-get (ellama-session-extra session) key))))
+    (and (listp value) value)))
+
+(defun ellama-tools--session-note-list-extra (session key value)
+  "Add VALUE to SESSION extra list KEY."
+  (when (and (ellama-session-p session)
+             value
+             (not (member value (ellama-tools--session-list-extra
+                                 session key))))
+    (ellama-tools--set-session-extra
+     session
+     (ellama-tools--session-extra-with
+      session key
+      (cons value (ellama-tools--session-list-extra session key))))))
+
+(defun ellama-tools--mark-file-read (file-name)
+  "Mark existing FILE-NAME as read in the active tool session."
+  (when-let* ((session (ellama-tools--active-session))
+              (file-key (ellama-tools--existing-file-key file-name)))
+    (ellama-tools--session-note-list-extra
+     session :read-before-write-read-files file-key)))
+
+(defun ellama-tools--file-read-p (file-name)
+  "Return non-nil when FILE-NAME was read in the active tool session."
+  (when-let* ((session (ellama-tools--active-session))
+              (file-key (ellama-tools--existing-file-key file-name)))
+    (member file-key
+            (ellama-tools--session-list-extra
+             session :read-before-write-read-files))))
+
+(defun ellama-tools--read-before-write-warning-recorded-p (file-name)
+  "Return non-nil when FILE-NAME already triggered read-before-write guard."
+  (when-let* ((session (ellama-tools--active-session))
+              (file-key (ellama-tools--existing-file-key file-name)))
+    (member file-key
+            (ellama-tools--session-list-extra
+             session :read-before-write-warned-files))))
+
+(defun ellama-tools--record-read-before-write-warning (file-name)
+  "Record that FILE-NAME triggered read-before-write guard."
+  (when-let* ((session (ellama-tools--active-session))
+              (file-key (ellama-tools--existing-file-key file-name)))
+    (ellama-tools--session-note-list-extra
+     session :read-before-write-warned-files file-key)))
+
+(defun ellama-tools--read-before-write-check (operation file-name)
+  "Return a read-before-write refusal for OPERATION on FILE-NAME, or nil."
+  (when (and ellama-tools-read-before-write-enabled
+             (ellama-tools--active-session)
+             (ellama-tools--existing-file-key file-name)
+             (not (ellama-tools--file-read-p file-name))
+             (not (ellama-tools--read-before-write-warning-recorded-p
+                   file-name)))
+    (ellama-tools--record-read-before-write-warning file-name)
+    (format
+     (concat
+      "%s refused: existing file %s has not been read in this Ellama "
+      "tool session. Use `read_file` or `lines_range` to inspect it, "
+      "then retry. A second attempt is allowed if this overwrite is "
+      "intentional.")
+     operation file-name)))
+
 (defcustom ellama-tools-allow-all nil
   "Allow `ellama' using all the tools without user confirmation.
 Dangerous.  Use at your own risk."
@@ -110,6 +190,14 @@ Use `image' to force image handling."
   :type '(choice (const auto)
                  (const text)
                  (const image))
+  :group 'ellama)
+
+(defcustom ellama-tools-read-before-write-enabled t
+  "Require a session-local read before overwriting existing files.
+When non-nil, full-file mutating tools refuse their first attempt to change an
+existing file that has not been read in the current Ellama tool session.  The
+next attempt is allowed so deliberate overwrites remain possible."
+  :type 'boolean
   :group 'ellama)
 
 (defcustom ellama-tools-balanced-edit-enabled t
@@ -578,6 +666,25 @@ MAX-LINE-LENGTH limits one line width in characters."
           path)
       (error nil))))
 
+(defun ellama-tools--output-truncation-next-range (truncation)
+  "Return next line range plist for TRUNCATION."
+  (let* ((total-lines (plist-get truncation :total-lines))
+         (max-lines (max 0 ellama-tools-output-line-budget-max-lines))
+         (window (max 1 max-lines))
+         (from (if (> max-lines 0) (1+ max-lines) 1))
+         (to (min total-lines (+ from window -1))))
+    (when (<= from total-lines)
+      (list :from from :to to))))
+
+(defun ellama-tools--output-truncation-range-hint (path truncation)
+  "Return concrete `lines_range' hint for PATH and TRUNCATION."
+  (when-let* ((range (ellama-tools--output-truncation-next-range truncation)))
+    (format
+     "Next suggested tool call: `lines_range` with file_name=%S, from=%d, to=%d.\n"
+     path
+     (plist-get range :from)
+     (plist-get range :to))))
+
 (defun ellama-tools--output-truncation-notice
     (tool-name truncation source-info saved-path)
   "Return tool output truncation notice string.
@@ -608,26 +715,40 @@ SAVED-PATH is optional path to full saved output."
      (cond
       ((and source-path (eq source-kind 'file))
        (format
-        (concat "Source file: %s\n"
-                "Use `lines_range` for more lines, or "
-                "`grep_in_file`/`grep` to search.\n")
+        (concat
+         "Source file: %s\n"
+         "%s"
+         "Use `grep_in_file` with file=%S and a specific search_string "
+         "to locate relevant lines.\n")
+        source-path
+        (or (ellama-tools--output-truncation-range-hint
+             source-path truncation)
+            "")
         source-path))
       ((and source-path (eq source-kind 'directory))
        (format
-        (concat "Source directory: %s\n"
-                "Use `grep` in this directory, or read a target file with "
-                "`read_file`/`lines_range`.\n")
-        source-path))
+        (concat
+         "Source directory: %s\n"
+         "Next suggested tool call: `grep` with dir=%S and a specific "
+         "search_string, then `read_file` or `lines_range` on the target file.\n")
+        source-path source-path))
       (saved-path
        (format
-        (concat "Full output saved to: %s\n"
-                "Use `lines_range` on this file for more lines, or "
-                "`grep_in_file`/`grep` to search.\n")
+        (concat
+         "Full output saved to: %s\n"
+         "%s"
+         "Use `grep_in_file` with file=%S and a specific search_string "
+         "to search the saved output.\n")
+        saved-path
+        (or (ellama-tools--output-truncation-range-hint
+             saved-path truncation)
+            "")
         saved-path))
       (t
        (concat
         "Full output file was not saved.\n"
-        "You can rerun the tool with narrower scope and use `grep`.\n")))
+        "Next suggested action: rerun the tool with narrower arguments "
+        "or use `grep` with a specific search_string.\n")))
      "\n--- BEGIN TRUNCATED OUTPUT ---\n"
      snippet
      "\n--- END TRUNCATED OUTPUT ---")))
@@ -1835,23 +1956,33 @@ Wrap command with `srt' when `ellama-tools-use-srt' is non-nil."
   "Read the file FILE-NAME.
 MODE can be `auto', `text' or `image'."
   (or (ellama-tools--tool-check-file-access file-name 'read)
-      (json-encode
-       (if (not (file-exists-p file-name))
-           (format "File %s does not exist." file-name)
-         (if (file-directory-p file-name)
-             (format "%s is a directory, not a file." file-name)
-           (pcase (ellama-tools--read-file-mode mode)
-             ('auto
-              (if (ellama-image-file-p file-name)
-                  (ellama-tools--read-image-file-tool file-name)
-                (ellama-tools--read-file-as-text file-name)))
-             ('text
-              (ellama-tools--read-file-as-text file-name))
-             ('image
-              (ellama-tools--read-image-file-tool file-name))
-             (_
-              (format "Unsupported read_file mode %S. Use auto, text or image."
-                      mode))))))))
+      (let ((result
+             (cond
+              ((not (file-exists-p file-name))
+               (format "File %s does not exist." file-name))
+              ((file-directory-p file-name)
+               (format "%s is a directory, not a file." file-name))
+              (t
+               (pcase (ellama-tools--read-file-mode mode)
+                 ('auto
+                  (prog1
+                      (if (ellama-image-file-p file-name)
+                          (ellama-tools--read-image-file-tool file-name)
+                        (ellama-tools--read-file-as-text file-name))
+                    (ellama-tools--mark-file-read file-name)))
+                 ('text
+                  (prog1
+                      (ellama-tools--read-file-as-text file-name)
+                    (ellama-tools--mark-file-read file-name)))
+                 ('image
+                  (prog1
+                      (ellama-tools--read-image-file-tool file-name)
+                    (ellama-tools--mark-file-read file-name)))
+                 (_
+                  (format
+                   "Unsupported read_file mode %S. Use auto, text or image."
+                   mode)))))))
+        (json-encode result))))
 
 (ellama-tools-define-tool
  '(:function
@@ -2385,6 +2516,7 @@ buffer contents, matching their historical behavior."
       (ellama-tools--file-parent-directory-error-message "write" file-name)
       (when (file-directory-p file-name)
         (format "Cannot write %s: path is a directory." file-name))
+      (ellama-tools--read-before-write-check "Write" file-name)
       (condition-case err
           (let* ((original (when (file-exists-p file-name)
                              (ellama-tools--current-file-content file-name)))
@@ -2435,6 +2567,7 @@ buffer contents, matching their historical behavior."
       (ellama-tools--file-parent-directory-error-message "append to" file-name)
       (when (file-directory-p file-name)
         (format "Cannot append to %s: path is a directory." file-name))
+      (ellama-tools--read-before-write-check "Append" file-name)
       (condition-case err
           (let* ((original (ellama-tools--current-file-content file-name))
                  (candidate (concat original content))
@@ -2485,6 +2618,7 @@ buffer contents, matching their historical behavior."
       (ellama-tools--file-parent-directory-error-message "prepend to" file-name)
       (when (file-directory-p file-name)
         (format "Cannot prepend to %s: path is a directory." file-name))
+      (ellama-tools--read-before-write-check "Prepend" file-name)
       (condition-case err
           (let* ((original (ellama-tools--current-file-content file-name))
                  (candidate (concat content original))
@@ -2581,6 +2715,7 @@ DEPTH is the current recursion depth, used internally."
   (or (ellama-tools--tool-check-file-access file-name 'read)
       (ellama-tools--tool-check-file-access file-name 'write)
       (ellama-tools--tool-check-file-access new-file-name 'write)
+      (ellama-tools--read-before-write-check "Move" file-name)
       (cond
        ((not (file-exists-p file-name))
         (format "Cannot move file: source file does not exist: %s."
@@ -2648,6 +2783,7 @@ Replace OLDCONTENT with NEWCONTENT."
       (let ((content (with-temp-buffer
                        (insert-file-contents-literally file-name)
                        (buffer-string))))
+        (ellama-tools--mark-file-read file-name)
         (if (not (string-match (regexp-quote oldcontent) content))
             (ellama-tools--edit-file-old-content-not-found-message file-name)
           (let* ((candidate (replace-match newcontent t t content))
@@ -2971,9 +3107,11 @@ ANSWER-VARIANT-LIST is a list of possible answer variants."))
                               (forward-line (1- to))
                               (end-of-line)
                               (point))))
-                   (ellama-tools--sanitize-tool-text-output
-                    (buffer-substring-no-properties start end)
-                    (format "File %s" file-name))))))))))))
+                   (prog1
+                       (ellama-tools--sanitize-tool-text-output
+                        (buffer-substring-no-properties start end)
+                        (format "File %s" file-name))
+                     (ellama-tools--mark-file-read file-name))))))))))))
 
 (ellama-tools-define-tool
  '(:function

--- a/ellama-tools.el
+++ b/ellama-tools.el
@@ -72,8 +72,8 @@
 
 (defun ellama-tools--set-session-extra (session extra)
   "Set SESSION EXTRA."
-  (with-no-warnings
-    (setf (ellama-session-extra session) extra)))
+  (let ((offset (cl-struct-slot-offset 'ellama-session 'extra)))
+    (aset session offset extra)))
 
 (defun ellama-tools--session-extra-with (session &rest pairs)
   "Return SESSION extra plist with PAIRS applied.

--- a/ellama.el
+++ b/ellama.el
@@ -6,7 +6,7 @@
 ;; URL: http://github.com/s-kostyaev/ellama
 ;; Keywords: help local tools
 ;; Package-Requires: ((emacs "28.1") (llm "0.30.2") (plz "0.8") (transient "0.7") (compat "29.1") (yaml "1.2.3"))
-;; Version: 1.21.0
+;; Version: 1.22.0
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;; Created: 8th Oct 2023
 

--- a/scripts/git-hooks/pre-commit
+++ b/scripts/git-hooks/pre-commit
@@ -1,0 +1,16 @@
+#!/bin/sh
+set -eu
+
+branch=$(git symbolic-ref --quiet --short HEAD 2>/dev/null || printf '')
+
+if [ "$branch" = "main" ]; then
+	cat >&2 <<'EOF'
+Commit blocked: current branch is main.
+
+Create and switch to a feature branch first:
+  git switch -c <branch-name>
+EOF
+	exit 1
+fi
+
+exit 0

--- a/scripts/git-hooks/pre-push
+++ b/scripts/git-hooks/pre-push
@@ -1,0 +1,28 @@
+#!/bin/sh
+set -eu
+
+branch=$(git symbolic-ref --quiet --short HEAD 2>/dev/null || printf '')
+
+if [ "$branch" = "main" ]; then
+	cat >&2 <<'EOF'
+Push blocked: current branch is main.
+
+Switch to a feature branch first:
+  git switch <branch-name>
+EOF
+	exit 1
+fi
+
+while read local_ref _local_sha _remote_ref _remote_sha
+do
+	if [ "$local_ref" = "refs/heads/main" ]; then
+		cat >&2 <<'EOF'
+Push blocked: refusing to push refs/heads/main.
+
+Push a feature branch instead.
+EOF
+		exit 1
+	fi
+done
+
+exit 0

--- a/tests/test-ellama-tools.el
+++ b/tests/test-ellama-tools.el
@@ -1875,7 +1875,14 @@ Return list with result and prompt."
             (with-temp-buffer
               (insert-file-contents saved-path)
               (should (equal (buffer-string)
-                             "line-1\nline-2\nline-3\nline-4"))))
+                             "line-1\nline-2\nline-3\nline-4")))
+            (should
+             (string-match-p
+              (regexp-quote
+               (format
+                "Next suggested tool call: `lines_range` with file_name=%S, from=3, to=4."
+                saved-path))
+              result)))
         (when (and saved-path (file-exists-p saved-path))
           (delete-file saved-path))))))
 
@@ -1906,6 +1913,13 @@ Return list with result and prompt."
               result))
             (should-not (string-match-p "Full output saved to:" result))
             (should (string-match-p "Use `lines_range`" result))
+            (should
+             (string-match-p
+              (regexp-quote
+               (format
+                "Next suggested tool call: `lines_range` with file_name=%S, from=3, to=3."
+                source-path))
+              result))
             (should (string-match-p "grep_in_file" result)))
         (when (file-exists-p source-path)
           (delete-file source-path))))))
@@ -2263,6 +2277,75 @@ Return list with result and prompt."
         (delete-file file))
       (when (file-directory-p dir)
         (delete-directory dir)))))
+
+(ert-deftest test-ellama-tools-read-before-write-refuses-first-overwrite ()
+  (ellama-test--ensure-local-ellama-tools)
+  (let* ((file (make-temp-file "ellama-read-before-write-"))
+         (session (make-ellama-session :id "read-before-write"))
+         (ellama--current-session session)
+         (ellama-tools--current-session nil)
+         (ellama-tools-read-before-write-enabled t))
+    (unwind-protect
+        (progn
+          (write-region "old" nil file nil 'silent)
+          (let ((result (ellama-tools-write-file-tool file "new")))
+            (should (string-match-p "Write refused" result))
+            (should (string-match-p "read_file" result))
+            (with-temp-buffer
+              (insert-file-contents file)
+              (should (equal (buffer-string) "old"))))
+          (let ((result (ellama-tools-write-file-tool file "new")))
+            (should (string-match-p "Wrote 3 characters" result))
+            (with-temp-buffer
+              (insert-file-contents file)
+              (should (equal (buffer-string) "new")))))
+      (when-let* ((buffer (get-file-buffer file)))
+        (kill-buffer buffer))
+      (when (file-exists-p file)
+        (delete-file file)))))
+
+(ert-deftest test-ellama-tools-read-before-write-allows-after-read-file ()
+  (ellama-test--ensure-local-ellama-tools)
+  (let* ((file (make-temp-file "ellama-read-before-write-"))
+         (session (make-ellama-session :id "read-before-write"))
+         (ellama--current-session session)
+         (ellama-tools--current-session nil)
+         (ellama-tools-read-before-write-enabled t))
+    (unwind-protect
+        (progn
+          (write-region "old" nil file nil 'silent)
+          (ellama-tools-read-file-tool file "text")
+          (let ((result (ellama-tools-write-file-tool file "new")))
+            (should (string-match-p "Wrote 3 characters" result))
+            (with-temp-buffer
+              (insert-file-contents file)
+              (should (equal (buffer-string) "new")))))
+      (when-let* ((buffer (get-file-buffer file)))
+        (kill-buffer buffer))
+      (when (file-exists-p file)
+        (delete-file file)))))
+
+(ert-deftest test-ellama-tools-read-before-write-edit-file-counts-as-read ()
+  (ellama-test--ensure-local-ellama-tools)
+  (let* ((file (make-temp-file "ellama-read-before-write-"))
+         (session (make-ellama-session :id "read-before-write"))
+         (ellama--current-session session)
+         (ellama-tools--current-session nil)
+         (ellama-tools-read-before-write-enabled t))
+    (unwind-protect
+        (progn
+          (write-region "old" nil file nil 'silent)
+          (let ((result (ellama-tools-edit-file-tool file "old" "mid")))
+            (should (string-match-p "Edited" result)))
+          (let ((result (ellama-tools-write-file-tool file "new")))
+            (should (string-match-p "Wrote 3 characters" result))
+            (with-temp-buffer
+              (insert-file-contents file)
+              (should (equal (buffer-string) "new")))))
+      (when-let* ((buffer (get-file-buffer file)))
+        (kill-buffer buffer))
+      (when (file-exists-p file)
+        (delete-file file)))))
 
 (ert-deftest test-ellama-tools-edit-hook-output-has-separate-budget ()
   (ellama-test--ensure-local-ellama-tools)

--- a/tests/test-ellama-tools.el
+++ b/tests/test-ellama-tools.el
@@ -1912,7 +1912,6 @@ Return list with result and prompt."
               (regexp-quote (format "Source file: %s" source-path))
               result))
             (should-not (string-match-p "Full output saved to:" result))
-            (should (string-match-p "Use `lines_range`" result))
             (should
              (string-match-p
               (regexp-quote


### PR DESCRIPTION
Introduce session-local read tracking to require that existing files be read before being overwritten. The first overwrite attempt of an existing file is refused, providing instructions to read the file first. The second attempt is allowed, enabling deliberate overwrites.

This applies to write-file, append-to-file, prepend-to-file, move-file, and edit-file tools. When enabled (default), read_file and lines_range now track which files have been read.

Also enhance output truncation messages with concrete next tool call suggestions including specific line ranges via lines_range.