### PR TITLE
Remove experimental profiles

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,9 @@
 
 Before committing, use the project-local `commit-message` skill.
 
+Never merge, rebase, cherry-pick, or otherwise integrate code into `main`.
+Never push directly to `main`; always use a feature branch and a pull request.
+
 For release work, use the project-local `changelog` skill.
 
 ## Code Style Guidelines

--- a/NEWS.org
+++ b/NEWS.org
@@ -1,3 +1,25 @@
+* Version 1.22.1
+
+- Remove experimental hypothesis profiles (numbered-read, line-edit,
+  numbered-line-edit) and their associated tools including ~edit_lines~,
+  ~ellama-eval-edit-lines-tool~, ~ellama-eval-monitored-edit-lines-tool~,
+  ~ellama-eval-numbered-read-file-tool~, and
+  ~ellama-eval-numbered-lines-range-tool~. Delete corresponding helper
+  functions: ~ellama-eval--line-edit-candidate~,
+  ~ellama-eval--number-text-lines~, ~ellama-eval--replace-profile-read-specs~,
+  and profile classifiers ~ellama-eval--profile-numbered-read-p~,
+  ~ellama-eval--profile-line-edit-p~,
+  ~ellama-eval--profile-balanced-edit-p~. Net change: -208 lines.
+- Unify ~ellama-eval--profile-tool-names~ to unconditionally append ~edit_file~
+  to the base tool list for all profiles (baseline and balanced-edit), removing
+  profile-specific matching logic.
+- Restore profile validation in ~ellama-eval--profile-tool-names~ to properly
+  reject unknown or misspelled profile names with an error, fixing the unused
+  lexical argument warning reported by CI.
+- Add policy forbidding direct integration into ~main~ branch; require feature
+  branches and pull requests instead of direct pushes.
+- Force ~cat~ pager for shell commands and shared command helpers, adding tests
+  to verify pager environment across all shell execution paths.
 * Version 1.22.0
 
 - Added read-before-write safety for mutating tools. Session-local read tracking

--- a/ellama-eval.el
+++ b/ellama-eval.el
@@ -407,13 +407,7 @@ in one short sentence."
 
 (defun ellama-eval--profile-tool-names (profile)
   "Return tool names for PROFILE."
-  (pcase profile
-    ('baseline
-     (copy-sequence ellama-eval--base-tool-names))
-    ('balanced-edit
-     (append ellama-eval--base-tool-names '("edit_file")))
-    (_
-     (error "Unknown evaluation profile %S" profile))))
+  (append ellama-eval--base-tool-names '("edit_file")))
 
 
 

--- a/ellama-eval.el
+++ b/ellama-eval.el
@@ -79,7 +79,7 @@ Only one evaluation run is supported at a time.")
   "Tool names included in every hypothesis profile.")
 
 (defconst ellama-eval-hypothesis-profiles
-  '(baseline numbered-read line-edit numbered-line-edit balanced-edit)
+  '(baseline balanced-edit)
   "Profiles used by hypothesis suites.")
 
 (defconst ellama-eval--coder-system
@@ -327,7 +327,7 @@ in one short sentence."
          :answer-regexps
          ,(ellama-eval--fixture-data "explore-summarize-policy"
                                      "answer-regexps.eld")))
-  "Built-in cases for the numbered-read and line-edit hypothesis.")
+  "Built-in cases for the baseline and balanced-edit hypotheses.")
 
 (defun ellama-eval--tool-spec (name function args description)
   "Return a tool plist for NAME, FUNCTION, ARGS and DESCRIPTION."
@@ -402,53 +402,20 @@ in one short sentence."
         (:name "newcontent" :type string
                :description "New content to replace with."))
       "Edit file FILE_NAME. Replace OLDCONTENT with NEWCONTENT."))
-    ("edit_lines"
-     (ellama-eval--tool-spec
-      "edit_lines"
-      #'ellama-eval-edit-lines-tool
-      '((:name "file_name" :type string :description "Name of the file.")
-        (:name "from" :type number :description "Starting line number.")
-        (:name "to" :type number :description "Ending line number.")
-        (:name "replacement" :type string
-               :description "Replacement block for the line range."))
-      "Replace file FILE_NAME lines FROM through TO with REPLACEMENT."))
     (_
      (error "Unknown evaluation tool %s" name))))
 
-(defun ellama-eval--profile-numbered-read-p (profile)
-  "Return non-nil when PROFILE use numbered read output."
-  (memq profile '(numbered-read numbered-line-edit)))
-
-(defun ellama-eval--profile-line-edit-p (profile)
-  "Return non-nil when PROFILE use line-based editing."
-  (memq profile '(line-edit numbered-line-edit)))
-
-(defun ellama-eval--profile-balanced-edit-p (profile)
-  "Return non-nil when PROFILE validate edits before applying them."
-  (eq profile 'balanced-edit))
-
 (defun ellama-eval--profile-tool-names (profile)
   "Return tool names for PROFILE."
-  (unless (memq profile ellama-eval-hypothesis-profiles)
-    (error "Unknown evaluation profile %S" profile))
-  (append ellama-eval--base-tool-names
-          (list (if (ellama-eval--profile-line-edit-p profile)
-                    "edit_lines"
-                  "edit_file"))))
+  (pcase profile
+    ('baseline
+     (copy-sequence ellama-eval--base-tool-names))
+    ('balanced-edit
+     (append ellama-eval--base-tool-names '("edit_file")))
+    (_
+     (error "Unknown evaluation profile %S" profile))))
 
-(defun ellama-eval--replace-profile-read-specs (spec profile)
-  "Return SPEC adjusted for numbered read PROFILE."
-  (if (not (ellama-eval--profile-numbered-read-p profile))
-      spec
-    (pcase (plist-get spec :name)
-      ("read_file"
-       (plist-put (copy-sequence spec)
-                  :function #'ellama-eval-numbered-read-file-tool))
-      ("lines_range"
-       (plist-put (copy-sequence spec)
-                  :function #'ellama-eval-numbered-lines-range-tool))
-      (_
-       spec))))
+
 
 (defun ellama-eval--replace-profile-edit-specs (spec profile)
   "Return SPEC adjusted for edit validation in PROFILE."
@@ -460,14 +427,7 @@ in one short sentence."
       (lambda (file-name oldcontent newcontent)
         (ellama-eval-monitored-edit-file-tool
          file-name oldcontent newcontent
-         (ellama-eval--profile-balanced-edit-p profile)))))
-    ("edit_lines"
-     (plist-put
-      (copy-sequence spec)
-      :function
-      (lambda (file-name from to replacement)
-        (ellama-eval-monitored-edit-lines-tool
-         file-name from to replacement nil))))
+         (eq profile 'balanced-edit)))))
     (_
      spec)))
 
@@ -503,77 +463,13 @@ in one short sentence."
   (mapcar
    (lambda (name)
      (let* ((spec (ellama-eval--tool-spec-by-name name))
-            (read-spec
-             (ellama-eval--replace-profile-read-specs spec profile))
             (edit-spec
-             (ellama-eval--replace-profile-edit-specs read-spec profile))
+             (ellama-eval--replace-profile-edit-specs spec profile))
             (instrumented
              (ellama-eval--instrument-tool-spec edit-spec)))
        (apply #'llm-make-tool
               (ellama-tools-wrap-with-confirm instrumented))))
    (ellama-eval--profile-tool-names profile)))
-
-(defun ellama-eval--number-text-lines (text &optional first-line)
-  "Return TEXT with line numbers starting at FIRST-LINE."
-  (let ((line-number (or first-line 1))
-        lines)
-    (with-temp-buffer
-      (insert text)
-      (goto-char (point-min))
-      (while (not (eobp))
-        (push (format "%d | %s"
-                      line-number
-                      (buffer-substring-no-properties
-                       (line-beginning-position)
-                       (line-end-position)))
-              lines)
-        (setq line-number (1+ line-number))
-        (forward-line 1)))
-    (string-join (nreverse lines) "\n")))
-
-(defun ellama-eval-numbered-read-file-tool (file-name &optional mode)
-  "Read FILE-NAME and number text output lines.
-MODE follows the same contract as `ellama-tools-read-file-tool'."
-  (or (ellama-tools--tool-check-file-access file-name 'read)
-      (json-encode
-       (if (not (file-exists-p file-name))
-           (format "File %s doesn't exists." file-name)
-         (pcase (ellama-tools--read-file-mode mode)
-           ('auto
-            (if (ellama-image-file-p file-name)
-                (ellama-tools--read-image-file-tool file-name)
-              (ellama-eval--number-text-lines
-               (ellama-tools--read-file-as-text file-name))))
-           ('text
-            (ellama-eval--number-text-lines
-             (ellama-tools--read-file-as-text file-name)))
-           ('image
-            (ellama-tools--read-image-file-tool file-name))
-           (_
-            (format "Unsupported read_file mode %S. Use auto, text or image."
-                    mode)))))))
-
-(defun ellama-eval-numbered-lines-range-tool (file-name from to)
-  "Return numbered FILE-NAME content from line FROM through TO."
-  (or (ellama-tools--tool-check-file-access file-name 'read)
-      (json-encode
-       (with-current-buffer (find-file-noselect file-name)
-         (save-excursion
-           (let ((start (progn
-                          (goto-char (point-min))
-                          (forward-line (1- from))
-                          (beginning-of-line)
-                          (point)))
-                 (end (progn
-                        (goto-char (point-min))
-                        (forward-line (1- to))
-                        (end-of-line)
-                        (point))))
-             (ellama-eval--number-text-lines
-              (ellama-tools--sanitize-tool-text-output
-               (buffer-substring-no-properties start end)
-               (format "File %s" file-name))
-              from)))))))
 
 (defun ellama-eval--line-count ()
   "Return line count for the current buffer."
@@ -919,96 +815,6 @@ When BLOCK-INVALID is non-nil, reject invalid resulting buffers."
   (ellama-eval-monitored-edit-file-tool
    file-name oldcontent newcontent t))
 
-(defun ellama-eval--line-edit-candidate
-    (file-name from to replacement)
-  "Return line edit data after replacing FILE-NAME lines FROM TO.
-REPLACEMENT is inserted for the inclusive line range.  Returned plist
-contains `:candidate' and `:old-fragment'."
-  (with-temp-buffer
-    (insert-file-contents-literally file-name)
-    (let ((line-count (ellama-eval--line-count)))
-      (when (> to line-count)
-        (error "Line range %d-%d exceeds file line count %d"
-               from to line-count)))
-    (goto-char (point-min))
-    (forward-line (1- from))
-    (let ((start (line-beginning-position))
-          end
-          old-fragment
-          suffix-p)
-      (goto-char (point-min))
-      (forward-line to)
-      (setq end (point))
-      (setq old-fragment
-            (buffer-substring-no-properties start end))
-      (setq suffix-p (< end (point-max)))
-      (delete-region start end)
-      (goto-char start)
-      (insert replacement)
-      (when (and suffix-p
-                 (not (string-empty-p replacement))
-                 (not (string-suffix-p "\n" replacement)))
-        (insert "\n"))
-      (list :candidate (buffer-string)
-            :old-fragment old-fragment))))
-
-(defun ellama-eval-monitored-edit-lines-tool
-    (file-name from to replacement &optional block-invalid)
-  "Replace FILE-NAME lines FROM through TO with validation.
-REPLACEMENT is the inserted text.  When BLOCK-INVALID is non-nil, reject
-invalid resulting buffers."
-  (or (ellama-tools--tool-check-file-access file-name 'read)
-      (ellama-tools--tool-check-file-access file-name 'write)
-      (progn
-        (unless (and (integerp from)
-                     (integerp to)
-                     (<= 1 from)
-                     (<= from to))
-          (error "Line range must use positive integers with FROM <= TO"))
-        (let* ((content (with-temp-buffer
-                          (insert-file-contents-literally file-name)
-                          (buffer-string)))
-               (line-edit-data
-                (ellama-eval--line-edit-candidate
-                 file-name from to replacement))
-               (candidate (plist-get line-edit-data :candidate))
-               (old-fragment (plist-get line-edit-data :old-fragment))
-               (candidate-validation
-                (ellama-eval--validate-text-in-file-buffer
-                 file-name candidate))
-               (original-validation
-                (ellama-eval--validate-text-in-file-buffer
-                 file-name content))
-               (old-validation
-                (ellama-eval--validate-text-in-file-buffer
-                 file-name old-fragment))
-               (new-validation
-                (ellama-eval--validate-text-in-file-buffer
-                 file-name replacement))
-               (valid-p (plist-get candidate-validation :valid))
-               (blocked-p (and block-invalid (not valid-p))))
-          (ellama-eval--record-edit-validation
-           (ellama-eval--edit-validation-entry
-            "edit_lines" file-name t candidate-validation
-            original-validation old-validation new-validation
-            (not blocked-p) blocked-p))
-          (if blocked-p
-              (ellama-eval--format-edit-rejection
-               file-name
-               candidate-validation
-               original-validation
-               old-validation
-               new-validation)
-            (ellama-tools--write-file-buffer-content
-             file-name candidate)
-            (format "Replaced lines %d-%d in %s."
-                    from to file-name))))))
-
-(defun ellama-eval-edit-lines-tool (file-name from to replacement)
-  "Replace FILE-NAME lines FROM through TO with REPLACEMENT."
-  (ellama-eval-monitored-edit-lines-tool
-   file-name from to replacement nil))
-
 (defun ellama-eval--write-case-files (workspace files)
   "Write FILES into WORKSPACE."
   (dolist (entry files)
@@ -1289,7 +1095,7 @@ EXPECTED-FILES and SYNTAX-FILES define the relative file paths to check."
      :read-call-count
      (ellama-eval--tool-count trace '("read_file" "lines_range"))
      :edit-call-count
-     (ellama-eval--tool-count trace '("edit_file" "edit_lines"))
+     (ellama-eval--tool-count trace '("edit_file"))
      :tool-trace trace
      :edit-validation-count (length validation-trace)
      :edit-rejection-count

--- a/ellama-eval.el
+++ b/ellama-eval.el
@@ -407,6 +407,8 @@ in one short sentence."
 
 (defun ellama-eval--profile-tool-names (profile)
   "Return tool names for PROFILE."
+  (unless (memq profile ellama-eval-hypothesis-profiles)
+    (error "Unknown evaluation profile %S" profile))
   (append ellama-eval--base-tool-names '("edit_file")))
 
 

--- a/ellama-tools.el
+++ b/ellama-tools.el
@@ -1863,13 +1863,25 @@ Wrap command with `srt' when `ellama-tools-use-srt' is non-nil."
          ellama-tools-srt-program))
       (append (list srt-path) ellama-tools-srt-args (cons program args)))))
 
+(defun ellama-tools--process-environment-with-cat-pager (&optional env)
+  "Return ENV with shell command pagers forced to cat."
+  (append
+   '("PAGER=cat" "GIT_PAGER=cat")
+   (seq-remove
+    (lambda (entry)
+      (or (string-prefix-p "PAGER=" entry)
+          (string-prefix-p "GIT_PAGER=" entry)))
+    (copy-sequence (or env process-environment)))))
+
 (defun ellama-tools--call-command-to-string (program &rest args)
   "Run PROGRAM with ARGS and return stdout as a string."
   (cdr (apply #'ellama-tools--call-command program args)))
 
 (defun ellama-tools--call-command (program &rest args)
   "Run PROGRAM with ARGS and return cons of exit status and stdout."
-  (let ((argv (apply #'ellama-tools--command-argv program args)))
+  (let ((argv (apply #'ellama-tools--command-argv program args))
+        (process-environment
+         (ellama-tools--process-environment-with-cat-pager)))
     (with-temp-buffer
       (let ((status (apply #'call-process (car argv) nil t nil (cdr argv))))
         (cons status (buffer-string))))))
@@ -2347,7 +2359,7 @@ describe the edit."
     (format "ELLAMA_FILE_NAME=%s" (expand-file-name file-name))
     (format "ELLAMA_PROJECT_ROOT=%s" root)
     (format "ELLAMA_HOOK_NAME=%s" (or (plist-get spec :name) "")))
-   process-environment))
+   (ellama-tools--process-environment-with-cat-pager)))
 
 (defun ellama-tools--run-edit-shell-hook
     (phase file-name operation tool-name spec)
@@ -2834,7 +2846,9 @@ Replace OLDCONTENT with NEWCONTENT."
   "Execute shell command CMD.
 CALLBACK – function called once with the result string."
   (let ((argv (ellama-tools--command-argv
-               shell-file-name shell-command-switch cmd)))
+               shell-file-name shell-command-switch cmd))
+        (process-environment
+         (ellama-tools--process-environment-with-cat-pager)))
     (condition-case err
         (let ((buf (get-buffer-create
                     (concat (make-temp-name " *ellama shell command") "*"))))

--- a/ellama.el
+++ b/ellama.el
@@ -6,7 +6,7 @@
 ;; URL: http://github.com/s-kostyaev/ellama
 ;; Keywords: help local tools
 ;; Package-Requires: ((emacs "28.1") (llm "0.30.2") (plz "0.8") (transient "0.7") (compat "29.1") (yaml "1.2.3"))
-;; Version: 1.22.0
+;; Version: 1.22.1
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;; Created: 8th Oct 2023
 

--- a/tests/test-ellama-eval.el
+++ b/tests/test-ellama-eval.el
@@ -144,13 +144,13 @@
         (delete-file file)))))
 
 (ert-deftest test-ellama-eval-profile-tools-switch-read-and-edit-shapes ()
-  "Verify baseline uses read_file and balanced-edit uses edit_file."
+  "Verify both baseline and balanced-edit use edit_file."
   (let ((ellama-tools-allow-all t)
         (ellama-tools-allowed nil)
         (ellama-tools-confirm-allowed (make-hash-table))
         (baseline (ellama-eval--make-profile-tools 'baseline))
         (balanced (ellama-eval--make-profile-tools 'balanced-edit)))
-    (should-not (member "edit_file" (mapcar #'llm-tool-name baseline)))
+    (should (member "edit_file" (mapcar #'llm-tool-name baseline)))
     (should (member "edit_file" (mapcar #'llm-tool-name balanced)))
     (should (member "read_file" (mapcar #'llm-tool-name baseline)))
     (should (member "read_file" (mapcar #'llm-tool-name balanced)))))

--- a/tests/test-ellama-eval.el
+++ b/tests/test-ellama-eval.el
@@ -28,28 +28,6 @@
 (require 'ellama-eval)
 (require 'ert)
 
-(ert-deftest test-ellama-eval-number-text-lines ()
-  (should
-   (equal
-    (ellama-eval--number-text-lines "alpha\nbeta\n" 7)
-    "7 | alpha\n8 | beta")))
-
-(ert-deftest test-ellama-eval-edit-lines-tool-replaces-range ()
-  (let ((file (make-temp-file "ellama-eval-edit-lines-")))
-    (unwind-protect
-        (progn
-          (with-temp-file file
-            (insert "alpha\nbeta\ngamma\n"))
-          (should
-           (string-match-p
-            "Replaced lines 2-2"
-            (ellama-eval-edit-lines-tool file 2 2 "delta")))
-          (with-temp-buffer
-            (insert-file-contents file)
-            (should (equal (buffer-string) "alpha\ndelta\ngamma\n"))))
-      (when (file-exists-p file)
-        (delete-file file)))))
-
 (ert-deftest test-ellama-eval-balanced-edit-file-tool-rejects-broken-elisp ()
   (let ((file (make-temp-file "ellama-eval-balanced-edit-" nil ".el")))
     (unwind-protect
@@ -166,35 +144,16 @@
         (delete-file file)))))
 
 (ert-deftest test-ellama-eval-profile-tools-switch-read-and-edit-shapes ()
+  "Verify baseline uses read_file and balanced-edit uses edit_file."
   (let ((ellama-tools-allow-all t)
         (ellama-tools-allowed nil)
         (ellama-tools-confirm-allowed (make-hash-table))
         (baseline (ellama-eval--make-profile-tools 'baseline))
-        (numbered (ellama-eval--make-profile-tools 'numbered-line-edit))
         (balanced (ellama-eval--make-profile-tools 'balanced-edit)))
-    (should (member "edit_file" (mapcar #'llm-tool-name baseline)))
-    (should-not (member "edit_lines" (mapcar #'llm-tool-name baseline)))
-    (should (member "edit_lines" (mapcar #'llm-tool-name numbered)))
-    (should-not (member "edit_file" (mapcar #'llm-tool-name numbered)))
+    (should-not (member "edit_file" (mapcar #'llm-tool-name baseline)))
     (should (member "edit_file" (mapcar #'llm-tool-name balanced)))
-    (should-not (member "edit_lines" (mapcar #'llm-tool-name balanced)))
-    (let* ((tool
-            (seq-find
-             (lambda (item)
-               (string= (llm-tool-name item) "read_file"))
-             numbered))
-           (function (llm-tool-function tool))
-           (file (make-temp-file "ellama-eval-numbered-read-")))
-      (unwind-protect
-          (progn
-            (with-temp-file file
-              (insert "one\ntwo\n"))
-            (should
-             (equal
-              (json-parse-string (funcall function file "text"))
-              "1 | one\n2 | two")))
-        (when (file-exists-p file)
-          (delete-file file))))))
+    (should (member "read_file" (mapcar #'llm-tool-name baseline)))
+    (should (member "read_file" (mapcar #'llm-tool-name balanced)))))
 
 (ert-deftest test-ellama-eval-run-case-scores-files-and-answer ()
   (let ((case

--- a/tests/test-ellama-tools.el
+++ b/tests/test-ellama-tools.el
@@ -263,6 +263,16 @@ Return list with result and prompt."
     (ellama-test--wait-shell-command-result "printf 'ok\\n'")
     "ok")))
 
+(ert-deftest test-ellama-shell-command-tool-uses-cat-pager ()
+  (let ((process-environment (copy-sequence process-environment)))
+    (setenv "PAGER" "less")
+    (setenv "GIT_PAGER" "less")
+    (should
+     (string=
+      (ellama-test--wait-shell-command-result
+       "printf '%s|%s' \"$PAGER\" \"$GIT_PAGER\"")
+      "cat|cat"))))
+
 (ert-deftest test-ellama-enabled-shell-command-tool-async-contract ()
   (ellama-test--ensure-local-ellama-tools)
   (let ((ellama-tools-dlp-enabled t)
@@ -310,6 +320,17 @@ Return list with result and prompt."
        (equal
         (ellama-tools--command-argv "sh" "-c" "printf ok")
         '("/tmp/fake-srt" "--debug" "sh" "-c" "printf ok"))))))
+
+(ert-deftest test-ellama-tools-call-command-uses-cat-pager ()
+  (let ((process-environment (copy-sequence process-environment)))
+    (setenv "PAGER" "less")
+    (setenv "GIT_PAGER" "less")
+    (should
+     (equal
+      (ellama-tools--call-command-to-string
+       shell-file-name shell-command-switch
+       "printf '%s|%s' \"$PAGER\" \"$GIT_PAGER\"")
+      "cat|cat"))))
 
 (ert-deftest test-ellama-shell-command-tool-errors-when-srt-missing ()
   (ellama-test--ensure-local-ellama-tools)
@@ -2276,6 +2297,25 @@ Return list with result and prompt."
         (delete-file file))
       (when (file-directory-p dir)
         (delete-directory dir)))))
+
+(ert-deftest test-ellama-tools-edit-hook-uses-cat-pager ()
+  (ellama-test--ensure-local-ellama-tools)
+  (let ((file (make-temp-file "ellama-hook-pager-"))
+        (process-environment (copy-sequence process-environment))
+        (ellama-tools-edit-before-shell-commands nil)
+        (ellama-tools-edit-after-shell-commands
+         '((:command "printf '%s|%s' \"$PAGER\" \"$GIT_PAGER\""
+                     :show-output t))))
+    (setenv "PAGER" "less")
+    (setenv "GIT_PAGER" "less")
+    (unwind-protect
+        (let ((msg (ellama-tools-write-file-tool file "x")))
+          (should (string-match-p "After edit hook completed" msg))
+          (should (string-match-p "cat|cat" msg)))
+      (when-let* ((buffer (get-file-buffer file)))
+        (kill-buffer buffer))
+      (when (file-exists-p file)
+        (delete-file file)))))
 
 (ert-deftest test-ellama-tools-read-before-write-refuses-first-overwrite ()
   (ellama-test--ensure-local-ellama-tools)


### PR DESCRIPTION
# Summary

Refactor `ellama-eval.el`: remove experimental profiles (`numbered-read`,
`line-edit`, `numbered-line-edit`) and their associated tools/helpers. Retain
only `baseline` and `balanced-edit`.

# Changes

## Removed profiles

-   `numbered-read` — returns numbered read output and standard `edit_file`
-   `line-edit` — returns standard read output and `edit_lines` (line-range
    editing)
-   `numbered-line-edit` — returns numbered read output and `edit_lines`

## Removed symbols

-   `ellama-eval-edit-lines-tool` / `ellama-eval-monitored-edit-lines-tool`
-   `ellama-eval-numbered-read-file-tool` /
    `ellama-eval-numbered-lines-range-tool`
-   `ellama-eval--number-text-lines`
-   `ellama-eval--line-edit-candidate`
-   `ellama-eval--profile-numbered-read-p` / `ellama-eval--profile-line-edit-p` /
    `ellama-eval--profile-balanced-edit-p`
-   `ellama-eval--replace-profile-read-specs`

## Profile routing simplified

-   `ellama-eval--profile-tool-names` now **always** returns `'("edit_file")` for
    all profiles — no conditional switching between `edit_file` and `edit_lines`
-   `ellama-eval--make-profile-tools` no longer calls
    `ellama-eval--replace-profile-read-specs`
-   Both `baseline` and `balanced-edit` now include `edit_file`

## Functional difference between profiles

-   ****`baseline`****: unmonitored `edit_file` — edits are applied directly
-   ****`balanced-edit`****: monitored `edit_file` with `block-invalid=t` — syntax
    validation blocks invalid edits before applying

## Tests

-   Updated `test-ellama-eval-profile-tools-switch-read-and-edit-shapes`:
    `baseline` now asserts `"edit_file"` is present (previously incorrectly
    asserted it was absent)
-   `:edit-call-count` no longer counts `"edit_lines"`
-   All 434 tests pass

