### PR TITLE
Add command timeouts for shell and grep tools

### DIFF
--- a/NEWS.org
+++ b/NEWS.org
@@ -6,6 +6,9 @@
 - Add optional ~timeout~ support to ~grep~ with the same five-second default.
   Directory searches now use timeout-aware command execution and return a clear
   diagnostic when grep exceeds the configured limit.
+- Add optional ~timeout~ support to ~directory_tree~ with the same five-second
+  default. Recursive directory traversal now stops when the timeout expires and
+  returns a clear diagnostic with the partial tree collected so far.
 - Strengthen project git hook templates for local Elisp validation. Staged Elisp
   changes now run ~make checkdocs~ before commit, while pushed Elisp changes run
   ~make check-elisp~ and block the push if formatting changes files.

--- a/NEWS.org
+++ b/NEWS.org
@@ -1,3 +1,15 @@
+* Version 1.23.0
+
+- Add optional ~timeout~ support to ~shell_command~ with a default of five
+  seconds. Long-running async shell commands are terminated when the timeout
+  expires and return a timeout message with any collected output.
+- Add optional ~timeout~ support to ~grep~ with the same five-second default.
+  Directory searches now use timeout-aware command execution and return a clear
+  diagnostic when grep exceeds the configured limit.
+- Strengthen project git hook templates for local Elisp validation. Staged Elisp
+  changes now run ~make checkdocs~ before commit, while pushed Elisp changes run
+  ~make check-elisp~ and block the push if formatting changes files.
+
 * Version 1.22.1
 
 - Remove experimental hypothesis profiles (numbered-read, line-edit,

--- a/ellama-tools.el
+++ b/ellama-tools.el
@@ -2723,37 +2723,66 @@ buffer contents, matching their historical behavior."
    :description
    "Prepend CONTENT to the file FILE_NAME."))
 
-(defun ellama-tools-directory-tree-tool (dir &optional depth)
+(defun ellama-tools--directory-tree-timeout-output (timeout output)
+  "Return diagnostic text for `directory_tree' timeout after TIMEOUT.
+OUTPUT is the partial directory tree collected before the timeout."
+  (if (string-empty-p output)
+      (format "directory_tree timed out after %s seconds." timeout)
+    (format "directory_tree timed out after %s seconds.\n%s"
+            timeout output)))
+
+(defun ellama-tools--directory-tree (dir depth deadline)
+  "Return directory tree under DIR at DEPTH until DEADLINE."
+  (let* ((indent (make-string (* (or depth 0) 2) ? ))
+         (entries
+          (sort (cl-remove-if
+                 (lambda (f)
+                   (string-prefix-p "." f))
+                 (directory-files dir))
+                #'string-lessp))
+         (single-entry-p (= (length entries) 1))
+         (tree "")
+         timed-out)
+    (catch 'done
+      (dolist (f entries)
+        (when (>= (float-time) deadline)
+          (setq timed-out t)
+          (throw 'done nil))
+        (let* ((full   (expand-file-name f dir))
+               (name   (file-name-nondirectory f))
+               (type   (if (file-directory-p full) "|-" "`-"))
+               (line   (concat indent
+                               (unless single-entry-p type)
+                               name "\n")))
+          (setq tree (concat tree line))
+          (when (file-directory-p full)
+            (let ((child (ellama-tools--directory-tree
+                          full
+                          (+ (or depth 0) 1)
+                          deadline)))
+              (setq tree (concat tree (car child)))
+              (when (cdr child)
+                (setq timed-out t)
+                (throw 'done nil)))))))
+    (cons tree timed-out)))
+
+(defun ellama-tools-directory-tree-tool (dir &optional timeout)
   "Return a string representing the directory tree under DIR.
-DEPTH is the current recursion depth, used internally."
+TIMEOUT is the optional command timeout in seconds."
   (or (ellama-tools--tool-check-file-access dir 'list)
       (if (not (file-exists-p dir))
           (format "Directory %s does not exist." dir)
         (if (not (file-directory-p dir))
             (format "%s is not a directory." dir)
-          (let* ((indent (make-string (* (or depth 0) 2) ? ))
-                 (entries
-                  (sort (cl-remove-if
-                         (lambda (f)
-                           (string-prefix-p "." f))
-                         (directory-files dir))
-                        #'string-lessp))
-                 (single-entry-p (= (length entries) 1))
-                 (tree ""))
-            (dolist (f entries)
-              (let* ((full   (expand-file-name f dir))
-                     (name   (file-name-nondirectory f))
-                     (type   (if (file-directory-p full) "|-" "`-"))
-                     (line   (concat indent
-                                     (unless single-entry-p type)
-                                     name "\n")))
-                (setq tree (concat tree line))
-                (when (file-directory-p full)
-                  (setq tree (concat tree
-                                     (ellama-tools-directory-tree-tool
-                                      full
-                                      (+ (or depth 0) 1)))))))
-            tree)))))
+          (let* ((timeout (ellama-tools--shell-command-timeout timeout))
+                 (result (ellama-tools--directory-tree
+                          dir
+                          0
+                          (+ (float-time) timeout)))
+                 (tree (car result)))
+            (if (cdr result)
+                (ellama-tools--directory-tree-timeout-output timeout tree)
+              tree))))))
 
 (ellama-tools-define-tool
  '(:function
@@ -2766,7 +2795,15 @@ DEPTH is the current recursion depth, used internally."
      :type
      string
      :description
-     "Directory path to generate tree for."))
+     "Directory path to generate tree for.")
+    (:name
+     "timeout"
+     :type
+     number
+     :optional
+     t
+     :description
+     "Command timeout in seconds. Defaults to 5."))
    :description
    "Return a string representing the directory tree under DIR."))
 

--- a/ellama-tools.el
+++ b/ellama-tools.el
@@ -192,6 +192,11 @@ Use `image' to force image handling."
                  (const image))
   :group 'ellama)
 
+(defcustom ellama-tools-shell-command-default-timeout 5
+  "Default timeout in seconds for the `shell_command' tool."
+  :type 'number
+  :group 'ellama)
+
 (defcustom ellama-tools-read-before-write-enabled t
   "Require a session-local read before overwriting existing files.
 When non-nil, full-file mutating tools refuse their first attempt to change an
@@ -1894,6 +1899,12 @@ Wrap command with `srt' when `ellama-tools-use-srt' is non-nil."
       (format "%s failed with exit status %s:\n%s"
               program status trimmed))))
 
+(defun ellama-tools--shell-command-timeout (timeout)
+  "Return shell command TIMEOUT or the configured default."
+  (if (and (numberp timeout) (> timeout 0))
+      timeout
+    ellama-tools-shell-command-default-timeout))
+
 (defun ellama-tools--grep-output (result no-matches-message)
   "Return grep RESULT output or NO-MATCHES-MESSAGE."
   (let ((status (car result))
@@ -2842,46 +2853,80 @@ Replace OLDCONTENT with NEWCONTENT."
    :description
    "Edit file FILE_NAME. Replace OLDCONTENT with NEWCONTENT."))
 
-(defun ellama-tools-shell-command-tool (callback cmd)
+(defun ellama-tools-shell-command-tool (callback cmd &optional timeout)
   "Execute shell command CMD.
-CALLBACK – function called once with the result string."
+CALLBACK – function called once with the result string.
+TIMEOUT is the optional command timeout in seconds."
   (let ((argv (ellama-tools--command-argv
                shell-file-name shell-command-switch cmd))
+        (timeout (ellama-tools--shell-command-timeout timeout))
         (process-environment
          (ellama-tools--process-environment-with-cat-pager)))
     (condition-case err
         (let ((buf (get-buffer-create
-                    (concat (make-temp-name " *ellama shell command") "*"))))
-          (set-process-sentinel
-           (apply #'start-process
-                  "*ellama-shell-command*" buf
-                  (car argv) (cdr argv))
-           (lambda (process _)
-             (when (not (process-live-p process))
-               (let* ((raw-output
-                       ;; trim trailing newline to reduce noisy tool output
-                       (string-trim-right
-                        (with-current-buffer buf (buffer-string))
-                        "\n"))
-                      (output
-                       (ellama-tools--sanitize-tool-text-output
-                        raw-output
-                        "Command output"))
-                      (exit-code (process-exit-status process))
-                      (result
-                       (cond
-                        ((and (string= output "") (zerop exit-code))
-                         "Command completed successfully with no output.")
-                        ((string= output "")
-                         (format "Command failed with exit code %d and no output."
-                                 exit-code))
-                        ((zerop exit-code)
-                         output)
-                        (t
-                         (format "Command failed with exit code %d.\n%s"
-                                 exit-code output)))))
-                 (funcall callback result)
-                 (kill-buffer buf))))))
+                    (concat (make-temp-name " *ellama shell command") "*")))
+              process timer done timed-out)
+          (cl-labels
+              ((command-output ()
+                 ;; trim trailing newline to reduce noisy tool output
+                 (ellama-tools--sanitize-tool-text-output
+                  (string-trim-right
+                   (with-current-buffer buf (buffer-string))
+                   "\n")
+                  "Command output"))
+               (timeout-result ()
+                 (let ((output (command-output)))
+                   (if (string-empty-p output)
+                       (format "Command timed out after %s seconds."
+                               timeout)
+                     (format "Command timed out after %s seconds.\n%s"
+                             timeout output))))
+               (finish (result)
+                 (unless done
+                   (setq done t)
+                   (when timer
+                     (cancel-timer timer))
+                   (unwind-protect
+                       (funcall callback result)
+                     (when (buffer-live-p buf)
+                       (kill-buffer buf)))))
+               (finish-process (proc)
+                 (if timed-out
+                     (finish (timeout-result))
+                   (let* ((output (command-output))
+                          (exit-code (process-exit-status proc))
+                          (result
+                           (cond
+                            ((and (string= output "") (zerop exit-code))
+                             "Command completed successfully with no output.")
+                            ((string= output "")
+                             (format
+                              "Command failed with exit code %d and no output."
+                              exit-code))
+                            ((zerop exit-code)
+                             output)
+                            (t
+                             (format "Command failed with exit code %d.\n%s"
+                                     exit-code output)))))
+                     (finish result)))))
+            (setq process
+                  (apply #'start-process
+                         "*ellama-shell-command*" buf
+                         (car argv) (cdr argv)))
+            (set-process-sentinel
+             process
+             (lambda (proc _)
+               (when (not (process-live-p proc))
+                 (finish-process proc))))
+            (setq timer
+                  (run-at-time
+                   timeout nil
+                   (lambda ()
+                     (when (and process (process-live-p process))
+                       (setq timed-out t)
+                       (let ((result (timeout-result)))
+                         (delete-process process)
+                         (finish result))))))))
       (error
        (funcall callback
                 (format "Failed to start shell command: %s"
@@ -2902,7 +2947,15 @@ CALLBACK – function called once with the result string."
      :type
      string
      :description
-     "Shell command to execute."))
+     "Shell command to execute.")
+    (:name
+     "timeout"
+     :type
+     number
+     :optional
+     t
+     :description
+     "Command timeout in seconds. Defaults to 5."))
    :description
    "Execute shell command CMD."))
 

--- a/ellama-tools.el
+++ b/ellama-tools.el
@@ -1891,6 +1891,32 @@ Wrap command with `srt' when `ellama-tools-use-srt' is non-nil."
       (let ((status (apply #'call-process (car argv) nil t nil (cdr argv))))
         (cons status (buffer-string))))))
 
+(defun ellama-tools--call-command-with-timeout (timeout program &rest args)
+  "Run PROGRAM with ARGS and return cons of exit status and stdout.
+Terminate the process and return `timeout' as status after TIMEOUT seconds."
+  (let ((argv (apply #'ellama-tools--command-argv program args))
+        (process-environment
+         (ellama-tools--process-environment-with-cat-pager)))
+    (with-temp-buffer
+      (let* ((process (apply #'start-process
+                             "*ellama-command*" (current-buffer)
+                             (car argv) (cdr argv)))
+             (deadline (+ (float-time) timeout))
+             timed-out)
+        (set-process-sentinel process (lambda (_process _event) nil))
+        (while (and (process-live-p process)
+                    (< (float-time) deadline))
+          (accept-process-output
+           process
+           (max 0.0 (min 0.05 (- deadline (float-time))))))
+        (when (process-live-p process)
+          (setq timed-out t)
+          (delete-process process))
+        (cons (if timed-out
+                  'timeout
+                (process-exit-status process))
+              (buffer-string))))))
+
 (defun ellama-tools--command-failure-output (program status output)
   "Return diagnostic text for PROGRAM failure with STATUS and OUTPUT."
   (let ((trimmed (string-trim-right output "\n")))
@@ -1899,18 +1925,28 @@ Wrap command with `srt' when `ellama-tools-use-srt' is non-nil."
       (format "%s failed with exit status %s:\n%s"
               program status trimmed))))
 
+(defun ellama-tools--command-timeout-output (program timeout output)
+  "Return diagnostic text for PROGRAM timeout after TIMEOUT with OUTPUT."
+  (let ((trimmed (string-trim-right output "\n")))
+    (if (string-empty-p trimmed)
+        (format "%s timed out after %s seconds." program timeout)
+      (format "%s timed out after %s seconds:\n%s"
+              program timeout trimmed))))
+
 (defun ellama-tools--shell-command-timeout (timeout)
   "Return shell command TIMEOUT or the configured default."
   (if (and (numberp timeout) (> timeout 0))
       timeout
     ellama-tools-shell-command-default-timeout))
 
-(defun ellama-tools--grep-output (result no-matches-message)
+(defun ellama-tools--grep-output (result no-matches-message &optional timeout)
   "Return grep RESULT output or NO-MATCHES-MESSAGE."
   (let ((status (car result))
         (output (string-trim-right (cdr result) "\n")))
     (cond
      ((and (integerp status) (zerop status)) output)
+     ((eq status 'timeout)
+      (ellama-tools--command-timeout-output "grep" timeout output))
      ((and (integerp status)
            (= status 1)
            (string-empty-p output))
@@ -2964,10 +3000,12 @@ TIMEOUT is the optional command timeout in seconds."
   (unless case-sensitive
     '("-i")))
 
-(defun ellama-tools-grep-tool (dir search-string &optional case-sensitive)
+(defun ellama-tools-grep-tool (dir search-string &optional case-sensitive timeout)
   "Grep SEARCH-STRING in DIR files.
-Match case-insensitively unless CASE-SENSITIVE is non-nil."
-  (let ((search-dir (expand-file-name dir)))
+Match case-insensitively unless CASE-SENSITIVE is non-nil.
+TIMEOUT is the optional command timeout in seconds."
+  (let ((search-dir (expand-file-name dir))
+        (timeout (ellama-tools--shell-command-timeout timeout)))
     (json-encode
      (cond
       ((not (file-exists-p search-dir))
@@ -2978,14 +3016,16 @@ Match case-insensitively unless CASE-SENSITIVE is non-nil."
        (let ((default-directory (file-name-as-directory search-dir)))
          (ellama-tools--grep-output
           (apply
-           #'ellama-tools--call-command
+           #'ellama-tools--call-command-with-timeout
            (append
-            (list "find" "." "-type" "f" "-exec" "grep" "--color=never")
+            (list timeout
+                  "find" "." "-type" "f" "-exec" "grep" "--color=never")
             (ellama-tools--grep-case-args case-sensitive)
             (list "-nH" "-e" search-string "{}" "+")))
           (format "No matches for %S in %s."
                   search-string
-                  search-dir))))))))
+                  search-dir)
+          timeout)))))))
 
 (ellama-tools-define-tool
  '(:function
@@ -3012,7 +3052,15 @@ Match case-insensitively unless CASE-SENSITIVE is non-nil."
      :optional
      t
      :description
-     "When non-nil, match case sensitively. Defaults to false."))
+     "When non-nil, match case sensitively. Defaults to false.")
+    (:name
+     "timeout"
+     :type
+     number
+     :optional
+     t
+     :description
+     "Command timeout in seconds. Defaults to 5."))
    :description
    "Grep SEARCH-STRING in directory files. Case-insensitive by default."))
 

--- a/ellama-tools.el
+++ b/ellama-tools.el
@@ -1940,7 +1940,8 @@ Terminate the process and return `timeout' as status after TIMEOUT seconds."
     ellama-tools-shell-command-default-timeout))
 
 (defun ellama-tools--grep-output (result no-matches-message &optional timeout)
-  "Return grep RESULT output or NO-MATCHES-MESSAGE."
+  "Return grep RESULT output or NO-MATCHES-MESSAGE.
+TIMEOUT is the timeout in seconds used when RESULT reports a timeout."
   (let ((status (car result))
         (output (string-trim-right (cdr result) "\n")))
     (cond

--- a/ellama.el
+++ b/ellama.el
@@ -6,7 +6,7 @@
 ;; URL: http://github.com/s-kostyaev/ellama
 ;; Keywords: help local tools
 ;; Package-Requires: ((emacs "28.1") (llm "0.30.2") (plz "0.8") (transient "0.7") (compat "29.1") (yaml "1.2.3"))
-;; Version: 1.22.1
+;; Version: 1.23.0
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;; Created: 8th Oct 2023
 

--- a/scripts/git-hooks/pre-commit
+++ b/scripts/git-hooks/pre-commit
@@ -13,4 +13,10 @@ EOF
 	exit 1
 fi
 
+if git diff --cached --name-only --diff-filter=ACMR -- '*.el' | grep -q .
+then
+	printf '%s\n' "Running make checkdocs for staged Elisp changes..."
+	make checkdocs
+fi
+
 exit 0

--- a/scripts/git-hooks/pre-push
+++ b/scripts/git-hooks/pre-push
@@ -13,7 +13,10 @@ EOF
 	exit 1
 fi
 
-while read local_ref _local_sha _remote_ref _remote_sha
+zero_sha=0000000000000000000000000000000000000000
+check_elisp=false
+
+while read local_ref local_sha _remote_ref remote_sha
 do
 	if [ "$local_ref" = "refs/heads/main" ]; then
 		cat >&2 <<'EOF'
@@ -23,6 +26,40 @@ Push a feature branch instead.
 EOF
 		exit 1
 	fi
+
+	if [ "$local_sha" = "$zero_sha" ]; then
+		continue
+	fi
+
+	if [ "$remote_sha" = "$zero_sha" ]; then
+		base=$(git merge-base "$local_sha" main 2>/dev/null || printf '')
+		if [ -n "$base" ]; then
+			range="$base..$local_sha"
+		else
+			range="$local_sha"
+		fi
+	else
+		range="$remote_sha..$local_sha"
+	fi
+
+	if git diff --name-only --diff-filter=ACMR "$range" -- '*.el' | grep -q .
+	then
+		check_elisp=true
+	fi
 done
+
+if [ "$check_elisp" = true ]; then
+	printf '%s\n' "Running make check-elisp for pushed Elisp changes..."
+	make check-elisp
+
+	if ! git diff --quiet -- '*.el'; then
+		cat >&2 <<'EOF'
+Push blocked: make check-elisp changed Elisp files.
+
+Review, stage, and commit those changes before pushing.
+EOF
+		exit 1
+	fi
+fi
 
 exit 0

--- a/tests/test-ellama-tools.el
+++ b/tests/test-ellama-tools.el
@@ -716,8 +716,8 @@ Return list with result and prompt."
                      "\"a:1:match\"")))
     (should (equal captured
                    '(5 "find" "." "-type" "f" "-exec"
-                     "grep" "--color=never" "-i" "-nH" "-e"
-                     "match" "{}" "+")))))
+                       "grep" "--color=never" "-i" "-nH" "-e"
+                       "match" "{}" "+")))))
 
 (ert-deftest test-ellama-tools-grep-tool-passes-timeout ()
   (ellama-test--ensure-local-ellama-tools)
@@ -750,8 +750,8 @@ Return list with result and prompt."
                      "\"a:1:Match\"")))
     (should (equal captured
                    '(5 "find" "." "-type" "f" "-exec"
-                     "grep" "--color=never" "-nH" "-e"
-                     "Match" "{}" "+")))))
+                       "grep" "--color=never" "-nH" "-e"
+                       "Match" "{}" "+")))))
 
 (ert-deftest test-ellama-tools-grep-tool-explains-no-matches ()
   (ellama-test--ensure-local-ellama-tools)

--- a/tests/test-ellama-tools.el
+++ b/tests/test-ellama-tools.el
@@ -2621,6 +2621,52 @@ Return list with result and prompt."
       (when (file-exists-p dir)
         (delete-directory dir t)))))
 
+(ert-deftest test-ellama-tools-directory-tree-tool-uses-default-timeout ()
+  (ellama-test--ensure-local-ellama-tools)
+  (let ((dir (make-temp-file "ellama-tree-timeout-default-" t))
+        (ellama-tools-shell-command-default-timeout 5)
+        captured-timeout)
+    (unwind-protect
+        (cl-letf (((symbol-function 'float-time)
+                   (lambda () 100.0))
+                  ((symbol-function 'ellama-tools--directory-tree)
+                   (lambda (_dir _depth deadline)
+                     (setq captured-timeout (- deadline 100.0))
+                     '("ok\n" . nil))))
+          (should (equal (ellama-tools-directory-tree-tool dir) "ok\n"))
+          (should (= captured-timeout 5)))
+      (when (file-exists-p dir)
+        (delete-directory dir t)))))
+
+(ert-deftest test-ellama-tools-directory-tree-tool-passes-timeout ()
+  (ellama-test--ensure-local-ellama-tools)
+  (let ((dir (make-temp-file "ellama-tree-timeout-" t))
+        captured-timeout)
+    (unwind-protect
+        (cl-letf (((symbol-function 'float-time)
+                   (lambda () 100.0))
+                  ((symbol-function 'ellama-tools--directory-tree)
+                   (lambda (_dir _depth deadline)
+                     (setq captured-timeout (- deadline 100.0))
+                     '("ok\n" . nil))))
+          (should (equal (ellama-tools-directory-tree-tool dir 0.25) "ok\n"))
+          (should (= captured-timeout 0.25)))
+      (when (file-exists-p dir)
+        (delete-directory dir t)))))
+
+(ert-deftest test-ellama-tools-directory-tree-tool-explains-timeout ()
+  (ellama-test--ensure-local-ellama-tools)
+  (let ((dir (make-temp-file "ellama-tree-timeout-output-" t)))
+    (unwind-protect
+        (cl-letf (((symbol-function 'ellama-tools--directory-tree)
+                   (lambda (&rest _args)
+                     '("|-a\n" . t))))
+          (should
+           (equal (ellama-tools-directory-tree-tool dir 0.1)
+                  "directory_tree timed out after 0.1 seconds.\n|-a\n")))
+      (when (file-exists-p dir)
+        (delete-directory dir t)))))
+
 (ert-deftest test-ellama-tools-grep-explains-missing-directory ()
   (ellama-test--ensure-local-ellama-tools)
   (let ((dir (make-temp-name

--- a/tests/test-ellama-tools.el
+++ b/tests/test-ellama-tools.el
@@ -138,15 +138,17 @@
        (when (file-exists-p settings-file)
          (delete-file settings-file)))))
 
-(defun ellama-test--wait-shell-command-result (cmd)
+(defun ellama-test--wait-shell-command-result (cmd &optional timeout)
   "Run shell tool CMD and wait for a result string."
   (ellama-test--ensure-local-ellama-tools)
   (let ((result :pending)
-        (deadline (+ (float-time) 3.0)))
+        (deadline (+ (float-time)
+                     (max 3.0 (+ (or timeout 0) 1.0)))))
     (ellama-tools-shell-command-tool
      (lambda (res)
        (setq result res))
-     cmd)
+     cmd
+     timeout)
     (while (and (eq result :pending)
                 (< (float-time) deadline))
       (accept-process-output nil 0.01))
@@ -262,6 +264,17 @@ Return list with result and prompt."
    (string=
     (ellama-test--wait-shell-command-result "printf 'ok\\n'")
     "ok")))
+
+(ert-deftest test-ellama-shell-command-tool-default-timeout ()
+  (ellama-test--ensure-local-ellama-tools)
+  (let ((ellama-tools-shell-command-default-timeout 5))
+    (should (= (ellama-tools--shell-command-timeout nil) 5))))
+
+(ert-deftest test-ellama-shell-command-tool-times-out ()
+  (should
+   (string-match-p
+    "Command timed out after 0\\.1 seconds\\."
+    (ellama-test--wait-shell-command-result "sleep 1" 0.1))))
 
 (ert-deftest test-ellama-shell-command-tool-uses-cat-pager ()
   (let ((process-environment (copy-sequence process-environment)))

--- a/tests/test-ellama-tools.el
+++ b/tests/test-ellama-tools.el
@@ -139,7 +139,7 @@
          (delete-file settings-file)))))
 
 (defun ellama-test--wait-shell-command-result (cmd &optional timeout)
-  "Run shell tool CMD and wait for a result string."
+  "Run shell tool CMD with TIMEOUT and wait for a result string."
   (ellama-test--ensure-local-ellama-tools)
   (let ((result :pending)
         (deadline (+ (float-time)

--- a/tests/test-ellama-tools.el
+++ b/tests/test-ellama-tools.el
@@ -345,6 +345,12 @@ Return list with result and prompt."
        "printf '%s|%s' \"$PAGER\" \"$GIT_PAGER\"")
       "cat|cat"))))
 
+(ert-deftest test-ellama-tools-call-command-with-timeout-times-out ()
+  (should
+   (eq (car (ellama-tools--call-command-with-timeout
+             0.1 shell-file-name shell-command-switch "sleep 1"))
+       'timeout)))
+
 (ert-deftest test-ellama-shell-command-tool-errors-when-srt-missing ()
   (ellama-test--ensure-local-ellama-tools)
   (let ((ellama-tools-use-srt t)
@@ -700,29 +706,50 @@ Return list with result and prompt."
 
 (ert-deftest test-ellama-tools-grep-tool-uses-shared-command-helper ()
   (ellama-test--ensure-local-ellama-tools)
-  (let (captured)
-    (cl-letf (((symbol-function 'ellama-tools--call-command)
+  (let ((ellama-tools-shell-command-default-timeout 5)
+        captured)
+    (cl-letf (((symbol-function 'ellama-tools--call-command-with-timeout)
                (lambda (&rest args)
                  (setq captured args)
                  '(0 . "a:1:match\n"))))
       (should (equal (ellama-tools-grep-tool default-directory "match")
                      "\"a:1:match\"")))
     (should (equal captured
-                   '("find" "." "-type" "f" "-exec"
+                   '(5 "find" "." "-type" "f" "-exec"
                      "grep" "--color=never" "-i" "-nH" "-e"
                      "match" "{}" "+")))))
 
-(ert-deftest test-ellama-tools-grep-tool-can-match-case-sensitively ()
+(ert-deftest test-ellama-tools-grep-tool-passes-timeout ()
   (ellama-test--ensure-local-ellama-tools)
   (let (captured)
-    (cl-letf (((symbol-function 'ellama-tools--call-command)
+    (cl-letf (((symbol-function 'ellama-tools--call-command-with-timeout)
+               (lambda (&rest args)
+                 (setq captured args)
+                 '(0 . "a:1:match\n"))))
+      (should (equal (ellama-tools-grep-tool default-directory "match" nil 0.25)
+                     "\"a:1:match\"")))
+    (should (equal (car captured) 0.25))))
+
+(ert-deftest test-ellama-tools-grep-tool-explains-timeout ()
+  (ellama-test--ensure-local-ellama-tools)
+  (cl-letf (((symbol-function 'ellama-tools--call-command-with-timeout)
+             (lambda (&rest _args)
+               '(timeout . ""))))
+    (should (equal (ellama-tools-grep-tool default-directory "match" nil 0.1)
+                   "\"grep timed out after 0.1 seconds.\""))))
+
+(ert-deftest test-ellama-tools-grep-tool-can-match-case-sensitively ()
+  (ellama-test--ensure-local-ellama-tools)
+  (let ((ellama-tools-shell-command-default-timeout 5)
+        captured)
+    (cl-letf (((symbol-function 'ellama-tools--call-command-with-timeout)
                (lambda (&rest args)
                  (setq captured args)
                  '(0 . "a:1:Match\n"))))
       (should (equal (ellama-tools-grep-tool default-directory "Match" t)
                      "\"a:1:Match\"")))
     (should (equal captured
-                   '("find" "." "-type" "f" "-exec"
+                   '(5 "find" "." "-type" "f" "-exec"
                      "grep" "--color=never" "-nH" "-e"
                      "Match" "{}" "+")))))
 


### PR DESCRIPTION
## Summary
- add optional timeout support to shell_command with a 5 second default
- add optional timeout support to grep using timeout-aware command execution
- cover timeout defaults, explicit timeout arguments, and timeout diagnostics in tests

## Tests
- make test