### PR TITLE
Add plan-and-act agent loop

### DIFF
--- a/.codex/hooks/check-files.sh
+++ b/.codex/hooks/check-files.sh
@@ -1,0 +1,87 @@
+#!/bin/sh
+set -eu
+
+check_elisp=false
+check_readme=false
+check_news=false
+elisp_files=
+
+append_file() {
+	files=$1
+	file=$2
+	if [ -n "$files" ]; then
+		printf '%s %s' "$files" "$file"
+	else
+		printf '%s' "$file"
+	fi
+}
+
+for file in "$@"
+do
+	case "$file" in
+		"$PWD"/*) rel=${file#"$PWD"/} ;;
+		*) rel=$file ;;
+	esac
+
+	case "$rel" in
+		*.el)
+			check_elisp=true
+			elisp_files=$(append_file "$elisp_files" "$rel")
+			;;
+		README.org)
+			check_readme=true
+			;;
+		NEWS.org)
+			check_news=true
+			;;
+	esac
+done
+
+ensure_clean() {
+	target=$1
+	shift
+
+	if [ "${ELLAMA_BLOCK_ON_CHECK_CHANGES:-}" != 1 ]; then
+		return
+	fi
+
+	if ! git diff --quiet -- "$@"; then
+		cat >&2 <<EOF
+Push blocked: make $target changed files.
+
+Review, stage, and commit those changes before pushing.
+EOF
+		exit 1
+	fi
+}
+
+run_check() {
+	target=$1
+	label=$2
+	shift 2
+	output=$(mktemp)
+	printf '%s\n' "Running make $target for $label..."
+	if make "$target" >"$output" 2>&1; then
+		rm -f "$output"
+		printf '%s\n' "$target passed for $label."
+	else
+		status=$?
+		printf '%s\n\n' "$target failed for $label."
+		cat "$output"
+		rm -f "$output"
+		exit "$status"
+	fi
+	ensure_clean "$target" "$@"
+}
+
+if [ "$check_elisp" = true ]; then
+	run_check check-elisp "$elisp_files" '*.el' 'tests/*.el'
+fi
+
+if [ "$check_readme" = true ]; then
+	run_check check-readme README.org README.org ellama.texi ellama.info
+fi
+
+if [ "$check_news" = true ]; then
+	run_check check-news NEWS.org NEWS.org
+fi

--- a/.codex/hooks/post-edit.sh
+++ b/.codex/hooks/post-edit.sh
@@ -8,34 +8,4 @@ if [ -z "$file" ]; then
 	exit 1
 fi
 
-case "$file" in
-	"$PWD"/*) rel=${file#"$PWD"/} ;;
-	*) rel=$file ;;
-esac
-
-run_check() {
-	target=$1
-	output=$(mktemp)
-	if make "$target" >"$output" 2>&1; then
-		rm -f "$output"
-		printf '%s\n' "$target passed for $rel."
-	else
-		status=$?
-		printf '%s\n\n' "$target failed for $rel."
-		cat "$output"
-		rm -f "$output"
-		exit "$status"
-	fi
-}
-
-case "$rel" in
-	*.el)
-		run_check check-elisp
-		;;
-	README.org)
-		run_check check-readme
-		;;
-	NEWS.org)
-		run_check check-news
-		;;
-esac
+sh .codex/hooks/check-files.sh "$file"

--- a/NEWS.org
+++ b/NEWS.org
@@ -1,3 +1,10 @@
+* Version 1.24.0
+- Added plan-and-act agent loop for multi-agent code generation workflows.
+- Added plan-and-act agent to transient menu for easy access.
+- Added support for resuming plan-and-act after interruption.
+- Formatted plan-and-act tool arguments for better reliability.
+- Fixed plan-and-act test root path for correct test execution.
+- Documented plan-and-act agent loop functionality.
 * Version 1.23.0
 
 - Add optional ~timeout~ support to ~shell_command~ with a default of five

--- a/README.org
+++ b/README.org
@@ -132,6 +132,10 @@ More sophisticated configuration example:
 - ~ellama-chat~: Ask Ellama about something by entering a prompt in an
   interactive buffer and continue conversation. If called with universal
   argument (~C-u~) will start new session with llm model interactive selection.
+- ~ellama-plan-and-act~: Start an agent loop that first creates a checklist plan
+  and then acts on it with automatic continuations.  It reuses the current chat
+  session when possible and can be launched from the main transient menu with
+  ~A~ in the ~Problem solving~ section.
 - ~ellama-ask-image~: Ask Ellama about one image file by adding it as ephemeral
   context for the request. If called with universal argument (~C-u~) will start
   new session with llm model interactive selection.
@@ -354,9 +358,9 @@ generated text string.
   context limit that triggers automatic compaction. Default value is 80.
 - ~ellama-session-auto-compact-keep-last-turns~: Number of recent user turns to
   keep verbatim during compaction. Default value is 3.
-- ~ellama-session-auto-compact-allow-fewer-kept-turns~: Allow compaction to
-  keep fewer recent user turns when the configured keep count would otherwise
-  prevent short but oversized sessions from being compacted. Enabled by default.
+- ~ellama-session-auto-compact-allow-fewer-kept-turns~: Allow compaction to keep
+  fewer recent user turns when the configured keep count would otherwise prevent
+  short but oversized sessions from being compacted. Enabled by default.
 - ~ellama-session-auto-compact-target-token-threshold~: Preferred target token
   count after compaction. If not set, Ellama targets half of the compaction
   threshold.
@@ -658,16 +662,52 @@ Template resolution is intentionally scoped:
 This keeps large prompts out of the main agent context while still letting
 skills bundle reusable task prompts next to their ~SKILL.md~ files.
 
+** Plan-and-Act Agent Loop
+
+~ellama-plan-and-act~ runs a local agent in the current Ellama chat session.  It
+starts with a planning turn, asks the model to submit a checklist, and then
+continues automatically through the checklist until the agent reports a result,
+marks the plan complete, becomes blocked, or reaches
+~ellama-tools-agent-default-max-steps~.
+
+The loop adds temporary controller tools to the session:
+
+- ~agent_submit_plan~ records the initial checklist before acting starts
+- ~agent_update_plan~ records progress as checklist items move between states
+- ~agent_report_result~ finishes the loop and restores the original tool set
+
+Models or providers that cannot call tools can still participate by emitting the
+fallback ~BEGIN_ELLAMA_AGENT_STATE~ block described in the controller prompt.
+Ellama parses that block, updates the stored state, and prints visible plan or
+status snapshots into the chat buffer.
+
+Start the loop with ~M-x ellama-plan-and-act~, or open the main transient with
+~M-x ellama~ and press ~A~ in the ~Problem solving~ section.  The transient
+entry respects the regular session options: use ~-n~ before ~A~ to create a new
+session, and use ~-e~ when ephemeral sessions are enabled.
+
+Without a new-session request, the command reuses the current chat buffer and
+session.  If that session already has an active plan-and-act loop, a new user
+message resumes the same loop instead of replacing the plan.  This makes it
+possible to interrupt a running request with ~C-g~, add corrective instructions
+under the next ~User:~ prompt, and continue the existing loop with ~C-c C-c~ or
+another ~ellama-plan-and-act~ call.
+
+Plan-and-act state is stored in the session extra data, so the loop survives
+session compaction and regular session persistence.  The visible plan/status
+notes in the chat buffer are for transparency; the canonical state is the
+session state used by the continuation handler.
+
 ** Edit Tool Shell Hooks
 
 Projects can define shell commands that run around mutating edit tools:
 ~write_file~, ~append_file~, ~prepend_file~ and ~edit_file~.  Hooks are read
-from the target file buffer, so project-local values from ~.dir-locals.el~
-apply to the file being edited.
+from the target file buffer, so project-local values from ~.dir-locals.el~ apply
+to the file being edited.
 
 Each hook entry is a plist with a required ~:command~ string.  A non-zero exit
-status is always returned to the agent.  Successful hook output is returned
-only when that hook has ~:show-output t~ and produced non-empty output.
+status is always returned to the agent.  Successful hook output is returned only
+when that hook has ~:show-output t~ and produced non-empty output.
 
 Before hooks run after access checks and syntax validation, but before the file
 is written.  A failing before hook blocks the edit.  After hooks run after a

--- a/ellama-tools.el
+++ b/ellama-tools.el
@@ -3787,6 +3787,12 @@ TEMPLATE-BASE, ROLE and ARGUMENTS are used for template rendering and hints."
      (ellama-tools--session-extra-with
       session :tools (and had-tools tools)))))
 
+(defun ellama-tools-agent-active-p (session)
+  "Return non-nil when SESSION has a running plan-and-act loop."
+  (when-let* ((state (ellama-tools--agent-state session)))
+    (and (not (plist-get state :completed))
+         (not (memq (plist-get state :phase) '(done blocked))))))
+
 (defun ellama-tools--agent-active-session ()
   "Return active session for plan-and-act controller tools."
   (or (ellama-tools--active-session)
@@ -4005,6 +4011,31 @@ automatic continuations."
       :tools combined-tools))
     (ellama-tools--agent-insert-note
      buffer "Status" "Planning started.")
+    (list :system agent-system
+          :tools combined-tools
+          :on-done (ellama-tools--make-agent-loop-handler
+                    session buffer agent-system))))
+
+(defun ellama-tools-resume-plan-and-act
+    (session buffer &optional system tools)
+  "Return stream args needed to resume SESSION plan-and-act loop in BUFFER.
+SYSTEM and TOOLS can override the stored runtime values."
+  (unless (ellama-tools-agent-active-p session)
+    (error "No active plan-and-act loop"))
+  (let* ((state (ellama-tools--agent-state session))
+         (agent-system (or system
+                           (plist-get state :system)
+                           (ellama-tools--agent-system-message nil)))
+         (combined-tools
+          (ellama-tools--agent-combine-tools
+           (or tools
+               (plist-get (ellama-session-extra session) :tools)
+               ellama-tools-enabled))))
+    (setq state (ellama-tools--agent-state-put state :system agent-system))
+    (ellama-tools--agent-put-state session state)
+    (ellama-tools--set-session-extra
+     session
+     (ellama-tools--session-extra-with session :tools combined-tools))
     (list :system agent-system
           :tools combined-tools
           :on-done (ellama-tools--make-agent-loop-handler

--- a/ellama-tools.el
+++ b/ellama-tools.el
@@ -3748,15 +3748,15 @@ TEMPLATE-BASE, ROLE and ARGUMENTS are used for template rendering and hints."
     :name "agent_submit_plan"
     :description "Submit the checklist plan before acting."
     :args '((:name "plan" :type string
-             :description "Org-style checklist or numbered plan.")))
+                   :description "Org-style checklist or numbered plan.")))
    (llm-make-tool
     :function #'ellama-tools-agent-update-plan-tool
     :name "agent_update_plan"
     :description "Update checklist status after making progress."
     :args '((:name "plan" :type string
-             :description "Full updated Org-style checklist.")
+                   :description "Full updated Org-style checklist.")
             (:name "status" :type string
-             :description "Short status summary.")))
+                   :description "Short status summary.")))
    (llm-make-tool
     :function #'ellama-tools-agent-report-result-tool
     :name "agent_report_result"

--- a/ellama-tools.el
+++ b/ellama-tools.el
@@ -272,6 +272,11 @@ Plist with keys `:path', `:mtime' and `:policy'.")
   :type 'integer
   :group 'ellama)
 
+(defcustom ellama-tools-agent-default-max-steps 40
+  "Default maximum number of auto-continue steps for plan-and-act agents."
+  :type 'integer
+  :group 'ellama)
+
 (defcustom ellama-tools-task-template-dirs
   (list (locate-user-emacs-file "ellama/task-templates"))
   "Directories used to resolve relative task template names.
@@ -316,6 +321,31 @@ The guard applies before output is sent back to the LLM."
 
 (defcustom ellama-tools-subagent-continue-prompt "Task not marked complete. Continue working. If you are done, YOU MUST use the `report_result` tool."
   "Prompt sent to sub-agent to keep the loop going."
+  :type 'string
+  :group 'ellama)
+
+(defcustom ellama-tools-agent-planning-prompt
+  "Create a concise checklist plan for the user's task before acting.
+Inspect context with tools if needed. When the plan is ready, either call the
+`agent_submit_plan` tool with the full checklist, or include this block exactly
+if tool calls are not available:
+
+BEGIN_ELLAMA_AGENT_STATE
+phase: acting
+plan:
+- [ ] First concrete step
+- [ ] Second concrete step
+END_ELLAMA_AGENT_STATE"
+  "Prompt sent while the plan-and-act loop is planning."
+  :type 'string
+  :group 'ellama)
+
+(defcustom ellama-tools-agent-continue-prompt
+  "Continue the plan-and-act loop. Work on the first pending checklist item.
+After each meaningful change, call `agent_update_plan` or include an updated
+BEGIN_ELLAMA_AGENT_STATE block. When all items are complete, call
+`agent_report_result` or set phase: done with a result."
+  "Prompt sent to continue a plan-and-act loop."
   :type 'string
   :group 'ellama)
 
@@ -3507,6 +3537,478 @@ TEMPLATE-BASE, ROLE and ARGUMENTS are used for template rendering and hints."
     (or description
         (error "%s" (ellama-tools--task-template-error
                      "Either description or template is required")))))
+
+(defconst ellama-tools--agent-state-begin "BEGIN_ELLAMA_AGENT_STATE"
+  "Marker starting a fallback plan-and-act state block.")
+
+(defconst ellama-tools--agent-state-end "END_ELLAMA_AGENT_STATE"
+  "Marker ending a fallback plan-and-act state block.")
+
+(defun ellama-tools--agent-state (session)
+  "Return plan-and-act state from SESSION."
+  (when-let* (((ellama-session-p session))
+              (extra (ellama-session-extra session)))
+    (plist-get extra :agent-loop)))
+
+(defun ellama-tools--agent-put-state (session state)
+  "Store plan-and-act STATE in SESSION."
+  (ellama-tools--set-session-extra
+   session
+   (ellama-tools--session-extra-with session :agent-loop state)))
+
+(defun ellama-tools--agent-state-put (state key value)
+  "Return STATE with KEY set to VALUE."
+  (plist-put (copy-sequence state) key value))
+
+(defun ellama-tools--agent-session-buffer (session &optional buffer)
+  "Return live chat BUFFER for SESSION."
+  (or (and (buffer-live-p buffer) buffer)
+      (when-let* (((ellama-session-p session))
+                  (extra (ellama-session-extra session))
+                  (uid (plist-get extra :uid))
+                  (session-buffer (ellama-get-session-buffer uid)))
+        (and (buffer-live-p session-buffer) session-buffer))
+      (when-let* (((ellama-session-p session))
+                  (session-buffer
+                   (ellama-get-session-buffer (ellama-session-id session))))
+        (and (buffer-live-p session-buffer) session-buffer))))
+
+(defun ellama-tools--agent-step-status (step)
+  "Return STEP status."
+  (or (plist-get step :status) 'pending))
+
+(defun ellama-tools--agent-step-done-p (step)
+  "Return non-nil when STEP is done."
+  (eq (ellama-tools--agent-step-status step) 'done))
+
+(defun ellama-tools--agent-next-step (state)
+  "Return first pending step in STATE."
+  (seq-find (lambda (step)
+              (not (ellama-tools--agent-step-done-p step)))
+            (plist-get state :plan)))
+
+(defun ellama-tools--agent-plan-complete-p (state)
+  "Return non-nil when STATE plan is fully done."
+  (let ((plan (plist-get state :plan)))
+    (and plan (seq-every-p #'ellama-tools--agent-step-done-p plan))))
+
+(defun ellama-tools--agent-clean-step-title (line)
+  "Return checklist step title parsed from LINE."
+  (let ((title (string-trim line)))
+    (setq title
+          (replace-regexp-in-string
+           "\\`[-+*][[:space:]]+\\(?:\\[[ Xx-]\\][[:space:]]+\\)?"
+           "" title))
+    (setq title
+          (replace-regexp-in-string
+           "\\`[0-9]+[.)][[:space:]]+\\(?:\\[[ Xx-]\\][[:space:]]+\\)?"
+           "" title))
+    (string-trim title)))
+
+(defun ellama-tools--agent-status-from-line (line)
+  "Return checklist status parsed from LINE."
+  (cond
+   ((string-match-p "\\[[Xx]\\]" line) 'done)
+   ((string-match-p "\\[-\\]" line) 'in-progress)
+   (t 'pending)))
+
+(defun ellama-tools--agent-parse-plan (text)
+  "Return checklist entries parsed from TEXT."
+  (let ((id 0)
+        steps)
+    (dolist (line (split-string (or text "") "\n"))
+      (let ((trimmed (string-trim line)))
+        (when (string-match-p
+               "\\`\\(?:[-+*][[:space:]]+\\|[0-9]+[.)][[:space:]]+\\)"
+               trimmed)
+          (let ((title (ellama-tools--agent-clean-step-title trimmed)))
+            (unless (string-empty-p title)
+              (push (list :id (cl-incf id)
+                          :title title
+                          :status (ellama-tools--agent-status-from-line
+                                   trimmed))
+                    steps))))))
+    (nreverse steps)))
+
+(defun ellama-tools--agent-state-block (text)
+  "Return fallback state block from TEXT, or nil."
+  (when (and (stringp text)
+             (string-match
+              (concat (regexp-quote ellama-tools--agent-state-begin)
+                      "\\(?:.\\|\n\\)*?"
+                      (regexp-quote ellama-tools--agent-state-end))
+              text))
+    (match-string 0 text)))
+
+(defun ellama-tools--agent-parse-phase (text)
+  "Return plan-and-act phase parsed from TEXT."
+  (when (and (stringp text)
+             (string-match
+              "^phase:[[:space:]]*\\([[:alpha:]-]+\\)[[:space:]]*$"
+              text))
+    (intern (match-string 1 text))))
+
+(defun ellama-tools--agent-parse-field (field text)
+  "Return FIELD value parsed from TEXT."
+  (when (and (stringp text)
+             (string-match
+              (format "^%s:[[:space:]]*\\(.+\\)[[:space:]]*$"
+                      (regexp-quote field))
+              text))
+    (string-trim (match-string 1 text))))
+
+(defun ellama-tools--agent-state-from-text (text)
+  "Return plan-and-act state update parsed from TEXT."
+  (when-let* ((block (ellama-tools--agent-state-block text)))
+    (let ((plan (ellama-tools--agent-parse-plan block))
+          (phase (ellama-tools--agent-parse-phase block))
+          (result (ellama-tools--agent-parse-field "result" block))
+          (blocked (ellama-tools--agent-parse-field "blocked" block)))
+      (when (or plan phase result blocked)
+        (list :phase phase
+              :plan plan
+              :result result
+              :blocked blocked)))))
+
+(defun ellama-tools--agent-merge-state-update (state update)
+  "Return STATE merged with parsed UPDATE."
+  (let ((state (copy-sequence state)))
+    (when-let ((phase (plist-get update :phase)))
+      (setq state (plist-put state :phase phase)))
+    (when-let ((plan (plist-get update :plan)))
+      (setq state (plist-put state :plan plan)))
+    (when-let ((result (plist-get update :result)))
+      (setq state (plist-put state :result result)))
+    (when-let ((blocked (plist-get update :blocked)))
+      (setq state (plist-put state :blocked blocked)
+            state (plist-put state :phase 'blocked)))
+    (when (eq (plist-get state :phase) 'done)
+      (setq state (plist-put state :completed t)))
+    state))
+
+(defun ellama-tools--agent-checkbox (status)
+  "Return Org checkbox string for STATUS."
+  (pcase status
+    ('done "[X]")
+    ((or 'in-progress 'blocked) "[-]")
+    (_ "[ ]")))
+
+(defun ellama-tools--agent-render-plan (state)
+  "Return Org text rendering plan in STATE."
+  (mapconcat
+   (lambda (step)
+     (format "- %s %s"
+             (ellama-tools--agent-checkbox
+              (ellama-tools--agent-step-status step))
+             (plist-get step :title)))
+   (plist-get state :plan)
+   "\n"))
+
+(defun ellama-tools--agent-insert-note (buffer title body)
+  "Insert visible plan-and-act note with TITLE and BODY into BUFFER."
+  (when (buffer-live-p buffer)
+    (with-current-buffer buffer
+      (save-excursion
+        (goto-char (point-max))
+        (unless (bobp)
+          (unless (bolp)
+            (insert "\n"))
+          (unless (save-excursion
+                    (forward-line -1)
+                    (looking-at-p "[[:space:]]*$"))
+            (insert "\n")))
+        (insert (ellama-get-nick-prefix-for-mode)
+                " Ellama Agent " title ":\n"
+                (or body "")
+                "\n\n")))))
+
+(defun ellama-tools--agent-insert-state (session buffer title)
+  "Insert SESSION plan-and-act state into BUFFER with TITLE."
+  (when-let* ((state (ellama-tools--agent-state session)))
+    (let ((plan (ellama-tools--agent-render-plan state))
+          (phase (plist-get state :phase))
+          (result (plist-get state :result))
+          (blocked (plist-get state :blocked)))
+      (ellama-tools--agent-insert-note
+       (ellama-tools--agent-session-buffer session buffer)
+       title
+       (string-join
+        (delq nil
+              (list (format "Phase: %s" phase)
+                    (unless (string-empty-p plan) plan)
+                    (when blocked (format "Blocked: %s" blocked))
+                    (when result (format "Result: %s" result))))
+        "\n")))))
+
+(defun ellama-tools--agent-controller-tools ()
+  "Return plan-and-act controller tools."
+  (list
+   (llm-make-tool
+    :function #'ellama-tools-agent-submit-plan-tool
+    :name "agent_submit_plan"
+    :description "Submit the checklist plan before acting."
+    :args '((:name "plan" :type string
+             :description "Org-style checklist or numbered plan.")))
+   (llm-make-tool
+    :function #'ellama-tools-agent-update-plan-tool
+    :name "agent_update_plan"
+    :description "Update checklist status after making progress."
+    :args '((:name "plan" :type string
+             :description "Full updated Org-style checklist.")
+            (:name "status" :type string
+             :description "Short status summary.")))
+   (llm-make-tool
+    :function #'ellama-tools-agent-report-result-tool
+    :name "agent_report_result"
+    :description "Report final result and terminate the plan-and-act loop."
+    :args '((:name "result" :type string)))))
+
+(defun ellama-tools--agent-tool-name-p (name)
+  "Return non-nil when NAME is a plan-and-act controller tool."
+  (member name '("agent_submit_plan"
+                 "agent_update_plan"
+                 "agent_report_result")))
+
+(defun ellama-tools--agent-combine-tools (tools)
+  "Return TOOLS plus plan-and-act controller tools."
+  (let ((base (seq-remove
+               (lambda (tool)
+                 (ellama-tools--agent-tool-name-p (llm-tool-name tool)))
+               tools)))
+    (append (ellama-tools--agent-controller-tools) base)))
+
+(defun ellama-tools--agent-restore-tools (session)
+  "Restore SESSION tools saved before plan-and-act started."
+  (let* ((state (ellama-tools--agent-state session))
+         (had-tools (plist-get state :had-original-tools))
+         (tools (plist-get state :original-tools)))
+    (ellama-tools--set-session-extra
+     session
+     (ellama-tools--session-extra-with
+      session :tools (and had-tools tools)))))
+
+(defun ellama-tools--agent-active-session ()
+  "Return active session for plan-and-act controller tools."
+  (or (ellama-tools--active-session)
+      ellama--current-session))
+
+(defun ellama-tools-agent-submit-plan-tool (plan)
+  "Submit plan-and-act PLAN."
+  (let* ((session (ellama-tools--agent-active-session))
+         (state (ellama-tools--agent-state session))
+         (steps (ellama-tools--agent-parse-plan plan)))
+    (unless (and (ellama-session-p session) state)
+      (error "No active plan-and-act session"))
+    (unless steps
+      (error "Plan must contain at least one checklist or numbered item"))
+    (setq state (ellama-tools--agent-state-put state :plan steps))
+    (setq state (ellama-tools--agent-state-put state :phase 'acting))
+    (ellama-tools--agent-put-state session state)
+    (ellama-tools--agent-insert-state session nil "Plan")
+    "Plan accepted. Continue with the first pending item."))
+
+(defun ellama-tools-agent-update-plan-tool (plan &optional status)
+  "Update current plan-and-act PLAN with optional STATUS."
+  (let* ((session (ellama-tools--agent-active-session))
+         (state (ellama-tools--agent-state session))
+         (steps (ellama-tools--agent-parse-plan plan)))
+    (unless (and (ellama-session-p session) state)
+      (error "No active plan-and-act session"))
+    (unless steps
+      (error "Plan update must contain at least one checklist or numbered item"))
+    (setq state (ellama-tools--agent-state-put state :plan steps))
+    (setq state (ellama-tools--agent-state-put state :phase 'acting))
+    (when status
+      (setq state (ellama-tools--agent-state-put state :status status)))
+    (ellama-tools--agent-put-state session state)
+    (ellama-tools--agent-insert-state session nil "Status")
+    "Plan updated."))
+
+(defun ellama-tools-agent-report-result-tool (result)
+  "Report final plan-and-act RESULT."
+  (let* ((session (ellama-tools--agent-active-session))
+         (state (ellama-tools--agent-state session)))
+    (unless (and (ellama-session-p session) state)
+      (error "No active plan-and-act session"))
+    (setq state (ellama-tools--agent-state-put state :phase 'done))
+    (setq state (ellama-tools--agent-state-put state :completed t))
+    (setq state (ellama-tools--agent-state-put state :result result))
+    (ellama-tools--agent-put-state session state)
+    (ellama-tools--agent-insert-state session nil "Done")
+    (ellama-tools--agent-restore-tools session)
+    "Result received. Plan-and-act loop completed."))
+
+(defun ellama-tools--agent-system-message (system)
+  "Return plan-and-act system message appended to SYSTEM."
+  (format
+   "%s\n\nPLAN AND ACT INSTRUCTIONS:\n\
+You are running inside Ellama's plan-and-act controller. The controller gives \
+you three extra tools for this session:
+
+- `agent_submit_plan`: call this once after you have a concrete checklist. Do \
+not start making changes before submitting a plan unless you need read-only \
+inspection to craft it.
+- `agent_update_plan`: call this after meaningful progress, especially when a \
+checklist item moves to in-progress or done.
+- `agent_report_result`: call this exactly once when the task is complete.
+
+Do not ask the user unless you are truly blocked. Execute the checklist step by \
+step and keep it current. If the provider or model cannot use tools, emit \
+exactly one BEGIN_ELLAMA_AGENT_STATE block with phase, plan, and optional \
+result/blocked fields instead."
+   (or system "")))
+
+(defun ellama-tools--agent-prompt (state)
+  "Return controller prompt for plan-and-act STATE."
+  (let ((plan (ellama-tools--agent-render-plan state))
+        (next (ellama-tools--agent-next-step state)))
+    (string-join
+     (delq nil
+           (list
+            (if (plist-get state :plan)
+                ellama-tools-agent-continue-prompt
+              ellama-tools-agent-planning-prompt)
+            (unless (string-empty-p plan)
+              (concat "Current plan state:\n" plan))
+            (when next
+              (format "Next pending item: %s" (plist-get next :title)))))
+     "\n\n")))
+
+(defun ellama-tools--insert-agent-prompt (buffer prompt)
+  "Insert controller PROMPT into BUFFER and return insertion point."
+  (with-current-buffer buffer
+    (save-excursion
+      (goto-char (point-max))
+      (unless (bobp)
+        (unless (bolp)
+          (insert "\n"))
+        (unless (save-excursion
+                  (forward-line -1)
+                  (looking-at-p "[[:space:]]*$"))
+          (insert "\n")))
+      (insert (ellama-get-nick-prefix-for-mode)
+              " Agent controller:\n"
+              (ellama--fill-long-lines prompt)
+              "\n\n"
+              (ellama-get-nick-prefix-for-mode)
+              " " ellama-assistant-nick ":\n")
+      (point))))
+
+(defun ellama-tools--agent-apply-text-update (session text)
+  "Apply fallback state update parsed from TEXT to SESSION."
+  (when-let* ((state (ellama-tools--agent-state session))
+              (update (ellama-tools--agent-state-from-text text)))
+    (let ((merged (ellama-tools--agent-merge-state-update state update)))
+      (ellama-tools--agent-put-state session merged)
+      merged)))
+
+(defun ellama-tools--agent-loop-handler (text &optional session buffer system)
+  "Continue plan-and-act SESSION loop after TEXT in BUFFER with SYSTEM message."
+  (let* ((session (or session ellama--current-session))
+         (parsed (and (ellama-session-p session)
+                      (ellama-tools--agent-apply-text-update session text)))
+         (state (and (ellama-session-p session)
+                     (ellama-tools--agent-state session)))
+         (buffer (ellama-tools--agent-session-buffer session buffer))
+         (done (plist-get state :completed))
+         (phase (plist-get state :phase))
+         (steps (or (plist-get state :step-count) 0))
+         (max (or (plist-get state :max-steps)
+                  ellama-tools-agent-default-max-steps))
+         (tools (and (ellama-session-p session)
+                     (plist-get (ellama-session-extra session) :tools)))
+         (system (or system (plist-get state :system))))
+    (when parsed
+      (ellama-tools--agent-insert-state
+       session buffer (if (plist-get parsed :plan) "Plan" "Status")))
+    (cond
+     ((not (ellama-session-p session))
+      (message "Plan-and-act session is not available."))
+     (done
+      (message "Plan-and-act loop finished."))
+     ((eq phase 'done)
+      (setq state (ellama-tools--agent-state-put state :completed t))
+      (ellama-tools--agent-put-state session state)
+      (ellama-tools--agent-insert-state session buffer "Done")
+      (ellama-tools--agent-restore-tools session))
+     ((eq phase 'blocked)
+      (ellama-tools--agent-insert-state session buffer "Blocked")
+      (ellama-tools--agent-restore-tools session))
+     ((>= steps max)
+      (setq state (ellama-tools--agent-state-put state :phase 'blocked))
+      (setq state (ellama-tools--agent-state-put
+                   state :blocked (format "Max steps (%d) reached." max)))
+      (ellama-tools--agent-put-state session state)
+      (ellama-tools--agent-insert-state session buffer "Blocked")
+      (ellama-tools--agent-restore-tools session))
+     ((ellama-tools--agent-plan-complete-p state)
+      (setq state (ellama-tools--agent-state-put state :phase 'done))
+      (setq state (ellama-tools--agent-state-put state :completed t))
+      (ellama-tools--agent-put-state session state)
+      (ellama-tools--agent-insert-state session buffer "Done")
+      (ellama-tools--agent-restore-tools session))
+     (t
+      (setq state (ellama-tools--agent-state-put state :step-count (1+ steps)))
+      (ellama-tools--agent-put-state session state)
+      (let* ((prompt (ellama-tools--agent-prompt state))
+             (point (when (buffer-live-p buffer)
+                      (ellama-tools--insert-agent-prompt buffer prompt))))
+        (apply
+         #'ellama-stream
+         prompt
+         (append
+          (list :buffer buffer
+                :session session
+                :tools tools
+                :system system
+                :on-done
+                (ellama-tools--make-agent-loop-handler
+                 session buffer system))
+          (when point
+            (list :point point)))))))))
+
+(defun ellama-tools--make-agent-loop-handler (session &optional buffer system)
+  "Return plan-and-act loop handler for SESSION, BUFFER and SYSTEM."
+  (lambda (text)
+    (ellama-tools--agent-loop-handler text session buffer system)))
+
+(defun ellama-tools-start-plan-and-act
+    (session buffer prompt &optional system tools max-steps)
+  "Initialize plan-and-act state for SESSION in BUFFER.
+PROMPT is the original user task.  SYSTEM is the base system message.
+TOOLS is the tool list to extend with controller tools.  MAX-STEPS limits
+automatic continuations."
+  (unless (ellama-session-p session)
+    (error "No session for plan-and-act loop"))
+  (let* ((extra (ellama-session-extra session))
+         (had-tools (and (plistp extra) (plist-member extra :tools)))
+         (original-tools (and (plistp extra) (plist-get extra :tools)))
+         (combined-tools
+          (ellama-tools--agent-combine-tools
+           (or tools original-tools ellama-tools-enabled)))
+         (agent-system (ellama-tools--agent-system-message system))
+         (state (list :phase 'planning
+                      :plan nil
+                      :task prompt
+                      :step-count 0
+                      :max-steps (or max-steps
+                                     ellama-tools-agent-default-max-steps)
+                      :completed nil
+                      :system agent-system
+                      :had-original-tools had-tools
+                      :original-tools original-tools)))
+    (ellama-tools--set-session-extra
+     session
+     (ellama-tools--session-extra-with
+      session
+      :agent-loop state
+      :tools combined-tools))
+    (ellama-tools--agent-insert-note
+     buffer "Status" "Planning started.")
+    (list :system agent-system
+          :tools combined-tools
+          :on-done (ellama-tools--make-agent-loop-handler
+                    session buffer agent-system))))
 
 (defun ellama-tools--insert-subagent-prompt (buffer description)
   "Insert sub-agent DESCRIPTION into BUFFER as a main-agent turn.

--- a/ellama-transient.el
+++ b/ellama-transient.el
@@ -814,6 +814,14 @@ ARGS used for transient arguments."
    (transient-arg-value "--new-session" args)
    :ephemeral (transient-arg-value "--ephemeral" args)))
 
+(transient-define-suffix ellama-transient-plan-and-act (&optional args)
+  "Start a plan-and-act agent loop.  ARGS used for transient arguments."
+  (interactive (list (transient-args transient-current-command)))
+  (ellama-plan-and-act
+   (read-string "Ask ellama agent: ")
+   (transient-arg-value "--new-session" args)
+   :ephemeral (transient-arg-value "--ephemeral" args)))
+
 (transient-define-suffix ellama-transient-chat-with-image (&optional args)
   "Chat with Ellama about an image.  ARGS used for transient arguments."
   (interactive (list (transient-args transient-current-command)))
@@ -861,7 +869,8 @@ ARGS used for transient arguments."
     ("x" "Context Commands" ellama-transient-context-menu)]]
   [["Problem solving"
     ("R" "Solve reasoning problem" ellama-solve-reasoning-problem)
-    ("D" "Solve domain specific problem" ellama-solve-domain-specific-problem)]]
+    ("D" "Solve domain specific problem" ellama-solve-domain-specific-problem)
+    ("A" "Agent" ellama-transient-plan-and-act)]]
   [["Quit" ("q" "Quit" transient-quit-one)]]
   (interactive)
   (transient-setup 'ellama-transient-main-menu)

--- a/ellama.el
+++ b/ellama.el
@@ -3887,6 +3887,116 @@ the full response text when the request completes (with BUFFER current)."
                      #'ellama--translate-markdown-to-org-filter)))))))
 
 ;;;###autoload
+(defun ellama-plan-and-act (prompt &optional create-session &rest args)
+  "Start a plan-and-act agent loop for PROMPT in an Ellama chat session.
+
+If CREATE-SESSION is non-nil, create a new session.  Otherwise reuse the
+current session when possible.  ARGS accepts the same provider/session/system
+keys as `ellama-chat'.  The loop stores canonical state in session extra data,
+prints plan/status snapshots into the chat buffer, and continues automatically
+after compaction."
+  (interactive "sAsk ellama agent: ")
+  (let* ((providers (append
+                     `(("default model" . ellama-provider)
+                       ("ollama model" . (ellama-get-ollama-local-model)))
+                     ellama-providers))
+         (variants (mapcar #'car providers))
+         (system (plist-get args :system))
+         (max-tokens (plist-get args :max-tokens))
+         (max-steps (plist-get args :max-steps))
+         (provider (if current-prefix-arg
+                       (eval (alist-get
+                              (completing-read "Select model: " variants)
+                              providers nil nil #'string=))
+                     (or (plist-get args :provider)
+                         ellama-provider
+                         (ellama-get-first-ollama-chat-model))))
+         (explicit-session-arg (plist-get args :session))
+         (explicit-session-id (plist-get args :session-id))
+         (explicit-session (when (or explicit-session-arg
+                                     explicit-session-id)
+                             (ellama--resolve-session
+                              explicit-session-arg
+                              explicit-session-id)))
+         (current-session (or explicit-session
+                              (ellama--resolve-session
+                               nil ellama--current-session-id)))
+         (need-new-session (and (not explicit-session)
+                                (or create-session
+                                    current-prefix-arg
+                                    (and provider
+                                         current-session
+                                         (or (plist-get args :provider)
+                                             (not (equal provider ellama-provider)))
+                                         (not (equal
+                                               provider
+                                               (ellama-session-provider
+                                                current-session))))
+                                    (not current-session))))
+         (session (or explicit-session
+                      (if need-new-session
+                          (ellama-new-session
+                           provider prompt (plist-get args :ephemeral))
+                        current-session)))
+         (_ (unless (ellama-session-p session)
+              (error "Unable to resolve ellama session")))
+         (buffer (or (ellama-get-session-buffer
+                      (ellama--session-uid session))
+                     (if-let ((session-file (ellama-session-file session)))
+                         (find-file-noselect session-file)
+                       (get-buffer-create (ellama-session-id session)))))
+         (_ (ellama--ensure-session-request-idle session buffer))
+         (_ (with-current-buffer buffer
+              (setq ellama--current-session session)
+              (unless ellama-session-mode
+                (ellama-session-mode +1))))
+         (_ (ellama--register-session session buffer t)))
+    (with-current-buffer buffer
+      (when (and
+             (derived-mode-p 'org-mode)
+             (not (and (boundp 'org-ctrl-c-ctrl-c-hook)
+                       (member #'ellama-chat-send-last-message
+                               org-ctrl-c-ctrl-c-hook))))
+        (add-hook 'org-ctrl-c-ctrl-c-hook #'ellama-chat-send-last-message
+                  10 t)))
+    (display-buffer
+     buffer
+     (when ellama-chat-display-action-function
+       `((ignore . (,ellama-chat-display-action-function)))))
+    (with-current-buffer buffer
+      (save-excursion
+        (goto-char (point-max))
+        (if (equal (point-min) (point-max))
+            (insert
+             (ellama-get-nick-prefix-for-mode)
+             " " ellama-user-nick ":\n"
+             (ellama-context-format session)
+             (ellama--fill-long-lines prompt) "\n\n"
+             (ellama-get-nick-prefix-for-mode)
+             " " ellama-assistant-nick ":\n")
+          (insert
+           (ellama-context-format session)
+           (ellama--fill-long-lines prompt) "\n\n"
+           (ellama-get-nick-prefix-for-mode)
+           " " ellama-assistant-nick ":\n"))
+        (let* ((agent
+                (ellama-tools-start-plan-and-act
+                 session buffer prompt system (plist-get args :tools)
+                 max-steps))
+               (agent-system (plist-get agent :system))
+               (agent-tools (plist-get agent :tools))
+               (donecb (plist-get agent :on-done)))
+          (ellama-stream
+           prompt
+           :session session
+           :system agent-system
+           :tools agent-tools
+           :max-tokens max-tokens
+           :on-done donecb
+           :filter (when (derived-mode-p 'org-mode)
+                     #'ellama--translate-markdown-to-org-filter)))))))
+
+;;;###autoload
 (defun ellama-chat-with-system-from-buffer ()
   "Start a new chat session with a system message created from the current buffer."
   (interactive)

--- a/ellama.el
+++ b/ellama.el
@@ -6,7 +6,7 @@
 ;; URL: http://github.com/s-kostyaev/ellama
 ;; Keywords: help local tools
 ;; Package-Requires: ((emacs "28.1") (llm "0.30.2") (plz "0.8") (transient "0.7") (compat "29.1") (yaml "1.2.3"))
-;; Version: 1.23.0
+;; Version: 1.24.0
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;; Created: 8th Oct 2023
 

--- a/ellama.el
+++ b/ellama.el
@@ -2173,6 +2173,34 @@ REQUEST-CONTEXT is a request context."
       (with-current-buffer buffer
         (ellama-request-mode -1)))))
 
+(defun ellama--chat-last-role ()
+  "Return last chat role marker in current buffer."
+  (save-excursion
+    (save-match-data
+      (goto-char (point-max))
+      (when (re-search-backward
+             (format "^%s \\(%s\\|%s\\):[[:space:]]*$"
+                     (regexp-quote (ellama-get-nick-prefix-for-mode))
+                     (regexp-quote ellama-user-nick)
+                     (regexp-quote ellama-assistant-nick))
+             nil t)
+        (match-string 1)))))
+
+(defun ellama--chat-append-user-header-after-cancel (buffer)
+  "Append a user header to BUFFER after interactive request cancellation."
+  (when (and (buffer-live-p buffer)
+             (ellama-chat-buffer-p buffer))
+    (with-current-buffer buffer
+      (unless (equal (ellama--chat-last-role) ellama-user-nick)
+        (save-excursion
+          (goto-char (point-max))
+          (insert "\n\n"
+                  (ellama-get-nick-prefix-for-mode)
+                  " " ellama-user-nick ":\n")
+          (when (and ellama-session-auto-save
+                     buffer-file-name)
+            (save-buffer)))))))
+
 (defun ellama--kill-buffer-without-request-cancel (buffer)
   "Kill BUFFER without request cancellation hook."
   (when (buffer-live-p buffer)
@@ -2180,24 +2208,30 @@ REQUEST-CONTEXT is a request context."
       (setq ellama--ignore-kill-buffer-request-cancel t)
       (kill-buffer buffer))))
 
-(defun ellama--cancel-current-request ()
-  "Cancel current running request."
+(defun ellama--cancel-current-request (&optional append-user-header)
+  "Cancel current running request.
+When APPEND-USER-HEADER is non-nil, append a user header in chat buffers."
   (declare-function spinner-stop "ext:spinner")
   (let* ((request-context ellama--request-context)
          (request (or ellama--current-request
                       (when request-context
-                        (ellama--request-context-request request-context)))))
+                        (ellama--request-context-request request-context))))
+         (buffers (and request-context
+                       (ellama--request-context-buffers request-context))))
     (when request
       (llm-cancel-request request)
       (when ellama-spinner-enabled
         (require 'spinner)
         (spinner-stop))
-      (ellama--deactivate-current-request request-context))))
+      (ellama--deactivate-current-request request-context)
+      (when append-user-header
+        (dolist (buffer (or buffers (list (current-buffer))))
+          (ellama--chat-append-user-header-after-cancel buffer))))))
 
 (defun ellama--cancel-current-request-and-quit ()
   "Cancel the current request and quit."
   (interactive)
-  (ellama--cancel-current-request)
+  (ellama--cancel-current-request t)
   (keyboard-quit))
 
 (defun ellama--session-deactivate ()
@@ -3980,9 +4014,13 @@ after compaction."
            (ellama-get-nick-prefix-for-mode)
            " " ellama-assistant-nick ":\n"))
         (let* ((agent
-                (ellama-tools-start-plan-and-act
-                 session buffer prompt system (plist-get args :tools)
-                 max-steps))
+                (if (and (not create-session)
+                         (ellama-tools-agent-active-p session))
+                    (ellama-tools-resume-plan-and-act
+                     session buffer system (plist-get args :tools))
+                  (ellama-tools-start-plan-and-act
+                   session buffer prompt system (plist-get args :tools)
+                   max-steps)))
                (agent-system (plist-get agent :system))
                (agent-tools (plist-get agent :tools))
                (donecb (plist-get agent :on-done)))
@@ -4029,11 +4067,20 @@ after compaction."
     (when (or ellama-context-global ellama-context-ephemeral)
       (insert (ellama-context-format session)))
     (insert (ellama-get-nick-prefix-for-mode) " " ellama-assistant-nick ":\n")
-    (ellama-stream text
-                   :session session
-                   :on-done #'ellama-chat-done
-                   :filter (when (derived-mode-p 'org-mode)
-                             #'ellama--translate-markdown-to-org-filter))))
+    (let* ((agent (when (ellama-tools-agent-active-p session)
+                    (ellama-tools-resume-plan-and-act
+                     session (current-buffer))))
+           (system (plist-get agent :system))
+           (tools (plist-get agent :tools))
+           (donecb (or (plist-get agent :on-done)
+                       #'ellama-chat-done)))
+      (ellama-stream text
+                     :session session
+                     :system system
+                     :tools tools
+                     :on-done donecb
+                     :filter (when (derived-mode-p 'org-mode)
+                               #'ellama--translate-markdown-to-org-filter)))))
 
 ;;;###autoload
 (defun ellama-ask-about (&optional create-session &rest args)

--- a/ellama.info
+++ b/ellama.info
@@ -79,6 +79,7 @@ Configuration
 * Session Compaction::
 * Image Input::
 * Task Tool Subagents::
+* Plan-and-Act Agent Loop::
 * Edit Tool Shell Hooks::
 * DLP for Tool Input/Output::
 * SRT Filesystem Policy for Tools::
@@ -244,6 +245,11 @@ File: ellama.info,  Node: Commands,  Next: Keymap,  Prev: Installation,  Up: Top
      an interactive buffer and continue conversation.  If called with
      universal argument (‘C-u’) will start new session with llm model
      interactive selection.
+   • ‘ellama-plan-and-act’: Start an agent loop that first creates a
+     checklist plan and then acts on it with automatic continuations.
+     It reuses the current chat session when possible and can be
+     launched from the main transient menu with ‘A’ in the ‘Problem
+     solving’ section.
    • ‘ellama-ask-image’: Ask Ellama about one image file by adding it as
      ephemeral context for the request.  If called with universal
      argument (‘C-u’) will start new session with llm model interactive
@@ -645,6 +651,7 @@ argument generated text string.
 * Session Compaction::
 * Image Input::
 * Task Tool Subagents::
+* Plan-and-Act Agent Loop::
 * Edit Tool Shell Hooks::
 * DLP for Tool Input/Output::
 * SRT Filesystem Policy for Tools::
@@ -793,7 +800,7 @@ Tool calls can request image handling explicitly:
      }
 
 
-File: ellama.info,  Node: Task Tool Subagents,  Next: Edit Tool Shell Hooks,  Prev: Image Input,  Up: Configuration
+File: ellama.info,  Node: Task Tool Subagents,  Next: Plan-and-Act Agent Loop,  Prev: Image Input,  Up: Configuration
 
 4.4 Task Tool Subagents
 =======================
@@ -844,9 +851,53 @@ letting skills bundle reusable task prompts next to their ‘SKILL.md’
 files.
 
 
-File: ellama.info,  Node: Edit Tool Shell Hooks,  Next: DLP for Tool Input/Output,  Prev: Task Tool Subagents,  Up: Configuration
+File: ellama.info,  Node: Plan-and-Act Agent Loop,  Next: Edit Tool Shell Hooks,  Prev: Task Tool Subagents,  Up: Configuration
 
-4.5 Edit Tool Shell Hooks
+4.5 Plan-and-Act Agent Loop
+===========================
+
+‘ellama-plan-and-act’ runs a local agent in the current Ellama chat
+session.  It starts with a planning turn, asks the model to submit a
+checklist, and then continues automatically through the checklist until
+the agent reports a result, marks the plan complete, becomes blocked, or
+reaches ‘ellama-tools-agent-default-max-steps’.
+
+The loop adds temporary controller tools to the session:
+
+   • ‘agent_submit_plan’ records the initial checklist before acting
+     starts
+   • ‘agent_update_plan’ records progress as checklist items move
+     between states
+   • ‘agent_report_result’ finishes the loop and restores the original
+     tool set
+
+Models or providers that cannot call tools can still participate by
+emitting the fallback ‘BEGIN_ELLAMA_AGENT_STATE’ block described in the
+controller prompt.  Ellama parses that block, updates the stored state,
+and prints visible plan or status snapshots into the chat buffer.
+
+Start the loop with ‘M-x ellama-plan-and-act’, or open the main
+transient with ‘M-x ellama’ and press ‘A’ in the ‘Problem solving’
+section.  The transient entry respects the regular session options: use
+‘-n’ before ‘A’ to create a new session, and use ‘-e’ when ephemeral
+sessions are enabled.
+
+Without a new-session request, the command reuses the current chat
+buffer and session.  If that session already has an active plan-and-act
+loop, a new user message resumes the same loop instead of replacing the
+plan.  This makes it possible to interrupt a running request with ‘C-g’,
+add corrective instructions under the next ‘User:’ prompt, and continue
+the existing loop with ‘C-c C-c’ or another ‘ellama-plan-and-act’ call.
+
+Plan-and-act state is stored in the session extra data, so the loop
+survives session compaction and regular session persistence.  The
+visible plan/status notes in the chat buffer are for transparency; the
+canonical state is the session state used by the continuation handler.
+
+
+File: ellama.info,  Node: Edit Tool Shell Hooks,  Next: DLP for Tool Input/Output,  Prev: Plan-and-Act Agent Loop,  Up: Configuration
+
+4.6 Edit Tool Shell Hooks
 =========================
 
 Projects can define shell commands that run around mutating edit tools:
@@ -889,7 +940,7 @@ and is not scanned by tool output DLP.
 
 File: ellama.info,  Node: DLP for Tool Input/Output,  Next: SRT Filesystem Policy for Tools,  Prev: Edit Tool Shell Hooks,  Up: Configuration
 
-4.6 DLP for Tool Input/Output
+4.7 DLP for Tool Input/Output
 =============================
 
 Ellama includes an optional DLP (Data Loss Prevention) layer for tool
@@ -1215,7 +1266,7 @@ Troubleshooting:
 
 File: ellama.info,  Node: SRT Filesystem Policy for Tools,  Prev: DLP for Tool Input/Output,  Up: Configuration
 
-4.7 SRT Filesystem Policy for Tools
+4.8 SRT Filesystem Policy for Tools
 ===================================
 
 When ‘ellama-tools-use-srt’ is non-nil, the ‘srt’ settings file is the
@@ -2455,48 +2506,49 @@ their use in free software.
 
 Tag Table:
 Node: Top1379
-Node: Installation3945
-Node: Commands8959
-Node: Keymap17588
-Node: Configuration20475
-Node: Session Provider Keys32787
-Node: Session Compaction34648
-Node: Image Input36942
-Node: Task Tool Subagents39087
-Node: Edit Tool Shell Hooks41186
-Node: DLP for Tool Input/Output43170
-Node: SRT Filesystem Policy for Tools58074
-Node: Context Management63743
-Node: Transient Menus for Context Management64811
-Node: Managing the Context66490
-Node: Considerations67265
-Node: Minor modes67858
-Node: ellama-context-header-line-mode69846
-Node: ellama-context-header-line-global-mode70671
-Node: ellama-context-mode-line-mode71391
-Node: ellama-context-mode-line-global-mode72239
-Node: Ellama Session Header Line Mode72943
-Node: Enabling and Disabling73512
-Node: Customization73959
-Node: Ellama Session Mode Line Mode74247
-Node: Enabling and Disabling (1)74832
-Node: Customization (1)75279
-Node: Using Blueprints75573
-Node: Key Components of Ellama Blueprints76213
-Node: Creating and Managing Blueprints76820
-Node: Blueprints files77798
-Node: Variable Management78219
-Node: Keymap and Mode78672
-Node: Transient Menus79608
-Node: Running Blueprints programmatically80154
-Node: MCP Integration80741
-Node: Agent Skills81976
-Node: Directory Structure82339
-Node: Creating a Skill83366
-Node: How it works83741
-Node: Acknowledgments84132
-Node: Contributions84843
-Node: GNU Free Documentation License85229
+Node: Installation3973
+Node: Commands8987
+Node: Keymap17925
+Node: Configuration20812
+Node: Session Provider Keys33152
+Node: Session Compaction35013
+Node: Image Input37307
+Node: Task Tool Subagents39452
+Node: Plan-and-Act Agent Loop41553
+Node: Edit Tool Shell Hooks43737
+Node: DLP for Tool Input/Output45725
+Node: SRT Filesystem Policy for Tools60629
+Node: Context Management66298
+Node: Transient Menus for Context Management67366
+Node: Managing the Context69045
+Node: Considerations69820
+Node: Minor modes70413
+Node: ellama-context-header-line-mode72401
+Node: ellama-context-header-line-global-mode73226
+Node: ellama-context-mode-line-mode73946
+Node: ellama-context-mode-line-global-mode74794
+Node: Ellama Session Header Line Mode75498
+Node: Enabling and Disabling76067
+Node: Customization76514
+Node: Ellama Session Mode Line Mode76802
+Node: Enabling and Disabling (1)77387
+Node: Customization (1)77834
+Node: Using Blueprints78128
+Node: Key Components of Ellama Blueprints78768
+Node: Creating and Managing Blueprints79375
+Node: Blueprints files80353
+Node: Variable Management80774
+Node: Keymap and Mode81227
+Node: Transient Menus82163
+Node: Running Blueprints programmatically82709
+Node: MCP Integration83296
+Node: Agent Skills84531
+Node: Directory Structure84894
+Node: Creating a Skill85921
+Node: How it works86296
+Node: Acknowledgments86687
+Node: Contributions87398
+Node: GNU Free Documentation License87784
 
 End Tag Table
 

--- a/scripts/git-hooks/pre-push
+++ b/scripts/git-hooks/pre-push
@@ -14,7 +14,14 @@ EOF
 fi
 
 zero_sha=0000000000000000000000000000000000000000
-check_elisp=false
+changed_files=$(mktemp)
+changed_files_sorted=$(mktemp)
+
+cleanup() {
+	rm -f "$changed_files" "$changed_files_sorted"
+}
+
+trap cleanup EXIT
 
 while read local_ref local_sha _remote_ref remote_sha
 do
@@ -42,24 +49,19 @@ EOF
 		range="$remote_sha..$local_sha"
 	fi
 
-	if git diff --name-only --diff-filter=ACMR "$range" -- '*.el' | grep -q .
-	then
-		check_elisp=true
-	fi
+	git diff --name-only --diff-filter=ACMR "$range" -- \
+		'*.el' README.org NEWS.org >>"$changed_files"
 done
 
-if [ "$check_elisp" = true ]; then
-	printf '%s\n' "Running make check-elisp for pushed Elisp changes..."
-	make check-elisp
+if [ -s "$changed_files" ]; then
+	sort -u "$changed_files" >"$changed_files_sorted"
+	set --
+	while IFS= read -r file
+	do
+		set -- "$@" "$file"
+	done <"$changed_files_sorted"
 
-	if ! git diff --quiet -- '*.el'; then
-		cat >&2 <<'EOF'
-Push blocked: make check-elisp changed Elisp files.
-
-Review, stage, and commit those changes before pushing.
-EOF
-		exit 1
-	fi
+	ELLAMA_BLOCK_ON_CHECK_CHANGES=1 sh .codex/hooks/check-files.sh "$@"
 fi
 
 exit 0

--- a/tests/test-ellama-tools.el
+++ b/tests/test-ellama-tools.el
@@ -2803,6 +2803,154 @@ Return list with result and prompt."
     (should (eq (ellama-tools--provider-for-role "all")
                 'default-provider))))
 
+(ert-deftest test-ellama-agent-start-plan-and-act-combines-tools-and-renders ()
+  (ellama-test--ensure-local-ellama-tools)
+  (let* ((buffer (generate-new-buffer " *ellama-agent-start-test*"))
+         (base-tool (llm-make-tool :name "read_file" :function #'ignore))
+         (session (make-ellama-session
+                   :id "agent-start"
+                   :extra '(:uid "agent-start-uid"))))
+    (unwind-protect
+        (progn
+          (with-current-buffer buffer
+            (org-mode))
+          (let ((result (ellama-tools-start-plan-and-act
+                         session buffer "Do work" "System"
+                         (list base-tool) 5)))
+            (should (equal (plist-get result :system)
+                           (plist-get
+                            (ellama-tools--agent-state session)
+                            :system)))
+            (should (functionp (plist-get result :on-done)))
+            (should (equal (plist-get
+                            (ellama-tools--agent-state session)
+                            :phase)
+                           'planning))
+            (should (= (plist-get
+                        (ellama-tools--agent-state session)
+                        :max-steps)
+                       5))
+            (should (equal
+                     (mapcar #'llm-tool-name
+                             (plist-get (ellama-session-extra session)
+                                        :tools))
+                     '("agent_submit_plan"
+                       "agent_update_plan"
+                       "agent_report_result"
+                       "read_file")))
+            (with-current-buffer buffer
+              (should (string-match-p "Ellama Agent Status:"
+                                      (buffer-string)))
+              (should (string-match-p "Planning started"
+                                      (buffer-string))))))
+      (when (buffer-live-p buffer)
+        (kill-buffer buffer)))))
+
+(ert-deftest test-ellama-agent-loop-handler-parses-fallback-state-and-continues ()
+  (ellama-test--ensure-local-ellama-tools)
+  (let* ((buffer (generate-new-buffer " *ellama-agent-loop-test*"))
+         (base-tool (llm-make-tool :name "read_file" :function #'ignore))
+         (session (make-ellama-session
+                   :id "agent-loop"
+                   :extra (list :uid "agent-loop-uid"
+                                :tools (list base-tool)
+                                :agent-loop
+                                (list :phase 'planning
+                                      :plan nil
+                                      :step-count 0
+                                      :max-steps 3
+                                      :completed nil
+                                      :system "System"))))
+         (stream-call nil)
+         (state-text
+          "BEGIN_ELLAMA_AGENT_STATE
+phase: acting
+plan:
+- [ ] Inspect code
+- [ ] Implement change
+END_ELLAMA_AGENT_STATE"))
+    (unwind-protect
+        (progn
+          (with-current-buffer buffer
+            (org-mode)
+            (insert "** Ellama:\nInitial response\n"))
+          (cl-letf (((symbol-function 'ellama-get-session-buffer)
+                     (lambda (id)
+                       (and (member id '("agent-loop" "agent-loop-uid"))
+                            buffer)))
+                    ((symbol-function 'ellama-stream)
+                     (lambda (prompt &rest args)
+                       (setq stream-call (list prompt args)))))
+            (let ((ellama--current-session nil))
+              (funcall
+               (ellama-tools--make-agent-loop-handler
+                session buffer "System")
+               state-text))
+            (let ((state (ellama-tools--agent-state session)))
+              (should (equal (plist-get state :phase) 'acting))
+              (should (= (plist-get state :step-count) 1))
+              (should (equal (plist-get (car (plist-get state :plan))
+                                        :title)
+                             "Inspect code")))
+            (should (equal (plist-get (cadr stream-call) :session)
+                           session))
+            (should (equal (plist-get (cadr stream-call) :tools)
+                           (list base-tool)))
+            (should (functionp (plist-get (cadr stream-call) :on-done)))
+            (should (string-match-p "Current plan state"
+                                    (car stream-call)))
+            (should (string-match-p "Next pending item: Inspect code"
+                                    (car stream-call)))
+            (with-current-buffer buffer
+              (should (string-match-p "Ellama Agent Plan:"
+                                      (buffer-string)))
+              (should (string-match-p "Inspect code" (buffer-string)))
+              (should (string-match-p "Agent controller:"
+                                      (buffer-string))))))
+      (when (buffer-live-p buffer)
+        (kill-buffer buffer)))))
+
+(ert-deftest test-ellama-agent-report-result-restores-original-tools ()
+  (ellama-test--ensure-local-ellama-tools)
+  (let* ((buffer (generate-new-buffer " *ellama-agent-done-test*"))
+         (base-tool (llm-make-tool :name "read_file" :function #'ignore))
+         (agent-tools (ellama-tools--agent-controller-tools))
+         (session (make-ellama-session
+                   :id "agent-done"
+                   :extra (list :uid "agent-done-uid"
+                                :tools (append agent-tools (list base-tool))
+                                :agent-loop
+                                (list :phase 'acting
+                                      :plan (list (list :id 1
+                                                        :title "Done"
+                                                        :status 'done))
+                                      :completed nil
+                                      :had-original-tools t
+                                      :original-tools (list base-tool))))))
+    (unwind-protect
+        (progn
+          (with-current-buffer buffer
+            (org-mode))
+          (cl-letf (((symbol-function 'ellama-get-session-buffer)
+                     (lambda (id)
+                       (and (member id '("agent-done" "agent-done-uid"))
+                            buffer))))
+            (let ((ellama-tools--current-session session))
+              (should (equal (ellama-tools-agent-report-result-tool "Finished")
+                             "Result received. Plan-and-act loop completed.")))
+            (should (plist-get (ellama-tools--agent-state session)
+                               :completed))
+            (should (equal (plist-get (ellama-tools--agent-state session)
+                                      :result)
+                           "Finished"))
+            (should (equal (plist-get (ellama-session-extra session) :tools)
+                           (list base-tool)))
+            (with-current-buffer buffer
+              (should (string-match-p "Ellama Agent Done:"
+                                      (buffer-string))))))
+      (when (buffer-live-p buffer)
+        (kill-buffer buffer)))))
+
 (ert-deftest test-ellama-subagent-loop-handler-max-steps-and-continue ()
   (ellama-test--ensure-local-ellama-tools)
   (let ((updated-extra nil)

--- a/tests/test-ellama.el
+++ b/tests/test-ellama.el
@@ -33,6 +33,11 @@
 (require 'llm-fake)
 (require 'llm-openai)
 
+(defconst ellama-test--root
+  (expand-file-name
+   ".."
+   (file-name-directory (or load-file-name buffer-file-name default-directory)))
+  "Project root directory for `test-ellama.el'.")
 
 (defun ellama-test--fake-stream-partials (response style)
   "Return streaming partial strings for RESPONSE using STYLE."
@@ -1016,7 +1021,8 @@ detailed comparison to help you decide:
         (kill-buffer session-buffer)))))
 
 (ert-deftest test-ellama-plan-and-act-reuses-current-session-buffer ()
-  (load-file (expand-file-name "ellama-tools.el" default-directory))
+  (load-file
+   (expand-file-name "ellama-tools.el" ellama-test--root))
   (let* ((provider (make-llm-fake))
          (base-tool (llm-make-tool :name "read_file" :function #'ignore))
          (ellama-provider provider)

--- a/tests/test-ellama.el
+++ b/tests/test-ellama.el
@@ -123,6 +123,29 @@ STYLE controls partial message shape.  Default value is `word-leading'."
       (should (null ellama--current-request))
       (should-not ellama-request-mode))))
 
+(ert-deftest test-ellama-request-mode-c-g-appends-user-header-in-chat ()
+  (let ((cancelled-request nil)
+        (ellama-spinner-enabled nil)
+        (ellama-session-auto-save nil)
+        (ellama-user-nick "User")
+        (ellama-assistant-nick "Ellama"))
+    (with-temp-buffer
+      (org-mode)
+      (setq-local ellama--current-session
+                  (make-ellama-session :id "cancel-chat"))
+      (insert "** User:\nStart\n\n** Ellama:\nPartial output")
+      (ellama--set-current-request 'request (list (current-buffer)))
+      (cl-letf (((symbol-function 'llm-cancel-request)
+                 (lambda (request)
+                   (setq cancelled-request request))))
+        (condition-case nil
+            (call-interactively #'ellama--cancel-current-request-and-quit)
+          (quit nil)))
+      (should (eq cancelled-request 'request))
+      (should (null ellama--current-request))
+      (should-not ellama-request-mode)
+      (should (string-suffix-p "\n\n** User:\n" (buffer-string))))))
+
 (ert-deftest test-ellama-request-mode-c-g-cancels-from-reasoning-buffer ()
   (let ((cancelled-request nil)
         (ellama-spinner-enabled nil)
@@ -1072,6 +1095,64 @@ detailed comparison to help you decide:
       (when (buffer-live-p session-buffer)
         (kill-buffer session-buffer)))))
 
+(ert-deftest test-ellama-plan-and-act-resumes-active-loop ()
+  (load-file
+   (expand-file-name "ellama-tools.el" ellama-test--root))
+  (let* ((provider (make-llm-fake))
+         (base-tool (llm-make-tool :name "read_file" :function #'ignore))
+         (ellama-provider provider)
+         (ellama-providers nil)
+         (ellama-tools-enabled (list base-tool))
+         (ellama-session-auto-save nil)
+         (ellama-chat-display-action-function nil)
+         (ellama--active-sessions (make-hash-table :test #'equal))
+         (ellama--active-session-states (make-hash-table :test #'equal))
+         (state (list :phase 'acting
+                      :plan (list (list :id 1
+                                        :title "Existing step"
+                                        :status 'pending))
+                      :completed nil
+                      :system "Existing system"))
+         (session (make-ellama-session
+                   :id "agent-resume"
+                   :provider provider
+                   :prompt nil
+                   :extra (list :uid "agent-resume-uid"
+                                :tools (list base-tool)
+                                :agent-loop state)))
+         (session-buffer (generate-new-buffer " *ellama-agent-resume-test*"))
+         (stream-call nil))
+    (unwind-protect
+        (progn
+          (with-current-buffer session-buffer
+            (org-mode)
+            (insert "** User:\nOriginal\n\n** Ellama:\nPartial\n\n** User:\n"))
+          (ellama--register-session session session-buffer t)
+          (cl-letf (((symbol-function 'display-buffer)
+                     (lambda (&rest _args) nil))
+                    ((symbol-function 'ellama-stream)
+                     (lambda (prompt &rest args)
+                       (setq stream-call (list prompt args)))))
+            (ellama-plan-and-act "Correct the approach"))
+          (should (equal (car stream-call) "Correct the approach"))
+          (should (eq (plist-get (cadr stream-call) :session)
+                      session))
+          (should (equal (plist-get (cadr stream-call) :system)
+                         "Existing system"))
+          (should (functionp (plist-get (cadr stream-call) :on-done)))
+          (should (equal (plist-get
+                          (car (plist-get
+                                (ellama-tools--agent-state session)
+                                :plan))
+                          :title)
+                         "Existing step"))
+          (with-current-buffer session-buffer
+            (let ((text (buffer-string)))
+              (should (string-match-p "Correct the approach" text))
+              (should-not (string-match-p "Planning started" text)))))
+      (when (buffer-live-p session-buffer)
+        (kill-buffer session-buffer)))))
+
 (defun ellama-test--with-temp-image-file (body)
   "Call BODY with a tiny temporary PNG file."
   (let ((file-name (make-temp-file "ellama-image-" nil ".png")))
@@ -1234,6 +1315,49 @@ detailed comparison to help you decide:
            (ellama-chat-send-last-message)
            :type 'user-error))
         (should (equal before (buffer-string)))))))
+
+(ert-deftest test-ellama-chat-send-last-message-resumes-plan-and-act-loop ()
+  (load-file
+   (expand-file-name "ellama-tools.el" ellama-test--root))
+  (let* ((base-tool (llm-make-tool :name "read_file" :function #'ignore))
+         (session (make-ellama-session
+                   :id "agent-chat"
+                   :provider (make-llm-fake)
+                   :extra (list :uid "agent-chat-uid"
+                                :tools (list base-tool)
+                                :agent-loop
+                                (list :phase 'acting
+                                      :plan (list (list :id 1
+                                                        :title "Fix issue"
+                                                        :status 'pending))
+                                      :completed nil
+                                      :system "Agent system"))))
+         (ellama-context-global nil)
+         (ellama-context-ephemeral nil)
+         (stream-call nil))
+    (with-temp-buffer
+      (org-mode)
+      (setq-local ellama--current-session session)
+      (insert "** User:\nGive the agent a correction")
+      (cl-letf (((symbol-function 'ellama-stream)
+                 (lambda (prompt &rest args)
+                   (setq stream-call (list prompt args)))))
+        (ellama-chat-send-last-message))
+      (should (equal (car stream-call) "Give the agent a correction"))
+      (should (eq (plist-get (cadr stream-call) :session) session))
+      (should (equal (plist-get (cadr stream-call) :system)
+                     "Agent system"))
+      (should (functionp (plist-get (cadr stream-call) :on-done)))
+      (should (not (eq (plist-get (cadr stream-call) :on-done)
+                       #'ellama-chat-done)))
+      (should (equal
+               (mapcar #'llm-tool-name
+                       (plist-get (cadr stream-call) :tools))
+               '("agent_submit_plan"
+                 "agent_update_plan"
+                 "agent_report_result"
+                 "read_file")))
+      (should (string-match-p "\\*\\* Ellama:" (buffer-string))))))
 
 (ert-deftest test-ellama-stream-displays-session-buffer-on-generation ()
   (let* ((provider (make-llm-fake

--- a/tests/test-ellama.el
+++ b/tests/test-ellama.el
@@ -1015,6 +1015,57 @@ detailed comparison to help you decide:
       (when (buffer-live-p session-buffer)
         (kill-buffer session-buffer)))))
 
+(ert-deftest test-ellama-plan-and-act-reuses-current-session-buffer ()
+  (load-file (expand-file-name "ellama-tools.el" default-directory))
+  (let* ((provider (make-llm-fake))
+         (base-tool (llm-make-tool :name "read_file" :function #'ignore))
+         (ellama-provider provider)
+         (ellama-providers nil)
+         (ellama-tools-enabled (list base-tool))
+         (ellama-session-auto-save nil)
+         (ellama-chat-display-action-function nil)
+         (ellama--active-sessions (make-hash-table :test #'equal))
+         (ellama--active-session-states (make-hash-table :test #'equal))
+         (session (make-ellama-session :id "agent-session"
+                                       :provider provider
+                                       :prompt nil
+                                       :extra '(:uid "agent-session-uid")))
+         (session-buffer (generate-new-buffer " *ellama-agent-chat-test*"))
+         (stream-call nil))
+    (unwind-protect
+        (progn
+          (with-current-buffer session-buffer
+            (org-mode))
+          (ellama--register-session session session-buffer t)
+          (cl-letf (((symbol-function 'display-buffer)
+                     (lambda (&rest _args) nil))
+                    ((symbol-function 'ellama-stream)
+                     (lambda (prompt &rest args)
+                       (setq stream-call (list prompt args)))))
+            (ellama-plan-and-act "Do work"))
+          (should (equal (car stream-call) "Do work"))
+          (should (eq (plist-get (cadr stream-call) :session)
+                      session))
+          (should (functionp (plist-get (cadr stream-call) :on-done)))
+          (should (string-match-p
+                   "PLAN AND ACT INSTRUCTIONS"
+                   (plist-get (cadr stream-call) :system)))
+          (should (equal
+                   (mapcar #'llm-tool-name
+                           (plist-get (ellama-session-extra session) :tools))
+                   '("agent_submit_plan"
+                     "agent_update_plan"
+                     "agent_report_result"
+                     "read_file")))
+          (with-current-buffer session-buffer
+            (let ((text (buffer-string)))
+              (should (string-match-p "User:" text))
+              (should (string-match-p "Do work" text))
+              (should (string-match-p "Ellama Agent Status:" text))
+              (should (string-match-p "Planning started" text)))))
+      (when (buffer-live-p session-buffer)
+        (kill-buffer session-buffer)))))
+
 (defun ellama-test--with-temp-image-file (body)
   "Call BODY with a tiny temporary PNG file."
   (let ((file-name (make-temp-file "ellama-image-" nil ".png")))


### PR DESCRIPTION
## Summary

Adds a plan-and-act agent loop with automatic continuation after compaction.

## Changes

- **ellama.el**: New `ellama-plan-and-act` interactive command that starts a plan-and-act agent loop, reusing existing sessions when appropriate.

- **ellama-tools.el**:
  - New fallback state parsing using `BEGIN_ELLAMA_AGENT_STATE` / `END_ELLAMA_AGENT_STATE` markers (for providers without tool call support)
  - Agent controller tools: `agent_submit_plan`, `agent_update_plan`, `agent_report_result`
  - `ellama-tools-start-plan-and-act` function to initialize the agent loop
  - New customizations: `ellama-tools-agent-default-max-steps`, `ellama-tools-agent-planning-prompt`, `ellama-tools-agent-continue-prompt`
  - State management for tracking plan progress (phase, plan, step-count, max-steps)

- **tests/test-ellama.el**: Test for `ellama-plan-and-act` reusing current session buffer

- **tests/test-ellama-tools.el**: Tests for:
  - `ellama-tools-start-plan-and-act` combining tools and rendering state
  - Agent loop handler parsing fallback state and continuing
  - `agent_report_result` restoring original tools