### PR TITLE
Add loop detection to ellama-eval harness

### DIFF
--- a/NEWS.org
+++ b/NEWS.org
@@ -1,3 +1,43 @@
+* Version 1.25.0
+
+- Add loop detection to ~ellama-eval~ harness that identifies repetitive tool
+  call patterns indicating agents are stuck in evaluation loops. The harness
+  returns recovery guidance on the first repeated identical tool call sequence,
+  and falls back to hard loop detection for repeated loops after recovery.
+  Configurable defcustoms control the behavior:
+  ~ellama-eval-loop-detection-enabled~ (default: t),
+  ~ellama-eval-loop-detection-repeated-threshold~ (default: 2), and
+  ~ellama-eval-loop-detection-max-traces~ (default: 50).
+
+- Move loop recovery into task subagents by wrapping role tools with
+  session-local repeated-call detection. Repeated identical tool calls return
+  recovery guidance at the configured threshold and complete the subtask if the
+  same consecutive chain continues. Document the new subagent loop-detection
+  settings in README.org.
+
+- Extend evaluation cancellation with request context tracking. Store the active
+  request context on the session for streaming, continuation, and compaction
+  requests so that eval timeout cancellation can target the correct context
+  directly. Cancel active eval worker requests when a run finishes with a
+  non-completed status, and register asynchronous session compaction requests in
+  the active request context so user cancellation and eval timeout stop the
+  compact request itself.
+
+- Harden evaluation async buffer handling by scheduling timers from a stable
+  internal buffer so callbacks do not inherit transient subagent buffers. Guard
+  interactive summary rendering against stale target-window errors and fall back
+  to display-buffer.
+
+- Render evaluation progress and final summaries into the selected window for
+  interactive runs, keeping the existing display-buffer behavior as a fallback
+  for noninteractive or stale-window calls.
+
+- Preserve triggering tool calls in public traces and final loop-detection
+  results when loop detection triggers, and record recovery metadata in tool
+  traces so recovered passing runs remain visible. Avoid false loop detection on
+  later repeated reads by treating the repeated-call threshold as the recovery
+  point for the current consecutive chain.
+
 * Version 1.24.1
 - Added literal string matching support to ~ellama-tools-grep-tool~ and
   ~ellama-tools-grep-in-file-tool~ using ~-F~ (fixed-strings) and ~-e~ flags,

--- a/README.org
+++ b/README.org
@@ -480,6 +480,13 @@ generated text string.
   Default value is ~"skills"~.
 - ~ellama-tools-subagent-default-max-steps~: Default maximum number of
   auto-continue steps for a sub-agent. Default value is 30.
+- ~ellama-tools-subagent-loop-detection-enabled~: Detect repeated identical tool
+  calls in sub-agent sessions. Enabled by default.
+- ~ellama-tools-subagent-loop-detection-repeated-threshold~: Number of
+  consecutive identical sub-agent tool calls that triggers recovery. Default
+  value is 2.
+- ~ellama-tools-subagent-loop-detection-max-traces~: Maximum recent sub-agent
+  tool calls retained for loop detection. Default value is 50.
 - ~ellama-tools-subagent-continue-prompt~: Prompt sent to a sub-agent when it
   finishes a turn without calling ~report_result~.
 - ~ellama-tools-subagent-roles~: Subagent roles with provider, system prompt and
@@ -631,6 +638,16 @@ Each sub-agent runs in its own Ellama session. When
 the main session and sub-agent session buffers as generation starts. Sub-agent
 buffers include the delegated prompt under the ~Main agent:~ label, followed by
 the sub-agent response.
+
+Sub-agents also keep session-local tool loop state. When
+~ellama-tools-subagent-loop-detection-enabled~ is non-nil, the second
+consecutive identical tool call returns a recovery message instead of the normal
+tool result. The message includes the repeated tool name, exact arguments, the
+latest tool result and a next action. If the same consecutive call chain
+continues beyond ~ellama-tools-subagent-loop-detection-repeated-threshold~,
+Ellama finishes the subtask with a loop-detected result. A later repeated call
+after a different tool call is treated as a new recovery opportunity, not as an
+immediate hard loop.
 
 The tool accepts either a free-form ~description~ or a prompt template:
 

--- a/ellama-eval.el
+++ b/ellama-eval.el
@@ -456,30 +456,35 @@ Also performs loop detection if enabled."
     (when (and ellama-eval-loop-detection-enabled
                (not (eq (ellama-eval--run-state-status state) 'loop-detected)))
       (let* ((loop-state (ellama-eval--run-state-loop-state state))
-             (tool-history (and loop-state (plist-get loop-state :tool-history)))
+             (tool-history (or (and loop-state (plist-get loop-state :tool-history))
+                               (list)))
              (threshold ellama-eval-loop-detection-repeated-threshold))
-        (when tool-history
-          ;; Check if this tool has been called with identical args recently
-          (let ((repeated (seq-take-while
-                           (lambda (entry)
-                             (and (eq (plist-get entry :name) name)
-                                  (equal (plist-get entry :args) args)))
-                           tool-history)))
-            (when (>= (length repeated) threshold)
-              ;; Loop detected - stop the run
+        ;; Check if this tool has been called with identical args recently
+        (let ((repeated (seq-take-while
+                         (lambda (entry)
+                           (and (eq (plist-get entry :name) name)
+                                (equal (plist-get entry :args) args)))
+                         tool-history)))
+          (when (>= (1+ (length repeated)) threshold)
+            ;; Loop detected - the current call makes it the threshold-th repetition
+            (let* ((loop-reason (format
+                                 "Loop detected: tool %s called %d times with identical args"
+                                 name threshold))
+                   (loop-result (list :status 'loop-detected :loop-reason loop-reason)))
               (setf (ellama-eval--run-state-status state) 'loop-detected)
-              (ellama-eval--run-state-set-result
-               state
-               (list :status 'loop-detected
-                     :loop-reason (format
-                                   "Loop detected: tool %s called %d times with identical args"
-                                   name threshold)))))
-          ;; Record the tool call in history
-          (push (list :name name :args args) tool-history)
-          ;; Limit history size
-          (let ((max-traces ellama-eval-loop-detection-max-traces))
-            (when (> (length tool-history) max-traces)
-              (setf (nthcdr max-traces tool-history) nil))))))
+              (setf (ellama-eval--run-state-result state) loop-result)
+              (setf loop-state (plist-put loop-state :loop-reason loop-reason))
+              (setf (ellama-eval--run-state-loop-state state) loop-state))))
+        ;; Record the tool call in history
+        (push (list :name name :args args) tool-history)
+        ;; Limit history size
+        (let ((max-traces ellama-eval-loop-detection-max-traces))
+          (when (> (length tool-history) max-traces)
+            (setf (nthcdr max-traces tool-history) nil)))
+        ;; Update the loop-state in the struct
+        (setf (ellama-eval--run-state-loop-state state)
+              (plist-put loop-state :tool-history tool-history))))
+    ;; Record the trace (inside when-let* so state is bound)
     (push (list :name name
                 :args args
                 :status status

--- a/ellama-eval.el
+++ b/ellama-eval.el
@@ -510,7 +510,7 @@ for the agent."
                       (format
                        "Loop detected: tool %s called %d times with identical args"
                        name repeat-count)))
-                (if (zerop recovery-count)
+                (if (= repeat-count threshold)
                     (progn
                       (setq recovery-message
                             (ellama-eval--loop-recovery-message
@@ -520,7 +520,8 @@ for the agent."
                                        :loop-recovery-attempted t))
                       (setq loop-state
                             (plist-put loop-state
-                                       :loop-recovery-count 1))
+                                       :loop-recovery-count
+                                       (1+ recovery-count)))
                       (setq loop-state
                             (plist-put loop-state
                                        :loop-recovery-reason loop-reason)))

--- a/ellama-eval.el
+++ b/ellama-eval.el
@@ -1635,9 +1635,10 @@ KEY is the property list key that contains VALUE."
              (plist-get result :elapsed-ms)))))
 
 (defun ellama-eval--render-summary-buffer
-    (results completed total &optional results-file)
+    (results completed total &optional results-file window)
   "Render RESULTS summary with COMPLETED and TOTAL progress.
-RESULTS-FILE is shown when JSONL export is configured."
+RESULTS-FILE is shown when JSONL export is configured.
+When WINDOW is live, show the summary in WINDOW."
   (let ((buffer (get-buffer-create ellama-eval--summary-buffer-name)))
     (with-current-buffer buffer
       (let ((inhibit-read-only t))
@@ -1657,7 +1658,9 @@ RESULTS-FILE is shown when JSONL export is configured."
           (insert "No completed cases yet.\n"))
         (goto-char (point-min))
         (special-mode)))
-    (display-buffer buffer)
+    (if (window-live-p window)
+        (set-window-buffer window buffer)
+      (display-buffer buffer))
     buffer))
 
 ;;;###autoload
@@ -1671,7 +1674,8 @@ select experiment profiles.  RESULTS-FILE receives JSONL output when non-nil."
          (ellama-eval--read-suite-selection)
          (ellama-eval--read-profile-selection)
          (ellama-eval--read-results-file)))
-  (let ((cases (ellama-eval--cases-for-suite-selection suite)))
+  (let ((cases (ellama-eval--cases-for-suite-selection suite))
+        (summary-window (selected-window)))
     (ellama-eval-run-hypothesis-suite-async
      provider profiles cases
      (lambda (results)
@@ -1679,11 +1683,11 @@ select experiment profiles.  RESULTS-FILE receives JSONL output when non-nil."
        (when results-file
          (ellama-eval-write-results-jsonl results results-file))
        (ellama-eval--render-summary-buffer
-        results (length results) (length results) results-file)
+        results (length results) (length results) results-file summary-window)
        (message "Ellama evaluation finished: %d runs." (length results)))
      (lambda (results completed total _latest)
        (ellama-eval--render-summary-buffer
-        results completed total results-file)))
+        results completed total results-file summary-window)))
     (message "Ellama evaluation started.")))
 
 (provide 'ellama-eval)

--- a/ellama-eval.el
+++ b/ellama-eval.el
@@ -1097,7 +1097,10 @@ EXPECTED-FILES and SYNTAX-FILES define the relative file paths to check."
       (when (plistp extra)
         (ellama-tools--set-session-extra
          worker
-         (plist-put (copy-sequence extra) :task-completed t))))
+         (plist-put (copy-sequence extra) :task-completed t))
+        (when-let* ((request-context
+                     (plist-get extra :current-request-context)))
+          (ellama--cancel-request-context request-context))))
     (when-let* ((buffer (ellama-tools--subagent-buffer worker)))
       (with-current-buffer buffer
         (ellama--cancel-current-request)))))

--- a/ellama-eval.el
+++ b/ellama-eval.el
@@ -1089,6 +1089,19 @@ EXPECTED-FILES and SYNTAX-FILES define the relative file paths to check."
     (cancel-timer timer)
     (setf (ellama-eval--run-state-timeout-timer state) nil)))
 
+(defun ellama-eval--cancel-worker-request (state)
+  "Cancel active worker request for STATE, if any."
+  (when-let* ((worker (ellama-eval--run-state-worker state))
+              ((ellama-session-p worker)))
+    (let ((extra (ellama-session-extra worker)))
+      (when (plistp extra)
+        (ellama-tools--set-session-extra
+         worker
+         (plist-put (copy-sequence extra) :task-completed t))))
+    (when-let* ((buffer (ellama-tools--subagent-buffer worker)))
+      (with-current-buffer buffer
+        (ellama--cancel-current-request)))))
+
 (defun ellama-eval--cleanup-workspace (state)
   "Delete STATE workspace unless retention is enabled."
   (let ((workspace (ellama-eval--run-state-workspace state)))
@@ -1190,6 +1203,8 @@ EXPECTED-FILES and SYNTAX-FILES define the relative file paths to check."
     (when task-result
       (setf (ellama-eval--run-state-result state) task-result))
     (setf (ellama-eval--run-state-status state) run-status)
+    (unless (eq run-status 'completed)
+      (ellama-eval--cancel-worker-request state))
     (ellama-eval--cancel-timeout-timer state)
     (let ((result (ellama-eval--build-result state run-status))
           (callback (ellama-eval--run-state-callback state)))

--- a/ellama-eval.el
+++ b/ellama-eval.el
@@ -96,6 +96,9 @@ Only one evaluation run is supported at a time.")
 (defconst ellama-eval--summary-buffer-name "*Ellama Eval Summary*"
   "Name of the interactive evaluation summary buffer.")
 
+(defconst ellama-eval--timer-buffer-name " *Ellama Eval Timer*"
+  "Name of the internal buffer used to schedule eval timers.")
+
 (defconst ellama-eval--base-tool-names
   '("read_file" "lines_range" "grep" "grep_in_file"
     "directory_tree" "project_root")
@@ -1144,6 +1147,11 @@ EXPECTED-FILES and SYNTAX-FILES define the relative file paths to check."
     (cancel-timer timer)
     (setf (ellama-eval--run-state-timeout-timer state) nil)))
 
+(defun ellama-eval--run-at-time (time function &rest args)
+  "Run FUNCTION with ARGS after TIME from a stable eval timer buffer."
+  (with-current-buffer (get-buffer-create ellama-eval--timer-buffer-name)
+    (apply #'run-at-time time nil function args)))
+
 (defun ellama-eval--cancel-worker-request (state)
   "Cancel active worker request for STATE, if any."
   (when-let* ((worker (ellama-eval--run-state-worker state))
@@ -1322,8 +1330,8 @@ PROVIDER overrides the provider used by the eval role."
          (original-new-session (symbol-function 'ellama-new-session)))
     (setq ellama-eval--active-run state)
     (setf (ellama-eval--run-state-timeout-timer state)
-          (run-at-time ellama-eval-timeout-seconds nil
-                       #'ellama-eval--timeout-run state))
+          (ellama-eval--run-at-time
+           ellama-eval-timeout-seconds #'ellama-eval--timeout-run state))
     (condition-case err
         (let ((default-directory workspace)
               (ellama-tools-allow-all t)
@@ -1418,11 +1426,11 @@ completed count, total count and the latest result."
                   (when progress-callback
                     (funcall progress-callback
                              (reverse results) completed total result))
-                  (run-at-time 0 nil #'start-next))
+                  (ellama-eval--run-at-time 0 #'start-next))
                 provider)))))
       (when progress-callback
         (funcall progress-callback nil 0 total nil))
-      (run-at-time 0 nil #'start-next)
+      (ellama-eval--run-at-time 0 #'start-next)
       total)))
 
 (defun ellama-eval-summarize-results (results)
@@ -1658,9 +1666,14 @@ When WINDOW is live, show the summary in WINDOW."
           (insert "No completed cases yet.\n"))
         (goto-char (point-min))
         (special-mode)))
-    (if (window-live-p window)
-        (set-window-buffer window buffer)
-      (display-buffer buffer))
+    (condition-case err
+        (if (window-live-p window)
+            (set-window-buffer window buffer)
+          (display-buffer buffer))
+      (error
+       (message "Ellama eval summary display failed: %s"
+                (error-message-string err))
+       (display-buffer buffer)))
     buffer))
 
 ;;;###autoload

--- a/ellama-eval.el
+++ b/ellama-eval.el
@@ -65,10 +65,11 @@ repetitive behavior that indicates the agent is stuck in a loop."
   :type 'boolean
   :group 'ellama-eval)
 
-(defcustom ellama-eval-loop-detection-repeated-threshold 3
-  "Number of repeated identical tool calls that triggers loop detection.
+(defcustom ellama-eval-loop-detection-repeated-threshold 2
+  "Number of repeated identical tool calls that triggers loop recovery.
 When the same tool is called with identical arguments this many times
-in a row, the harness flags it as a potential loop."
+in a row, the harness returns recovery guidance to the agent.  If
+another loop is detected after recovery, the run is stopped."
   :type 'integer
   :group 'ellama-eval)
 
@@ -449,50 +450,104 @@ in one short sentence."
     (_
      spec)))
 
+(defun ellama-eval--loop-recovery-message
+    (name args result repeat-count)
+  "Return recovery guidance for repeated tool NAME with ARGS.
+RESULT is the latest tool result.  REPEAT-COUNT is the repeated
+call count."
+  (concat
+   (format
+    "LOOP RECOVERY: `%s` was called %d times with identical arguments.\n"
+    name repeat-count)
+   (format "Do not call `%s` again with these exact arguments: %S\n"
+           name args)
+   (format "Latest tool result:\n%s\n\n" result)
+   (if (equal name "edit_file")
+       "Next action: read the exact current file text with `read_file` \
+or `lines_range`, copy the exact oldcontent from that output, then call \
+`edit_file` with different oldcontent.  If you cannot identify an exact \
+replacement, call `report_result` with the blocker."
+     "Next action: choose a different tool call or different arguments \
+based on the latest result.  If no different useful action exists, call \
+`report_result` with the blocker.")))
+
 (defun ellama-eval--trace-tool-call (name args status result)
   "Record a tool call with NAME, ARGS, STATUS and RESULT.
-Also performs loop detection if enabled."
+Also performs loop detection if enabled.
+Return recovery guidance when the tool result should be replaced
+for the agent."
   (when-let* ((state ellama-eval--active-run))
     ;; Record the trace before loop finalization so the triggering call is
     ;; visible in the final result.
-    (push (list :name name
-                :args args
-                :status status
-                :result result
-                :finished-at (float-time))
-          (ellama-eval--run-state-trace state))
-    (when (and ellama-eval-loop-detection-enabled
-               (eq (ellama-eval--run-state-status state) 'pending))
-      (let* ((loop-state (ellama-eval--run-state-loop-state state))
-             (tool-history (or (and loop-state (plist-get loop-state :tool-history))
-                               (list)))
-             (threshold ellama-eval-loop-detection-repeated-threshold))
-        ;; Check if this tool has been called with identical args recently
-        (let ((repeated (seq-take-while
-                         (lambda (entry)
-                           (and (equal (plist-get entry :name) name)
-                                (equal (plist-get entry :args) args)))
-                         tool-history)))
-          (when (>= (1+ (length repeated)) threshold)
-            ;; Loop detected - the current call makes it the threshold-th repetition
-            (let ((loop-reason (format
-                                "Loop detected: tool %s called %d times with identical args"
-                                name threshold)))
-              (setq loop-state (plist-put loop-state :loop-detected t))
-              (setf loop-state (plist-put loop-state :loop-reason loop-reason))
-              (setf (ellama-eval--run-state-loop-state state) loop-state))))
-        ;; Record the tool call in history
-        (push (list :name name :args args) tool-history)
-        ;; Limit history size
-        (let ((max-traces ellama-eval-loop-detection-max-traces))
-          (when (> (length tool-history) max-traces)
-            (setf (nthcdr max-traces tool-history) nil)))
-        ;; Update the loop-state in the struct
-        (setf (ellama-eval--run-state-loop-state state)
-              (plist-put loop-state :tool-history tool-history))
-        (when (plist-get loop-state :loop-detected)
-          (ellama-eval--finish-run
-           state 'loop-detected (plist-get loop-state :loop-reason)))))))
+    (let ((entry (list :name name
+                       :args args
+                       :status status
+                       :result result
+                       :finished-at (float-time)))
+          recovery-message)
+      (push entry (ellama-eval--run-state-trace state))
+      (when (and ellama-eval-loop-detection-enabled
+                 (eq (ellama-eval--run-state-status state) 'pending))
+        (let* ((loop-state (ellama-eval--run-state-loop-state state))
+               (tool-history
+                (or (and loop-state (plist-get loop-state :tool-history))
+                    (list)))
+               (threshold ellama-eval-loop-detection-repeated-threshold))
+          ;; Check if this tool has been called with identical args recently.
+          (let* ((repeated (seq-take-while
+                            (lambda (history-entry)
+                              (and (equal (plist-get history-entry :name) name)
+                                   (equal (plist-get history-entry :args) args)))
+                            tool-history))
+                 (repeat-count (1+ (length repeated))))
+            (when (>= repeat-count threshold)
+              (let* ((recovery-count
+                      (or (plist-get loop-state :loop-recovery-count) 0))
+                     (loop-reason
+                      (format
+                       "Loop detected: tool %s called %d times with identical args"
+                       name repeat-count)))
+                (if (zerop recovery-count)
+                    (progn
+                      (setq recovery-message
+                            (ellama-eval--loop-recovery-message
+                             name args result repeat-count))
+                      (setq loop-state
+                            (plist-put loop-state
+                                       :loop-recovery-attempted t))
+                      (setq loop-state
+                            (plist-put loop-state
+                                       :loop-recovery-count 1))
+                      (setq loop-state
+                            (plist-put loop-state
+                                       :loop-recovery-reason loop-reason)))
+                  (setq loop-state
+                        (plist-put loop-state :loop-detected t))
+                  (setf loop-state
+                        (plist-put loop-state :loop-reason loop-reason)))
+                (setf (ellama-eval--run-state-loop-state state)
+                      loop-state))))
+          ;; Record the tool call in history.
+          (push (list :name name :args args) tool-history)
+          ;; Limit history size.
+          (let ((max-traces ellama-eval-loop-detection-max-traces))
+            (when (> (length tool-history) max-traces)
+              (setf (nthcdr max-traces tool-history) nil)))
+          ;; Update the loop-state in the struct.
+          (setf (ellama-eval--run-state-loop-state state)
+                (plist-put loop-state :tool-history tool-history))
+          (when recovery-message
+            (setf (car (ellama-eval--run-state-trace state))
+                  (let ((recovery-entry (copy-sequence entry)))
+                    (setq recovery-entry
+                          (plist-put recovery-entry :raw-result result))
+                    (setq recovery-entry
+                          (plist-put recovery-entry :result recovery-message))
+                    (plist-put recovery-entry :loop-recovery t))))
+          (when (plist-get loop-state :loop-detected)
+            (ellama-eval--finish-run
+             state 'loop-detected (plist-get loop-state :loop-reason)))))
+      recovery-message)))
 
 (defun ellama-eval--instrument-tool-spec (spec)
   "Return SPEC with tool function wrapped for eval tracing."
@@ -504,8 +559,8 @@ Also performs loop detection if enabled."
      (lambda (&rest args)
        (condition-case err
            (let ((result (apply function args)))
-             (ellama-eval--trace-tool-call name args 'ok result)
-             result)
+             (or (ellama-eval--trace-tool-call name args 'ok result)
+                 result))
          (error
           (ellama-eval--trace-tool-call
            name args 'error (error-message-string err))
@@ -1145,6 +1200,13 @@ EXPECTED-FILES and SYNTAX-FILES define the relative file paths to check."
           (ellama-eval--result-status
            run-status file-checks file-regexp-checks
            elisp-check-results answer-checks))
+         (loop-state (ellama-eval--run-state-loop-state state))
+         (loop-detected (and loop-state
+                             (plist-get loop-state :loop-detected)))
+         (loop-recovery-count
+          (or (and loop-state
+                   (plist-get loop-state :loop-recovery-count))
+              0))
          (worker (ellama-eval--run-state-worker state))
          (extra (and worker (ellama-session-extra worker)))
          (continuation-steps (or (plist-get extra :step-count) 0)))
@@ -1194,10 +1256,20 @@ EXPECTED-FILES and SYNTAX-FILES define the relative file paths to check."
      :elisp-checks elisp-check-results
      :answer-checks answer-checks
      :loop-detection
-     (when-let* ((loop-state (ellama-eval--run-state-loop-state state))
-                 (loop-detected (plist-get loop-state :loop-detected)))
-       (list :loop-detected loop-detected
-             :loop-reason (plist-get loop-state :loop-reason)))
+     (when (and loop-state
+                (or loop-detected
+                    (> loop-recovery-count 0)))
+       (list :loop-detected (and loop-detected t)
+             :loop-reason (plist-get loop-state :loop-reason)
+             :loop-recovery-attempted
+             (and (plist-get loop-state :loop-recovery-attempted) t)
+             :loop-recovery-count loop-recovery-count
+             :loop-recovery-reason
+             (plist-get loop-state :loop-recovery-reason)
+             :loop-recovered
+             (and (> loop-recovery-count 0)
+                  (not loop-detected)
+                  (eq status 'passed))))
      :workspace (when ellama-eval-keep-workspaces workspace))))
 
 (defun ellama-eval--finish-run (state run-status &optional task-result)

--- a/ellama-eval.el
+++ b/ellama-eval.el
@@ -453,8 +453,16 @@ in one short sentence."
   "Record a tool call with NAME, ARGS, STATUS and RESULT.
 Also performs loop detection if enabled."
   (when-let* ((state ellama-eval--active-run))
+    ;; Record the trace before loop finalization so the triggering call is
+    ;; visible in the final result.
+    (push (list :name name
+                :args args
+                :status status
+                :result result
+                :finished-at (float-time))
+          (ellama-eval--run-state-trace state))
     (when (and ellama-eval-loop-detection-enabled
-               (not (eq (ellama-eval--run-state-status state) 'loop-detected)))
+               (eq (ellama-eval--run-state-status state) 'pending))
       (let* ((loop-state (ellama-eval--run-state-loop-state state))
              (tool-history (or (and loop-state (plist-get loop-state :tool-history))
                                (list)))
@@ -462,17 +470,15 @@ Also performs loop detection if enabled."
         ;; Check if this tool has been called with identical args recently
         (let ((repeated (seq-take-while
                          (lambda (entry)
-                           (and (eq (plist-get entry :name) name)
+                           (and (equal (plist-get entry :name) name)
                                 (equal (plist-get entry :args) args)))
                          tool-history)))
           (when (>= (1+ (length repeated)) threshold)
             ;; Loop detected - the current call makes it the threshold-th repetition
-            (let* ((loop-reason (format
-                                 "Loop detected: tool %s called %d times with identical args"
-                                 name threshold))
-                   (loop-result (list :status 'loop-detected :loop-reason loop-reason)))
-              (setf (ellama-eval--run-state-status state) 'loop-detected)
-              (setf (ellama-eval--run-state-result state) loop-result)
+            (let ((loop-reason (format
+                                "Loop detected: tool %s called %d times with identical args"
+                                name threshold)))
+              (setq loop-state (plist-put loop-state :loop-detected t))
               (setf loop-state (plist-put loop-state :loop-reason loop-reason))
               (setf (ellama-eval--run-state-loop-state state) loop-state))))
         ;; Record the tool call in history
@@ -483,14 +489,10 @@ Also performs loop detection if enabled."
             (setf (nthcdr max-traces tool-history) nil)))
         ;; Update the loop-state in the struct
         (setf (ellama-eval--run-state-loop-state state)
-              (plist-put loop-state :tool-history tool-history))))
-    ;; Record the trace (inside when-let* so state is bound)
-    (push (list :name name
-                :args args
-                :status status
-                :result result
-                :finished-at (float-time))
-          (ellama-eval--run-state-trace state))))
+              (plist-put loop-state :tool-history tool-history))
+        (when (plist-get loop-state :loop-detected)
+          (ellama-eval--finish-run
+           state 'loop-detected (plist-get loop-state :loop-reason)))))))
 
 (defun ellama-eval--instrument-tool-spec (spec)
   "Return SPEC with tool function wrapped for eval tracing."
@@ -1013,6 +1015,7 @@ RUN-STATUS is the execution status.  FILE-CHECKS, FILE-REGEXP-CHECKS,
 ELISP-CHECKS and ANSWER-CHECKS contain oracle results."
   (cond
    ((eq run-status 'timeout) 'timeout)
+   ((eq run-status 'loop-detected) 'loop-detected)
    ((and (ellama-eval--checks-pass-p file-checks)
          (ellama-eval--checks-pass-p file-regexp-checks)
          (ellama-eval--checks-pass-p elisp-checks)

--- a/ellama-eval.el
+++ b/ellama-eval.el
@@ -58,10 +58,32 @@
   :type 'integer
   :group 'ellama-eval)
 
+(defcustom ellama-eval-loop-detection-enabled t
+  "Enable automatic loop detection during evaluation runs.
+When non-nil, the eval harness tracks tool call patterns and detects
+repetitive behavior that indicates the agent is stuck in a loop."
+  :type 'boolean
+  :group 'ellama-eval)
+
+(defcustom ellama-eval-loop-detection-repeated-threshold 3
+  "Number of repeated identical tool calls that triggers loop detection.
+When the same tool is called with identical arguments this many times
+in a row, the harness flags it as a potential loop."
+  :type 'integer
+  :group 'ellama-eval)
+
+(defcustom ellama-eval-loop-detection-max-traces 50
+  "Maximum number of tool call traces to keep for loop analysis.
+Older traces are discarded when this limit is exceeded."
+  :type 'integer
+  :group 'ellama-eval)
+
 (cl-defstruct ellama-eval--run-state
   "Mutable state for one active evaluation run."
   status result trace worker started-at workspace case profile callback
-  timeout-timer edit-validation-trace)
+  timeout-timer edit-validation-trace
+  loop-detection loop-state)
+
 
 (defvar ellama-eval--active-run nil
   "Current evaluation run state.
@@ -428,8 +450,36 @@ in one short sentence."
      spec)))
 
 (defun ellama-eval--trace-tool-call (name args status result)
-  "Record a tool call with NAME, ARGS, STATUS and RESULT."
+  "Record a tool call with NAME, ARGS, STATUS and RESULT.
+Also performs loop detection if enabled."
   (when-let* ((state ellama-eval--active-run))
+    (when (and ellama-eval-loop-detection-enabled
+               (not (eq (ellama-eval--run-state-status state) 'loop-detected)))
+      (let* ((loop-state (ellama-eval--run-state-loop-state state))
+             (tool-history (and loop-state (plist-get loop-state :tool-history)))
+             (threshold ellama-eval-loop-detection-repeated-threshold))
+        (when tool-history
+          ;; Check if this tool has been called with identical args recently
+          (let ((repeated (seq-take-while
+                           (lambda (entry)
+                             (and (eq (plist-get entry :name) name)
+                                  (equal (plist-get entry :args) args)))
+                           tool-history)))
+            (when (>= (length repeated) threshold)
+              ;; Loop detected - stop the run
+              (setf (ellama-eval--run-state-status state) 'loop-detected)
+              (ellama-eval--run-state-set-result
+               state
+               (list :status 'loop-detected
+                     :loop-reason (format
+                                   "Loop detected: tool %s called %d times with identical args"
+                                   name threshold)))))
+          ;; Record the tool call in history
+          (push (list :name name :args args) tool-history)
+          ;; Limit history size
+          (let ((max-traces ellama-eval-loop-detection-max-traces))
+            (when (> (length tool-history) max-traces)
+              (setf (nthcdr max-traces tool-history) nil))))))
     (push (list :name name
                 :args args
                 :status status
@@ -1119,6 +1169,11 @@ EXPECTED-FILES and SYNTAX-FILES define the relative file paths to check."
      :file-regexp-checks file-regexp-checks
      :elisp-checks elisp-check-results
      :answer-checks answer-checks
+     :loop-detection
+     (when-let* ((loop-state (ellama-eval--run-state-loop-state state))
+                 (loop-detected (plist-get loop-state :loop-detected)))
+       (list :loop-detected loop-detected
+             :loop-reason (plist-get loop-state :loop-reason)))
      :workspace (when ellama-eval-keep-workspaces workspace))))
 
 (defun ellama-eval--finish-run (state run-status &optional task-result)
@@ -1162,7 +1217,10 @@ PROVIDER overrides the provider used by the eval role."
            :workspace workspace
            :case case
            :profile profile
-           :callback callback))
+           :callback callback
+           :loop-state
+           (when ellama-eval-loop-detection-enabled
+             (list :tool-history nil :loop-detected nil :loop-reason ""))))
          (original-new-session (symbol-function 'ellama-new-session)))
     (setq ellama-eval--active-run state)
     (setf (ellama-eval--run-state-timeout-timer state)

--- a/ellama-tools.el
+++ b/ellama-tools.el
@@ -272,6 +272,24 @@ Plist with keys `:path', `:mtime' and `:policy'.")
   :type 'integer
   :group 'ellama)
 
+(defcustom ellama-tools-subagent-loop-detection-enabled t
+  "Detect repeated identical tool calls in sub-agent sessions.
+When non-nil, sub-agent tools return recovery guidance on repeated identical
+calls and terminate the subtask if the same consecutive call chain continues."
+  :type 'boolean
+  :group 'ellama)
+
+(defcustom ellama-tools-subagent-loop-detection-repeated-threshold 2
+  "Number of consecutive identical sub-agent tool calls that triggers recovery.
+Values below 2 are treated as 2 so the first call is never considered a loop."
+  :type 'integer
+  :group 'ellama)
+
+(defcustom ellama-tools-subagent-loop-detection-max-traces 50
+  "Maximum recent sub-agent tool calls retained for loop detection."
+  :type 'integer
+  :group 'ellama)
+
 (defcustom ellama-tools-agent-default-max-steps 40
   "Default maximum number of auto-continue steps for plan-and-act agents."
   :type 'integer
@@ -4090,6 +4108,141 @@ CALLBACK will be used to report result asyncronously."
     :description "Report final result and terminate the task."
     :args ((:name "result" :type string))))
 
+(defun ellama-tools--subagent-loop-state ()
+  "Return a fresh sub-agent tool loop state plist."
+  (list :tool-history nil
+        :loop-detected nil
+        :loop-reason ""
+        :loop-recovery-attempted nil
+        :loop-recovery-count 0
+        :loop-recovery-reason ""))
+
+(defun ellama-tools--subagent-complete (session result)
+  "Complete sub-agent SESSION with RESULT when it is still active."
+  (when-let* (((ellama-session-p session))
+              (extra (ellama-session-extra session))
+              ((not (plist-get extra :task-completed))))
+    (ellama-tools--set-session-extra
+     session
+     (plist-put (copy-sequence extra) :task-completed t))
+    (when-let* ((callback (plist-get extra :result-callback))
+                ((functionp callback)))
+      (funcall callback result))))
+
+(defun ellama-tools--subagent-loop-recovery-message
+    (name args result repeat-count)
+  "Return recovery guidance for repeated tool NAME with ARGS.
+RESULT is the latest tool result.  REPEAT-COUNT is the repeated call count."
+  (concat
+   (format
+    "LOOP RECOVERY: `%s` was called %d times with identical arguments.\n"
+    name repeat-count)
+   (format "Do not call `%s` again with these exact arguments: %S\n"
+           name args)
+   (format "Latest tool result:\n%s\n\n" result)
+   (if (equal name "edit_file")
+       "Next action: read the exact current file text with `read_file` \
+or `lines_range`, copy the exact oldcontent from that output, then call \
+`edit_file` with different oldcontent.  If you cannot identify an exact \
+replacement, call `report_result` with the blocker."
+     "Next action: choose a different tool call or different arguments \
+based on the latest result.  If no different useful action exists, call \
+`report_result` with the blocker.")))
+
+(defun ellama-tools--subagent-trace-tool-call
+    (session name args result)
+  "Record sub-agent tool call NAME with ARGS and RESULT for SESSION.
+Return recovery guidance or loop termination text when it should replace
+RESULT for the agent."
+  (when (and ellama-tools-subagent-loop-detection-enabled
+             (ellama-session-p session))
+    (let* ((extra (ellama-session-extra session))
+           (loop-state (or (plist-get extra :tool-loop-state)
+                           (ellama-tools--subagent-loop-state)))
+           (tool-history (or (plist-get loop-state :tool-history) (list)))
+           (threshold
+            (max 2 ellama-tools-subagent-loop-detection-repeated-threshold))
+           replacement)
+      (unless (plist-get extra :task-completed)
+        (let* ((repeated
+                (seq-take-while
+                 (lambda (history-entry)
+                   (and (equal (plist-get history-entry :name) name)
+                        (equal (plist-get history-entry :args) args)))
+                 tool-history))
+               (repeat-count (1+ (length repeated))))
+          (when (>= repeat-count threshold)
+            (let* ((recovery-count
+                    (or (plist-get loop-state :loop-recovery-count) 0))
+                   (loop-reason
+                    (format
+                     "Loop detected: tool %s called %d times with identical args"
+                     name repeat-count)))
+              (if (= repeat-count threshold)
+                  (progn
+                    (setq replacement
+                          (ellama-tools--subagent-loop-recovery-message
+                           name args result repeat-count))
+                    (setq loop-state
+                          (plist-put loop-state
+                                     :loop-recovery-attempted t))
+                    (setq loop-state
+                          (plist-put loop-state
+                                     :loop-recovery-count
+                                     (1+ recovery-count)))
+                    (setq loop-state
+                          (plist-put loop-state
+                                     :loop-recovery-reason loop-reason)))
+                (setq loop-state
+                      (plist-put loop-state :loop-detected t))
+                (setq loop-state
+                      (plist-put loop-state :loop-reason loop-reason))
+                (setq replacement loop-reason)
+                (ellama-tools--subagent-complete session loop-reason)))))
+        (push (list :name name :args args) tool-history)
+        (let ((max-traces ellama-tools-subagent-loop-detection-max-traces))
+          (when (> (length tool-history) max-traces)
+            (setf (nthcdr max-traces tool-history) nil)))
+        (setq loop-state (plist-put loop-state :tool-history tool-history))
+        (ellama-tools--set-session-extra
+         session
+         (ellama-tools--session-extra-with
+          session :tool-loop-state loop-state)))
+      replacement)))
+
+(defun ellama-tools--wrap-subagent-tool (tool session)
+  "Return TOOL wrapped with sub-agent loop detection for SESSION."
+  (let* ((wrapped-tool (copy-sequence tool))
+         (name (llm-tool-name tool))
+         (function (llm-tool-function tool))
+         (async (llm-tool-async tool)))
+    (setf
+     (llm-tool-function wrapped-tool)
+     (lambda (&rest args)
+       (if (and async args (functionp (car args)))
+           (let ((callback (car args))
+                 (call-args (cdr args)))
+             (apply
+              function
+              (lambda (result)
+                (funcall
+                 callback
+                 (or (ellama-tools--subagent-trace-tool-call
+                      session name call-args result)
+                     result)))
+              call-args))
+         (let ((result (apply function args)))
+           (or (ellama-tools--subagent-trace-tool-call
+                session name args result)
+               result)))))
+    wrapped-tool))
+
+(defun ellama-tools--wrap-subagent-tools (tools session)
+  "Return TOOLS wrapped with sub-agent loop detection for SESSION."
+  (mapcar (lambda (tool)
+            (ellama-tools--wrap-subagent-tool tool session))
+          tools))
+
 (defun ellama-tools--subagent-system-message (system-msg)
   "Return subagent system message from SYSTEM-MSG."
   (format
@@ -4197,6 +4350,8 @@ ARGUMENTS  – object with template substitution values."
 
                ;; ---- resolve tools for role ----
                (role-tools (ellama-tools--for-role role-key))
+               (subagent-tools
+                (ellama-tools--wrap-subagent-tools role-tools worker))
 
                ;; ---- dynamic report_result tool ----
                (report-tool
@@ -4205,7 +4360,7 @@ ARGUMENTS  – object with template substitution values."
                         callback worker)))
 
                ;; IMPORTANT: report tool must be first (termination tool priority)
-               (all-tools (cons report-tool role-tools)))
+               (all-tools (cons report-tool subagent-tools)))
 
           ;; ============================================================
           ;; Initialize session state (single source of truth)
@@ -4222,6 +4377,7 @@ ARGUMENTS  – object with template substitution values."
             :task-completed nil
             :step-count 0
             :max-steps steps-limit
+            :tool-loop-state (ellama-tools--subagent-loop-state)
             :system subagent-system))
 
           ;; ============================================================

--- a/ellama.el
+++ b/ellama.el
@@ -1848,6 +1848,8 @@ If AUTOMATIC is non-nil, fail quietly and return nil."
                           (setq request-context
                                 (ellama--set-current-request
                                  request buffers request-context))
+                          (ellama--set-session-request-context
+                           session request-context)
                           (ellama--request-context-add-cancel-function
                            request-context #'cancel)))))
                   t)
@@ -2166,6 +2168,7 @@ If EPHEMERAL non nil new session will not be associated with any file."
   "Create request context for BUFFERS."
   (list :buffers (cl-remove-if-not #'buffer-live-p buffers)
         :request nil
+        :session nil
         :cancel-functions nil))
 
 (defun ellama--request-context-buffers (request-context)
@@ -2176,6 +2179,26 @@ If EPHEMERAL non nil new session will not be associated with any file."
 (defun ellama--request-context-request (request-context)
   "Return request object from REQUEST-CONTEXT."
   (plist-get request-context :request))
+
+(defun ellama--request-context-session (request-context)
+  "Return session from REQUEST-CONTEXT."
+  (plist-get request-context :session))
+
+(defun ellama--set-session-request-context (session request-context)
+  "Store REQUEST-CONTEXT as active request context for SESSION."
+  (when (ellama-session-p session)
+    (setf (plist-get request-context :session) session)
+    (ellama--session-extra-put
+     session :current-request-context request-context)))
+
+(defun ellama--clear-session-request-context (request-context)
+  "Clear session request context matching REQUEST-CONTEXT."
+  (when-let* ((session (ellama--request-context-session request-context))
+              ((ellama-session-p session))
+              ((eq (ellama--session-extra-get
+                    session :current-request-context)
+                   request-context)))
+    (ellama--session-extra-put session :current-request-context nil)))
 
 (defun ellama--request-context-add-cancel-function
     (request-context function)
@@ -2229,7 +2252,9 @@ REQUEST-CONTEXT is a request context."
           (push buffer target-buffers))))
     (dolist (buffer target-buffers)
       (with-current-buffer buffer
-        (ellama-request-mode -1)))))
+        (ellama-request-mode -1)))
+    (when ctx
+      (ellama--clear-session-request-context ctx))))
 
 (defun ellama--chat-last-role ()
   "Return last chat role marker in current buffer."
@@ -2287,6 +2312,25 @@ When APPEND-USER-HEADER is non-nil, append a user header in chat buffers."
       (when append-user-header
         (dolist (buffer (or buffers (list (current-buffer))))
           (ellama--chat-append-user-header-after-cancel buffer))))))
+
+(defun ellama--cancel-request-context
+    (request-context &optional append-user-header)
+  "Cancel request stored in REQUEST-CONTEXT.
+When APPEND-USER-HEADER is non-nil, append a user header in chat buffers."
+  (declare-function spinner-stop "ext:spinner")
+  (when-let* ((request-context)
+              (request (ellama--request-context-request request-context)))
+    (let ((buffers (ellama--request-context-buffers request-context)))
+      (llm-cancel-request request)
+      (ellama--run-request-context-cancel-functions request-context)
+      (when ellama-spinner-enabled
+        (require 'spinner)
+        (spinner-stop))
+      (ellama--deactivate-current-request request-context)
+      (when append-user-header
+        (dolist (buffer buffers)
+          (ellama--chat-append-user-header-after-cancel buffer)))
+      t)))
 
 (defun ellama--cancel-current-request-and-quit ()
   "Cancel the current request and quit."
@@ -3288,7 +3332,11 @@ inserted into the BUFFER."
                              (ellama--set-current-request
                               request
                               (list buffer reasoning-buffer)
-                              request-context))))))
+                              request-context))
+                       (ellama--set-session-request-context
+                        (with-current-buffer buffer
+                          ellama--current-session)
+                        request-context)))))
               (start-request)))
         (with-current-buffer buffer
           (accept-change-group ellama--change-group)
@@ -3545,7 +3593,9 @@ failure (with BUFFER current).
                          (ellama--set-current-request
                           request
                           (list buffer reasoning-buffer)
-                          request-context))))))
+                          request-context))
+                   (ellama--set-session-request-context
+                    session request-context)))))
           (start-request))))))
 
 (defun ellama-chain (initial-prompt forms &optional acc)

--- a/ellama.el
+++ b/ellama.el
@@ -6,7 +6,7 @@
 ;; URL: http://github.com/s-kostyaev/ellama
 ;; Keywords: help local tools
 ;; Package-Requires: ((emacs "28.1") (llm "0.30.2") (plz "0.8") (transient "0.7") (compat "29.1") (yaml "1.2.3"))
-;; Version: 1.24.1
+;; Version: 1.25.0
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;; Created: 8th Oct 2023
 

--- a/ellama.el
+++ b/ellama.el
@@ -1720,17 +1720,34 @@ REQUESTED-KEPT-TURNS is the configured recent turn count."
 
 (defun ellama--session-compact-handle-async-error (session err)
   "Reset SESSION compaction state and report asynchronous ERR."
-  (ellama--session-extra-put session :auto-compact-in-progress nil)
-  (ellama--session-set-compaction-mode session nil nil)
+  (ellama--session-compact-reset session nil)
   (message "Ellama context compaction failed: %s" err))
 
+(defun ellama--session-compact-reset (session buffer)
+  "Reset SESSION compaction state and BUFFER status."
+  (ellama--session-extra-put session :auto-compact-in-progress nil)
+  (ellama--session-extra-put session :auto-compact-request nil)
+  (ellama--session-set-compaction-mode session buffer nil))
+
+(defun ellama--session-compact-request-buffers
+    (buffer request-context)
+  "Return buffers that should own a compaction request.
+BUFFER is the compaction buffer.  REQUEST-CONTEXT is the active
+request context when compaction runs after a response."
+  (or (and request-context
+           (ellama--request-context-buffers request-context))
+      (and (buffer-live-p buffer)
+           (list buffer))))
+
 (cl-defun ellama--session-compact
-    (session &key provider buffer token-count automatic on-done)
+    (session &key provider buffer token-count automatic on-done
+             request-context)
   "Compact SESSION conversation context.
 PROVIDER is the current session provider.
 BUFFER is the chat buffer that should receive a notice.
 TOKEN-COUNT is the estimated context size before compaction.
 ON-DONE is called after asynchronous compaction succeeds or fails.
+REQUEST-CONTEXT is the active request context.
 If AUTOMATIC is non-nil, fail quietly and return nil."
   (condition-case err
       (let* ((provider (or provider (ellama-session-provider session)))
@@ -1779,43 +1796,63 @@ If AUTOMATIC is non-nil, fail quietly and return nil."
                   (ellama--session-compact-build-summary-prompt
                    previous-summary old-interactions target)))
             (condition-case err
-                (progn
-                  (llm-chat-async
-                   summary-provider
-                   (llm-make-chat-prompt summary-prompt)
-                   (lambda (response)
-                     (condition-case compact-err
-                         (ellama--session-compact-apply
-                          session prompt provider buffer original-context
-                          interactions old-interactions recent-interactions
-                          before-token-count
-                          (if (stringp response)
-                              response
-                            (plist-get response :text))
-                          requested-keep-turns)
-                       (error
-                        (ellama--session-compact-handle-async-error
-                         session (error-message-string compact-err))))
-                     (ellama--session-set-compaction-mode
-                      session buffer nil)
-                     (ellama--session-extra-put
-                      session :auto-compact-in-progress nil)
-                     (when on-done
-                       (funcall on-done)))
-                   (lambda (&rest err)
-                     (ellama--session-compact-handle-async-error
-                      session
-                      (mapconcat
-                       (lambda (item) (format "%s" item))
-                       err " "))
-                     (when on-done
-                       (funcall on-done)))
-                   t)
+                (let (completed request)
+                  (cl-labels
+                      ((finish ()
+                         (setq completed t)
+                         (ellama--session-compact-reset session buffer)
+                         (when request-context
+                           (ellama--deactivate-current-request
+                            request-context))
+                         (when on-done
+                           (funcall on-done)))
+                       (cancel ()
+                         (setq completed t)
+                         (ellama--session-compact-reset session buffer)))
+                    (setq
+                     request
+                     (llm-chat-async
+                      summary-provider
+                      (llm-make-chat-prompt summary-prompt)
+                      (lambda (response)
+                        (unless completed
+                          (condition-case compact-err
+                              (ellama--session-compact-apply
+                               session prompt provider buffer original-context
+                               interactions old-interactions recent-interactions
+                               before-token-count
+                               (if (stringp response)
+                                   response
+                                 (plist-get response :text))
+                               requested-keep-turns)
+                            (error
+                             (ellama--session-compact-handle-async-error
+                              session (error-message-string compact-err))))
+                          (finish)))
+                      (lambda (&rest err)
+                        (unless completed
+                          (ellama--session-compact-handle-async-error
+                           session
+                           (mapconcat
+                            (lambda (item) (format "%s" item))
+                            err " "))
+                          (finish)))
+                      t))
+                    (unless completed
+                      (ellama--session-extra-put
+                       session :auto-compact-request request)
+                      (let ((buffers
+                             (ellama--session-compact-request-buffers
+                              buffer request-context)))
+                        (when buffers
+                          (setq request-context
+                                (ellama--set-current-request
+                                 request buffers request-context))
+                          (ellama--request-context-add-cancel-function
+                           request-context #'cancel)))))
                   t)
               (error
-               (ellama--session-set-compaction-mode session buffer nil)
-               (ellama--session-extra-put
-                session :auto-compact-in-progress nil)
+               (ellama--session-compact-reset session buffer)
                (signal (car err) (cdr err)))))))
     (error
      (if automatic
@@ -1826,10 +1863,11 @@ If AUTOMATIC is non-nil, fail quietly and return nil."
        (signal (car err) (cdr err))))))
 
 (cl-defun ellama--session-auto-compact-maybe
-    (session provider response text buffer &key on-done)
+    (session provider response text buffer &key on-done request-context)
   "Compact SESSION when RESPONSE token use for TEXT crosses threshold.
 PROVIDER is the session provider.  BUFFER is the chat buffer.
-ON-DONE is called after asynchronous compaction succeeds or fails."
+ON-DONE is called after asynchronous compaction succeeds or fails.
+REQUEST-CONTEXT is the active request context."
   (when-let ((token-count
               (ellama--session-auto-compact-needed-p
                session provider response text)))
@@ -1839,7 +1877,8 @@ ON-DONE is called after asynchronous compaction succeeds or fails."
      :buffer buffer
      :token-count token-count
      :automatic t
-     :on-done on-done)))
+     :on-done on-done
+     :request-context request-context)))
 
 (defun ellama--active-session-by-id (id)
   "Return active session matching display ID."
@@ -2126,7 +2165,8 @@ If EPHEMERAL non nil new session will not be associated with any file."
 (defun ellama--make-request-context (buffers)
   "Create request context for BUFFERS."
   (list :buffers (cl-remove-if-not #'buffer-live-p buffers)
-        :request nil))
+        :request nil
+        :cancel-functions nil))
 
 (defun ellama--request-context-buffers (request-context)
   "Return live buffers from REQUEST-CONTEXT."
@@ -2136,6 +2176,24 @@ If EPHEMERAL non nil new session will not be associated with any file."
 (defun ellama--request-context-request (request-context)
   "Return request object from REQUEST-CONTEXT."
   (plist-get request-context :request))
+
+(defun ellama--request-context-add-cancel-function
+    (request-context function)
+  "Add FUNCTION to REQUEST-CONTEXT cancellation hooks."
+  (when request-context
+    (setf (plist-get request-context :cancel-functions)
+          (cons function
+                (plist-get request-context :cancel-functions)))))
+
+(defun ellama--run-request-context-cancel-functions (request-context)
+  "Run cancellation hooks from REQUEST-CONTEXT."
+  (dolist (function (plist-get request-context :cancel-functions))
+    (condition-case err
+        (funcall function)
+      (error
+       (message "Ellama request cancellation cleanup failed: %s"
+                (error-message-string err)))))
+  (setf (plist-get request-context :cancel-functions) nil))
 
 (defun ellama--set-current-request (request buffers &optional request-context)
   "Set REQUEST for BUFFERS and enable `ellama-request-mode'.
@@ -2220,6 +2278,8 @@ When APPEND-USER-HEADER is non-nil, append a user header in chat buffers."
                        (ellama--request-context-buffers request-context))))
     (when request
       (llm-cancel-request request)
+      (when request-context
+        (ellama--run-request-context-cancel-functions request-context))
       (when ellama-spinner-enabled
         (require 'spinner)
         (spinner-stop))
@@ -3258,7 +3318,8 @@ inserted into the BUFFER."
                   (unless
                       (ellama--session-auto-compact-maybe
                        ellama--current-session provider response text buffer
-                       :on-done finish-response)
+                       :on-done finish-response
+                       :request-context request-context)
                     (funcall finish-response)))
               (funcall finish-response))))))))
 

--- a/ellama.info
+++ b/ellama.info
@@ -639,6 +639,14 @@ argument generated text string.
      Skills.  Default value is ‘"skills"’.
    • ‘ellama-tools-subagent-default-max-steps’: Default maximum number
      of auto-continue steps for a sub-agent.  Default value is 30.
+   • ‘ellama-tools-subagent-loop-detection-enabled’: Detect repeated
+     identical tool calls in sub-agent sessions.  Enabled by default.
+   • ‘ellama-tools-subagent-loop-detection-repeated-threshold’: Number
+     of consecutive identical sub-agent tool calls that triggers
+     recovery.  Default value is 2.
+   • ‘ellama-tools-subagent-loop-detection-max-traces’: Maximum recent
+     sub-agent tool calls retained for loop detection.  Default value is
+     50.
    • ‘ellama-tools-subagent-continue-prompt’: Prompt sent to a sub-agent
      when it finishes a turn without calling ‘report_result’.
    • ‘ellama-tools-subagent-roles’: Subagent roles with provider, system
@@ -817,6 +825,17 @@ Each sub-agent runs in its own Ellama session.  When
 displays both the main session and sub-agent session buffers as
 generation starts.  Sub-agent buffers include the delegated prompt under
 the ‘Main agent:’ label, followed by the sub-agent response.
+
+Sub-agents also keep session-local tool loop state.  When
+‘ellama-tools-subagent-loop-detection-enabled’ is non-nil, the second
+consecutive identical tool call returns a recovery message instead of
+the normal tool result.  The message includes the repeated tool name,
+exact arguments, the latest tool result and a next action.  If the same
+consecutive call chain continues beyond
+‘ellama-tools-subagent-loop-detection-repeated-threshold’, Ellama
+finishes the subtask with a loop-detected result.  A later repeated call
+after a different tool call is treated as a new recovery opportunity,
+not as an immediate hard loop.
 
 The tool accepts either a free-form ‘description’ or a prompt template:
 
@@ -2510,45 +2529,45 @@ Node: Installation3973
 Node: Commands8987
 Node: Keymap17925
 Node: Configuration20812
-Node: Session Provider Keys33152
-Node: Session Compaction35013
-Node: Image Input37307
-Node: Task Tool Subagents39452
-Node: Plan-and-Act Agent Loop41553
-Node: Edit Tool Shell Hooks43737
-Node: DLP for Tool Input/Output45725
-Node: SRT Filesystem Policy for Tools60629
-Node: Context Management66298
-Node: Transient Menus for Context Management67366
-Node: Managing the Context69045
-Node: Considerations69820
-Node: Minor modes70413
-Node: ellama-context-header-line-mode72401
-Node: ellama-context-header-line-global-mode73226
-Node: ellama-context-mode-line-mode73946
-Node: ellama-context-mode-line-global-mode74794
-Node: Ellama Session Header Line Mode75498
-Node: Enabling and Disabling76067
-Node: Customization76514
-Node: Ellama Session Mode Line Mode76802
-Node: Enabling and Disabling (1)77387
-Node: Customization (1)77834
-Node: Using Blueprints78128
-Node: Key Components of Ellama Blueprints78768
-Node: Creating and Managing Blueprints79375
-Node: Blueprints files80353
-Node: Variable Management80774
-Node: Keymap and Mode81227
-Node: Transient Menus82163
-Node: Running Blueprints programmatically82709
-Node: MCP Integration83296
-Node: Agent Skills84531
-Node: Directory Structure84894
-Node: Creating a Skill85921
-Node: How it works86296
-Node: Acknowledgments86687
-Node: Contributions87398
-Node: GNU Free Documentation License87784
+Node: Session Provider Keys33634
+Node: Session Compaction35495
+Node: Image Input37789
+Node: Task Tool Subagents39934
+Node: Plan-and-Act Agent Loop42664
+Node: Edit Tool Shell Hooks44848
+Node: DLP for Tool Input/Output46836
+Node: SRT Filesystem Policy for Tools61740
+Node: Context Management67409
+Node: Transient Menus for Context Management68477
+Node: Managing the Context70156
+Node: Considerations70931
+Node: Minor modes71524
+Node: ellama-context-header-line-mode73512
+Node: ellama-context-header-line-global-mode74337
+Node: ellama-context-mode-line-mode75057
+Node: ellama-context-mode-line-global-mode75905
+Node: Ellama Session Header Line Mode76609
+Node: Enabling and Disabling77178
+Node: Customization77625
+Node: Ellama Session Mode Line Mode77913
+Node: Enabling and Disabling (1)78498
+Node: Customization (1)78945
+Node: Using Blueprints79239
+Node: Key Components of Ellama Blueprints79879
+Node: Creating and Managing Blueprints80486
+Node: Blueprints files81464
+Node: Variable Management81885
+Node: Keymap and Mode82338
+Node: Transient Menus83274
+Node: Running Blueprints programmatically83820
+Node: MCP Integration84407
+Node: Agent Skills85642
+Node: Directory Structure86005
+Node: Creating a Skill87032
+Node: How it works87407
+Node: Acknowledgments87798
+Node: Contributions88509
+Node: GNU Free Documentation License88895
 
 End Tag Table
 

--- a/tests/test-ellama-eval.el
+++ b/tests/test-ellama-eval.el
@@ -669,10 +669,10 @@
       (should (eq constructed-provider 'base-provider)))))
 
 (ert-deftest test-ellama-eval-loop-detection-identical-calls ()
-  "Test that identical tool calls trigger loop detection."
+  "Test that identical tool calls trigger recovery then detection."
   (let ((ellama-eval--active-run nil)
         (ellama-eval-loop-detection-enabled t)
-        (ellama-eval-loop-detection-repeated-threshold 3)
+        (ellama-eval-loop-detection-repeated-threshold 2)
         (ellama-eval-loop-detection-max-traces 50)
         (workspace (make-temp-file "ellama-eval-loop-" t))
         state)
@@ -690,10 +690,24 @@
            :loop-state
            (list :tool-history nil :loop-detected nil :loop-reason "")))
     (setq ellama-eval--active-run state)
-    ;; Simulate 3 identical tool calls
     (let ((identical-args '(:path "/test.el")))
-      (dotimes (_ 3)
-        (ellama-eval--trace-tool-call "read_file" identical-args 'ok "content"))
+      (should-not
+       (ellama-eval--trace-tool-call
+        "read_file" identical-args 'ok "content"))
+      (let ((recovery
+             (ellama-eval--trace-tool-call
+              "read_file" identical-args 'ok "content")))
+        (should (string-match-p "LOOP RECOVERY" recovery))
+        (should (eq (ellama-eval--run-state-status state) 'pending))
+        (should (plist-get (ellama-eval--run-state-loop-state state)
+                           :loop-recovery-attempted))
+        (should (= (plist-get (ellama-eval--run-state-loop-state state)
+                              :loop-recovery-count)
+                   1))
+        (should (plist-get (car (ellama-eval--run-state-trace state))
+                           :loop-recovery)))
+      (ellama-eval--trace-tool-call
+       "read_file" identical-args 'ok "content")
       (should (eq (ellama-eval--run-state-status state) 'loop-detected))
       (should (plist-get (ellama-eval--run-state-loop-state state)
                          :loop-detected))
@@ -704,7 +718,7 @@
   "Test that different tool args don't trigger loop detection."
   (let ((ellama-eval--active-run nil)
         (ellama-eval-loop-detection-enabled t)
-        (ellama-eval-loop-detection-repeated-threshold 3)
+        (ellama-eval-loop-detection-repeated-threshold 2)
         (ellama-eval-loop-detection-max-traces 50)
         (workspace (make-temp-file "ellama-eval-loop-" t))
         state)
@@ -803,7 +817,7 @@
   "Test that tool calls are still traced even when loop detection is active."
   (let ((ellama-eval--active-run nil)
         (ellama-eval-loop-detection-enabled t)
-        (ellama-eval-loop-detection-repeated-threshold 3)
+        (ellama-eval-loop-detection-repeated-threshold 2)
         (ellama-eval-loop-detection-max-traces 50)
         (workspace (make-temp-file "ellama-eval-loop-" t))
         callback-result
@@ -822,7 +836,7 @@
            :loop-state
            (list :tool-history nil :loop-detected nil :loop-reason "")))
     (setq ellama-eval--active-run state)
-    ;; Make 3 identical calls (triggers loop detection)
+    ;; Make 3 identical calls (recovery on second, detection on third).
     (let ((identical-args '(:path "/test.el")))
       (dotimes (_ 3)
         (ellama-eval--trace-tool-call "read_file" identical-args 'ok "content")))
@@ -831,13 +845,18 @@
       (should (= (length trace) 3))
       (should (seq-every-p (lambda (entry)
                              (eq (plist-get entry :status) 'ok))
-                           trace)))))
+                           trace))
+      (should (plist-get (nth 1 trace) :loop-recovery))
+      (should (string-match-p "LOOP RECOVERY"
+                              (plist-get (nth 1 trace) :result)))
+      (should (equal (plist-get (nth 1 trace) :raw-result)
+                     "content")))))
 
 (ert-deftest test-ellama-eval-loop-detection-finalizes-run ()
   "Test that loop detection finalizes the eval run and calls the callback."
   (let* ((ellama-eval--active-run nil)
          (ellama-eval-loop-detection-enabled t)
-         (ellama-eval-loop-detection-repeated-threshold 3)
+         (ellama-eval-loop-detection-repeated-threshold 2)
          (ellama-eval-loop-detection-max-traces 50)
          (workspace (make-temp-file "ellama-eval-loop-" t))
          callback-result
@@ -865,17 +884,21 @@
     (should-not (plist-get callback-result :success))
     (should (equal (plist-get callback-result :report-result)
                    "Loop detected: tool read_file called 3 times with identical args"))
-    (should (equal (plist-get callback-result :loop-detection)
-                   '(:loop-detected t
-                                    :loop-reason
-                                    "Loop detected: tool read_file called 3 times with identical args")))
+    (let ((loop-detection (plist-get callback-result :loop-detection)))
+      (should (plist-get loop-detection :loop-detected))
+      (should (equal
+               (plist-get loop-detection :loop-reason)
+               "Loop detected: tool read_file called 3 times with identical args"))
+      (should (plist-get loop-detection :loop-recovery-attempted))
+      (should (= (plist-get loop-detection :loop-recovery-count) 1))
+      (should-not (plist-get loop-detection :loop-recovered)))
     (should (= (plist-get callback-result :tool-call-count) 3))))
 
 (ert-deftest test-ellama-eval-loop-detection-cancels-worker-request ()
   "Test that loop detection cancels the active worker request."
   (let* ((ellama-eval--active-run nil)
          (ellama-eval-loop-detection-enabled t)
-         (ellama-eval-loop-detection-repeated-threshold 3)
+         (ellama-eval-loop-detection-repeated-threshold 2)
          (ellama-eval-loop-detection-max-traces 50)
          (workspace (make-temp-file "ellama-eval-loop-" t))
          (worker-buffer (generate-new-buffer " *ellama-eval-worker*"))
@@ -916,6 +939,49 @@
                              :task-completed)))
       (when (buffer-live-p worker-buffer)
         (kill-buffer worker-buffer))
+      (when (file-directory-p workspace)
+        (delete-directory workspace t)))))
+
+(ert-deftest test-ellama-eval-loop-recovery-visible-on-pass ()
+  "Test that successful runs still report loop recovery metadata."
+  (let* ((workspace (make-temp-file "ellama-eval-loop-pass-" t))
+         (state
+          (make-ellama-eval--run-state
+           :status 'pending
+           :result "done"
+           :trace (list (list :name "read_file"
+                              :args '("file.el")
+                              :status 'ok
+                              :result "LOOP RECOVERY: read differently"
+                              :raw-result "content"
+                              :loop-recovery t
+                              :finished-at (float-time)))
+           :edit-validation-trace nil
+           :started-at (float-time)
+           :workspace workspace
+           :case '(:id "test" :suite edit)
+           :profile 'baseline
+           :callback nil
+           :loop-state
+           (list :tool-history nil
+                 :loop-detected nil
+                 :loop-reason ""
+                 :loop-recovery-attempted t
+                 :loop-recovery-count 1
+                 :loop-recovery-reason
+                 "Loop detected: tool read_file called 2 times with identical args")))
+         (result (ellama-eval--build-result state 'completed))
+         (loop-detection (plist-get result :loop-detection)))
+    (unwind-protect
+        (progn
+          (should (eq (plist-get result :status) 'passed))
+          (should (plist-get result :success))
+          (should-not (plist-get loop-detection :loop-detected))
+          (should (plist-get loop-detection :loop-recovery-attempted))
+          (should (= (plist-get loop-detection :loop-recovery-count) 1))
+          (should (plist-get loop-detection :loop-recovered))
+          (should (plist-get (car (plist-get result :tool-trace))
+                             :loop-recovery)))
       (when (file-directory-p workspace)
         (delete-directory workspace t)))))
 

--- a/tests/test-ellama-eval.el
+++ b/tests/test-ellama-eval.el
@@ -380,6 +380,51 @@
       (when (file-directory-p workspace)
         (delete-directory workspace t)))))
 
+(ert-deftest test-ellama-eval-timeout-run-cancels-worker-request-context ()
+  (let* ((workspace (make-temp-file "ellama-eval-timeout-" t))
+         (worker-buffer (generate-new-buffer " *ellama-eval-worker*"))
+         (worker (make-ellama-session
+                  :id "eval-worker"
+                  :extra '(:task-completed nil :step-count 0)))
+         cancelled-request
+         request-context
+         (state
+          (make-ellama-eval--run-state
+           :status 'pending
+           :trace nil
+           :started-at (float-time)
+           :workspace workspace
+           :worker worker
+           :case '(:id "timeout" :suite edit)
+           :profile 'baseline
+           :callback nil)))
+    (unwind-protect
+        (progn
+          (with-current-buffer worker-buffer
+            (setq request-context
+                  (ellama--set-current-request
+                   'worker-request
+                   (list worker-buffer))))
+          (ellama--set-session-request-context worker request-context)
+          (cl-letf (((symbol-function 'ellama-tools--subagent-buffer)
+                     (lambda (&rest _args) nil))
+                    ((symbol-function 'llm-cancel-request)
+                     (lambda (request)
+                       (setq cancelled-request request))))
+            (ellama-eval--timeout-run state)
+            (should (eq cancelled-request 'worker-request))
+            (should (plist-get (ellama-session-extra worker)
+                               :task-completed))
+            (should-not (plist-get (ellama-session-extra worker)
+                                   :current-request-context))
+            (with-current-buffer worker-buffer
+              (should-not ellama--current-request)
+              (should-not ellama-request-mode))))
+      (when (buffer-live-p worker-buffer)
+        (kill-buffer worker-buffer))
+      (when (file-directory-p workspace)
+        (delete-directory workspace t)))))
+
 (ert-deftest test-ellama-eval-summarize-results ()
   (let* ((results
           '((:suite edit :profile baseline :success t

--- a/tests/test-ellama-eval.el
+++ b/tests/test-ellama-eval.el
@@ -425,6 +425,23 @@
       (when (file-directory-p workspace)
         (delete-directory workspace t)))))
 
+(ert-deftest test-ellama-eval-run-at-time-uses-stable-buffer ()
+  (let (scheduled-buffer scheduled-time scheduled-function scheduled-args)
+    (cl-letf (((symbol-function 'run-at-time)
+               (lambda (time repeat function &rest args)
+                 (setq scheduled-buffer (current-buffer))
+                 (setq scheduled-time time)
+                 (setq scheduled-function function)
+                 (setq scheduled-args args)
+                 repeat)))
+      (ellama-eval--run-at-time 5 #'ignore 'arg)
+      (should (buffer-live-p scheduled-buffer))
+      (should (equal (buffer-name scheduled-buffer)
+                     ellama-eval--timer-buffer-name))
+      (should (= scheduled-time 5))
+      (should (eq scheduled-function #'ignore))
+      (should (equal scheduled-args '(arg))))))
+
 (ert-deftest test-ellama-eval-summarize-results ()
   (let* ((results
           '((:suite edit :profile baseline :success t
@@ -470,6 +487,26 @@
         (kill-buffer buffer))
       (when (buffer-live-p placeholder)
         (kill-buffer placeholder)))))
+
+(ert-deftest test-ellama-eval-render-summary-buffer-falls-back-on-window-error ()
+  (let ((displayed nil)
+        buffer)
+    (unwind-protect
+        (cl-letf (((symbol-function 'set-window-buffer)
+                   (lambda (&rest _)
+                     (error "Selecting deleted buffer")))
+                  ((symbol-function 'display-buffer)
+                   (lambda (buf &rest _)
+                     (setq displayed buf)
+                     buf))
+                  ((symbol-function 'message)
+                   #'ignore))
+          (setq buffer
+                (ellama-eval--render-summary-buffer
+                 nil 0 1 nil (selected-window)))
+          (should (eq displayed buffer)))
+      (when (buffer-live-p buffer)
+        (kill-buffer buffer)))))
 
 (ert-deftest test-ellama-eval-write-results-jsonl-uses-arrays-and-booleans ()
   (let* ((file-name (make-temp-file "ellama-eval-results-" nil ".jsonl"))

--- a/tests/test-ellama-eval.el
+++ b/tests/test-ellama-eval.el
@@ -344,6 +344,42 @@
     (should-not (plist-get callback-result :success))
     (should-not (file-directory-p workspace))))
 
+(ert-deftest test-ellama-eval-timeout-run-cancels-worker-request ()
+  (let* ((workspace (make-temp-file "ellama-eval-timeout-" t))
+         (worker-buffer (generate-new-buffer " *ellama-eval-worker*"))
+         (worker (make-ellama-session
+                  :id "eval-worker"
+                  :extra '(:task-completed nil :step-count 0)))
+         cancel-buffer
+         canceled
+         (state
+          (make-ellama-eval--run-state
+           :status 'pending
+           :trace nil
+           :started-at (float-time)
+           :workspace workspace
+           :worker worker
+           :case '(:id "timeout" :suite edit)
+           :profile 'baseline
+           :callback nil)))
+    (unwind-protect
+        (cl-letf (((symbol-function 'ellama-tools--subagent-buffer)
+                   (lambda (session &optional _buffer)
+                     (and (eq session worker) worker-buffer)))
+                  ((symbol-function 'ellama--cancel-current-request)
+                   (lambda (&optional _append-user-header)
+                     (setq canceled t
+                           cancel-buffer (current-buffer)))))
+          (ellama-eval--timeout-run state)
+          (should canceled)
+          (should (eq cancel-buffer worker-buffer))
+          (should (plist-get (ellama-session-extra worker)
+                             :task-completed)))
+      (when (buffer-live-p worker-buffer)
+        (kill-buffer worker-buffer))
+      (when (file-directory-p workspace)
+        (delete-directory workspace t)))))
+
 (ert-deftest test-ellama-eval-summarize-results ()
   (let* ((results
           '((:suite edit :profile baseline :success t
@@ -789,6 +825,54 @@
                                     :loop-reason
                                     "Loop detected: tool read_file called 3 times with identical args")))
     (should (= (plist-get callback-result :tool-call-count) 3))))
+
+(ert-deftest test-ellama-eval-loop-detection-cancels-worker-request ()
+  "Test that loop detection cancels the active worker request."
+  (let* ((ellama-eval--active-run nil)
+         (ellama-eval-loop-detection-enabled t)
+         (ellama-eval-loop-detection-repeated-threshold 3)
+         (ellama-eval-loop-detection-max-traces 50)
+         (workspace (make-temp-file "ellama-eval-loop-" t))
+         (worker-buffer (generate-new-buffer " *ellama-eval-worker*"))
+         (worker (make-ellama-session
+                  :id "eval-worker"
+                  :extra '(:task-completed nil :step-count 0)))
+         cancel-buffer
+         canceled
+         (state
+          (make-ellama-eval--run-state
+           :status 'pending
+           :trace nil
+           :edit-validation-trace nil
+           :started-at (float-time)
+           :workspace workspace
+           :worker worker
+           :case '(:id "test" :suite edit)
+           :profile 'baseline
+           :callback nil
+           :loop-state
+           (list :tool-history nil :loop-detected nil :loop-reason ""))))
+    (unwind-protect
+        (cl-letf (((symbol-function 'ellama-tools--subagent-buffer)
+                   (lambda (session &optional _buffer)
+                     (and (eq session worker) worker-buffer)))
+                  ((symbol-function 'ellama--cancel-current-request)
+                   (lambda (&optional _append-user-header)
+                     (setq canceled t
+                           cancel-buffer (current-buffer)))))
+          (setq ellama-eval--active-run state)
+          (let ((identical-args '(:path "/test.el")))
+            (dotimes (_ 3)
+              (ellama-eval--trace-tool-call
+               "read_file" identical-args 'ok "content")))
+          (should canceled)
+          (should (eq cancel-buffer worker-buffer))
+          (should (plist-get (ellama-session-extra worker)
+                             :task-completed)))
+      (when (buffer-live-p worker-buffer)
+        (kill-buffer worker-buffer))
+      (when (file-directory-p workspace)
+        (delete-directory workspace t)))))
 
 (provide 'test-ellama-eval)
 

--- a/tests/test-ellama-eval.el
+++ b/tests/test-ellama-eval.el
@@ -703,7 +703,7 @@
        'ok "result"))
     (let ((history (plist-get (ellama-eval--run-state-loop-state state) :tool-history)))
       (should (= (length history) 5))
-      (should (eq (plist-get (car history) :name) "grep")))))
+      (should (equal (plist-get (car history) :name) "grep")))))
 
 (ert-deftest test-ellama-eval-loop-detection-no-active-run ()
   "Test that loop detection gracefully handles missing active run."

--- a/tests/test-ellama-eval.el
+++ b/tests/test-ellama-eval.el
@@ -587,16 +587,13 @@
       (should (eq read-provider 'base-provider))
       (should (eq constructed-provider 'base-provider)))))
 
-(provide 'test-ellama-eval)
-
-;;; test-ellama-eval.el ends here
-
 (ert-deftest test-ellama-eval-loop-detection-identical-calls ()
   "Test that identical tool calls trigger loop detection."
   (let ((ellama-eval--active-run nil)
         (ellama-eval-loop-detection-enabled t)
         (ellama-eval-loop-detection-repeated-threshold 3)
         (ellama-eval-loop-detection-max-traces 50)
+        (workspace (make-temp-file "ellama-eval-loop-" t))
         state)
     ;; Create a run state with loop detection enabled
     (setq state
@@ -605,7 +602,7 @@
            :trace nil
            :edit-validation-trace nil
            :started-at (float-time)
-           :workspace "/tmp"
+           :workspace workspace
            :case '(:id "test")
            :profile 'baseline
            :callback nil
@@ -614,9 +611,11 @@
     (setq ellama-eval--active-run state)
     ;; Simulate 3 identical tool calls
     (let ((identical-args '(:path "/test.el")))
-      (dotimes (i 3)
+      (dotimes (_ 3)
         (ellama-eval--trace-tool-call "read_file" identical-args 'ok "content"))
       (should (eq (ellama-eval--run-state-status state) 'loop-detected))
+      (should (plist-get (ellama-eval--run-state-loop-state state)
+                         :loop-detected))
       (should (string-match-p "Loop detected: tool read_file called"
                               (plist-get (ellama-eval--run-state-loop-state state) :loop-reason))))))
 
@@ -626,6 +625,7 @@
         (ellama-eval-loop-detection-enabled t)
         (ellama-eval-loop-detection-repeated-threshold 3)
         (ellama-eval-loop-detection-max-traces 50)
+        (workspace (make-temp-file "ellama-eval-loop-" t))
         state)
     (setq state
           (make-ellama-eval--run-state
@@ -633,7 +633,7 @@
            :trace nil
            :edit-validation-trace nil
            :started-at (float-time)
-           :workspace "/tmp"
+           :workspace workspace
            :case '(:id "test")
            :profile 'baseline
            :callback nil
@@ -671,7 +671,7 @@
     (setq ellama-eval--active-run state)
     ;; Simulate 5 identical calls (should NOT trigger since disabled)
     (let ((identical-args '(:path "/test.el")))
-      (dotimes (i 5)
+      (dotimes (_ 5)
         (ellama-eval--trace-tool-call "read_file" identical-args 'ok "content"))
       (should-not (eq (ellama-eval--run-state-status state) 'loop-detected)))))
 
@@ -724,6 +724,8 @@
         (ellama-eval-loop-detection-enabled t)
         (ellama-eval-loop-detection-repeated-threshold 3)
         (ellama-eval-loop-detection-max-traces 50)
+        (workspace (make-temp-file "ellama-eval-loop-" t))
+        callback-result
         state)
     (setq state
           (make-ellama-eval--run-state
@@ -731,22 +733,63 @@
            :trace nil
            :edit-validation-trace nil
            :started-at (float-time)
-           :workspace "/tmp"
+           :workspace workspace
            :case '(:id "test")
            :profile 'baseline
-           :callback nil
+           :callback (lambda (result)
+                       (setq callback-result result))
            :loop-state
            (list :tool-history nil :loop-detected nil :loop-reason "")))
     (setq ellama-eval--active-run state)
     ;; Make 3 identical calls (triggers loop detection)
     (let ((identical-args '(:path "/test.el")))
-      (dotimes (i 3)
+      (dotimes (_ 3)
         (ellama-eval--trace-tool-call "read_file" identical-args 'ok "content")))
-    ;; Verify trace still has all calls
-    (let ((trace (ellama-eval--run-state-trace state)))
+    ;; Verify the final public result still has all calls.
+    (let ((trace (plist-get callback-result :tool-trace)))
       (should (= (length trace) 3))
       (should (seq-every-p (lambda (entry)
                              (eq (plist-get entry :status) 'ok))
                            trace)))))
 
+(ert-deftest test-ellama-eval-loop-detection-finalizes-run ()
+  "Test that loop detection finalizes the eval run and calls the callback."
+  (let* ((ellama-eval--active-run nil)
+         (ellama-eval-loop-detection-enabled t)
+         (ellama-eval-loop-detection-repeated-threshold 3)
+         (ellama-eval-loop-detection-max-traces 50)
+         (workspace (make-temp-file "ellama-eval-loop-" t))
+         callback-result
+         (state
+          (make-ellama-eval--run-state
+           :status 'pending
+           :trace nil
+           :edit-validation-trace nil
+           :started-at (float-time)
+           :workspace workspace
+           :case '(:id "test" :suite edit)
+           :profile 'baseline
+           :callback (lambda (result)
+                       (setq callback-result result))
+           :loop-state
+           (list :tool-history nil :loop-detected nil :loop-reason ""))))
+    (setq ellama-eval--active-run state)
+    (let ((identical-args '(:path "/test.el")))
+      (dotimes (_ 3)
+        (ellama-eval--trace-tool-call
+         "read_file" identical-args 'ok "content")))
+    (should (null ellama-eval--active-run))
+    (should-not (file-directory-p workspace))
+    (should (eq (plist-get callback-result :status) 'loop-detected))
+    (should-not (plist-get callback-result :success))
+    (should (equal (plist-get callback-result :report-result)
+                   "Loop detected: tool read_file called 3 times with identical args"))
+    (should (equal (plist-get callback-result :loop-detection)
+                   '(:loop-detected t
+                                    :loop-reason
+                                    "Loop detected: tool read_file called 3 times with identical args")))
+    (should (= (plist-get callback-result :tool-call-count) 3))))
+
 (provide 'test-ellama-eval)
+
+;;; test-ellama-eval.el ends here

--- a/tests/test-ellama-eval.el
+++ b/tests/test-ellama-eval.el
@@ -590,3 +590,163 @@
 (provide 'test-ellama-eval)
 
 ;;; test-ellama-eval.el ends here
+
+(ert-deftest test-ellama-eval-loop-detection-identical-calls ()
+  "Test that identical tool calls trigger loop detection."
+  (let ((ellama-eval--active-run nil)
+        (ellama-eval-loop-detection-enabled t)
+        (ellama-eval-loop-detection-repeated-threshold 3)
+        (ellama-eval-loop-detection-max-traces 50)
+        state)
+    ;; Create a run state with loop detection enabled
+    (setq state
+          (make-ellama-eval--run-state
+           :status 'pending
+           :trace nil
+           :edit-validation-trace nil
+           :started-at (float-time)
+           :workspace "/tmp"
+           :case '(:id "test")
+           :profile 'baseline
+           :callback nil
+           :loop-state
+           (list :tool-history nil :loop-detected nil :loop-reason "")))
+    (setq ellama-eval--active-run state)
+    ;; Simulate 3 identical tool calls
+    (let ((identical-args '(:path "/test.el")))
+      (dotimes (i 3)
+        (ellama-eval--trace-tool-call "read_file" identical-args 'ok "content"))
+      (should (eq (ellama-eval--run-state-status state) 'loop-detected))
+      (should (string-match-p "Loop detected: tool read_file called"
+                              (plist-get (ellama-eval--run-state-loop-state state) :loop-reason))))))
+
+(ert-deftest test-ellama-eval-loop-detection-different-args ()
+  "Test that different tool args don't trigger loop detection."
+  (let ((ellama-eval--active-run nil)
+        (ellama-eval-loop-detection-enabled t)
+        (ellama-eval-loop-detection-repeated-threshold 3)
+        (ellama-eval-loop-detection-max-traces 50)
+        state)
+    (setq state
+          (make-ellama-eval--run-state
+           :status 'pending
+           :trace nil
+           :edit-validation-trace nil
+           :started-at (float-time)
+           :workspace "/tmp"
+           :case '(:id "test")
+           :profile 'baseline
+           :callback nil
+           :loop-state
+           (list :tool-history nil :loop-detected nil :loop-reason "")))
+    (setq ellama-eval--active-run state)
+    ;; Simulate 3 calls with different args (should NOT trigger loop)
+    (dotimes (i 3)
+      (ellama-eval--trace-tool-call
+       "read_file"
+       (list :path (format "/test-%d.el" i))
+       'ok "content"))
+    (should-not (eq (ellama-eval--run-state-status state) 'loop-detected))
+    (should (string= "" (plist-get (ellama-eval--run-state-loop-state state) :loop-reason)))))
+
+(ert-deftest test-ellama-eval-loop-detection-disabled ()
+  "Test that loop detection can be disabled."
+  (let ((ellama-eval--active-run nil)
+        (ellama-eval-loop-detection-enabled nil)
+        (ellama-eval-loop-detection-repeated-threshold 3)
+        (ellama-eval-loop-detection-max-traces 50)
+        state)
+    (setq state
+          (make-ellama-eval--run-state
+           :status 'pending
+           :trace nil
+           :edit-validation-trace nil
+           :started-at (float-time)
+           :workspace "/tmp"
+           :case '(:id "test")
+           :profile 'baseline
+           :callback nil
+           :loop-state
+           (list :tool-history nil :loop-detected nil :loop-reason "")))
+    (setq ellama-eval--active-run state)
+    ;; Simulate 5 identical calls (should NOT trigger since disabled)
+    (let ((identical-args '(:path "/test.el")))
+      (dotimes (i 5)
+        (ellama-eval--trace-tool-call "read_file" identical-args 'ok "content"))
+      (should-not (eq (ellama-eval--run-state-status state) 'loop-detected)))))
+
+(ert-deftest test-ellama-eval-loop-detection-history-trimming ()
+  "Test that tool call history is trimmed at max-traces limit."
+  (let ((ellama-eval--active-run nil)
+        (ellama-eval-loop-detection-enabled t)
+        (ellama-eval-loop-detection-repeated-threshold 3)
+        (ellama-eval-loop-detection-max-traces 5)
+        state)
+    (setq state
+          (make-ellama-eval--run-state
+           :status 'pending
+           :trace nil
+           :edit-validation-trace nil
+           :started-at (float-time)
+           :workspace "/tmp"
+           :case '(:id "test")
+           :profile 'baseline
+           :callback nil
+           :loop-state
+           (list :tool-history nil :loop-detected nil :loop-reason "")))
+    (setq ellama-eval--active-run state)
+    ;; Make 10 tool calls with different args
+    (dotimes (i 10)
+      (ellama-eval--trace-tool-call
+       "grep"
+       (list :string (format "pattern-%d" i) :dir "/tmp")
+       'ok "result"))
+    (let ((history (plist-get (ellama-eval--run-state-loop-state state) :tool-history)))
+      (should (= (length history) 5))
+      (should (eq (plist-get (car history) :name) "grep")))))
+
+(ert-deftest test-ellama-eval-loop-detection-no-active-run ()
+  "Test that loop detection gracefully handles missing active run."
+  (let ((ellama-eval--active-run nil)
+        (ellama-eval-loop-detection-enabled t)
+        (ellama-eval-loop-detection-repeated-threshold 3))
+    ;; Should not signal an error when no active run exists
+    (should
+     (null
+      (ignore-errors
+        (ellama-eval--trace-tool-call
+         "read_file" '(:path "/test.el") 'ok "content")
+        nil)))))
+
+(ert-deftest test-ellama-eval-loop-detection-trace-recorded ()
+  "Test that tool calls are still traced even when loop detection is active."
+  (let ((ellama-eval--active-run nil)
+        (ellama-eval-loop-detection-enabled t)
+        (ellama-eval-loop-detection-repeated-threshold 3)
+        (ellama-eval-loop-detection-max-traces 50)
+        state)
+    (setq state
+          (make-ellama-eval--run-state
+           :status 'pending
+           :trace nil
+           :edit-validation-trace nil
+           :started-at (float-time)
+           :workspace "/tmp"
+           :case '(:id "test")
+           :profile 'baseline
+           :callback nil
+           :loop-state
+           (list :tool-history nil :loop-detected nil :loop-reason "")))
+    (setq ellama-eval--active-run state)
+    ;; Make 3 identical calls (triggers loop detection)
+    (let ((identical-args '(:path "/test.el")))
+      (dotimes (i 3)
+        (ellama-eval--trace-tool-call "read_file" identical-args 'ok "content")))
+    ;; Verify trace still has all calls
+    (let ((trace (ellama-eval--run-state-trace state)))
+      (should (= (length trace) 3))
+      (should (seq-every-p (lambda (entry)
+                             (eq (plist-get entry :status) 'ok))
+                           trace)))))
+
+(provide 'test-ellama-eval)

--- a/tests/test-ellama-eval.el
+++ b/tests/test-ellama-eval.el
@@ -456,6 +456,21 @@
       (when (buffer-live-p buffer)
         (kill-buffer buffer)))))
 
+(ert-deftest test-ellama-eval-render-summary-buffer-uses-target-window ()
+  (let ((placeholder (get-buffer-create " *ellama-eval-placeholder*"))
+        buffer)
+    (unwind-protect
+        (save-window-excursion
+          (set-window-buffer (selected-window) placeholder)
+          (setq buffer
+                (ellama-eval--render-summary-buffer
+                 nil 0 1 nil (selected-window)))
+          (should (eq (window-buffer (selected-window)) buffer)))
+      (when (buffer-live-p buffer)
+        (kill-buffer buffer))
+      (when (buffer-live-p placeholder)
+        (kill-buffer placeholder)))))
+
 (ert-deftest test-ellama-eval-write-results-jsonl-uses-arrays-and-booleans ()
   (let* ((file-name (make-temp-file "ellama-eval-results-" nil ".jsonl"))
          (results

--- a/tests/test-ellama-eval.el
+++ b/tests/test-ellama-eval.el
@@ -796,6 +796,50 @@
     (should-not (eq (ellama-eval--run-state-status state) 'loop-detected))
     (should (string= "" (plist-get (ellama-eval--run-state-loop-state state) :loop-reason)))))
 
+(ert-deftest test-ellama-eval-loop-detection-allows-later-repeat-after-progress ()
+  "Test that a later repeated read after progress gets recovery, not hard stop."
+  (let ((ellama-eval--active-run nil)
+        (ellama-eval-loop-detection-enabled t)
+        (ellama-eval-loop-detection-repeated-threshold 2)
+        (ellama-eval-loop-detection-max-traces 50)
+        (workspace (make-temp-file "ellama-eval-loop-" t))
+        state)
+    (setq state
+          (make-ellama-eval--run-state
+           :status 'pending
+           :trace nil
+           :edit-validation-trace nil
+           :started-at (float-time)
+           :workspace workspace
+           :case '(:id "test")
+           :profile 'baseline
+           :callback nil
+           :loop-state
+           (list :tool-history nil :loop-detected nil :loop-reason "")))
+    (setq ellama-eval--active-run state)
+    (let ((read-args '("sample.el" nil)))
+      (should-not
+       (ellama-eval--trace-tool-call "read_file" read-args 'ok "before"))
+      (should
+       (string-match-p
+        "LOOP RECOVERY"
+        (ellama-eval--trace-tool-call "read_file" read-args 'ok "before")))
+      (should-not
+       (ellama-eval--trace-tool-call
+        "edit_file" '("sample.el" "old" "new") 'ok "Edited sample.el."))
+      (should-not
+       (ellama-eval--trace-tool-call "read_file" read-args 'ok "after"))
+      (should
+       (string-match-p
+        "LOOP RECOVERY"
+        (ellama-eval--trace-tool-call "read_file" read-args 'ok "after")))
+      (should (eq (ellama-eval--run-state-status state) 'pending))
+      (should-not (plist-get (ellama-eval--run-state-loop-state state)
+                             :loop-detected))
+      (should (= (plist-get (ellama-eval--run-state-loop-state state)
+                            :loop-recovery-count)
+                 2)))))
+
 (ert-deftest test-ellama-eval-loop-detection-disabled ()
   "Test that loop detection can be disabled."
   (let ((ellama-eval--active-run nil)

--- a/tests/test-ellama-tools.el
+++ b/tests/test-ellama-tools.el
@@ -3159,6 +3159,86 @@ END_ELLAMA_AGENT_STATE"))
       (when (buffer-live-p worker-buffer)
         (kill-buffer worker-buffer)))))
 
+(ert-deftest test-ellama-subagent-tool-loop-detection-completes-on-hard-loop ()
+  (ellama-test--ensure-local-ellama-tools)
+  (let* ((callback-result nil)
+         (session
+          (make-ellama-session
+           :id "worker-loop-detection"
+           :extra (list :task-completed nil
+                        :result-callback
+                        (lambda (result)
+                          (setq callback-result result))
+                        :tool-loop-state
+                        (ellama-tools--subagent-loop-state))))
+         (tool-call-count 0)
+         (tool
+          (llm-make-tool
+           :name "read_file"
+           :function (lambda (&rest _args)
+                       (setq tool-call-count (1+ tool-call-count))
+                       "content")))
+         (wrapped (car (ellama-tools--wrap-subagent-tools
+                        (list tool) session)))
+         (function (llm-tool-function wrapped)))
+    (let ((ellama-tools-subagent-loop-detection-enabled t)
+          (ellama-tools-subagent-loop-detection-repeated-threshold 2))
+      (should (equal (funcall function "file.el" nil) "content"))
+      (should (string-match-p
+               "LOOP RECOVERY"
+               (funcall function "file.el" nil)))
+      (let ((hard-loop-result (funcall function "file.el" nil)))
+        (should (string-match-p
+                 "Loop detected: tool read_file called 3 times"
+                 hard-loop-result))
+        (should (equal callback-result hard-loop-result))
+        (should (plist-get (ellama-session-extra session) :task-completed))
+        (should (= tool-call-count 3))))))
+
+(ert-deftest test-ellama-subagent-tool-loop-detection-allows-repeat-after-progress ()
+  (ellama-test--ensure-local-ellama-tools)
+  (let* ((callback-result nil)
+         (session
+          (make-ellama-session
+           :id "worker-loop-recovery"
+           :extra (list :task-completed nil
+                        :result-callback
+                        (lambda (result)
+                          (setq callback-result result))
+                        :tool-loop-state
+                        (ellama-tools--subagent-loop-state))))
+         (read-tool
+          (llm-make-tool
+           :name "read_file"
+           :function (lambda (&rest _args) "content")))
+         (edit-tool
+          (llm-make-tool
+           :name "edit_file"
+           :function (lambda (&rest _args) "Edited file.el.")))
+         (wrapped-tools
+          (ellama-tools--wrap-subagent-tools
+           (list read-tool edit-tool) session))
+         (read-function (llm-tool-function (car wrapped-tools)))
+         (edit-function (llm-tool-function (cadr wrapped-tools))))
+    (let ((ellama-tools-subagent-loop-detection-enabled t)
+          (ellama-tools-subagent-loop-detection-repeated-threshold 2))
+      (should (equal (funcall read-function "file.el" nil) "content"))
+      (should (string-match-p
+               "LOOP RECOVERY"
+               (funcall read-function "file.el" nil)))
+      (should (equal (funcall edit-function "file.el" "old" "new")
+                     "Edited file.el."))
+      (should (equal (funcall read-function "file.el" nil) "content"))
+      (should (string-match-p
+               "LOOP RECOVERY"
+               (funcall read-function "file.el" nil)))
+      (should-not callback-result)
+      (should-not (plist-get (ellama-session-extra session) :task-completed))
+      (should (= (plist-get
+                  (plist-get (ellama-session-extra session) :tool-loop-state)
+                  :loop-recovery-count)
+                 2)))))
+
 (ert-deftest test-ellama-tools-task-tool-role-fallback-and-report-priority ()
   (ellama-test--ensure-local-ellama-tools)
   (let ((ellama--current-session-id "parent-1")
@@ -3227,8 +3307,11 @@ END_ELLAMA_AGENT_STATE"))
                    (llm-tool-name
                     (car (plist-get captured-extra :tools)))
                    "report_result"))
-          (should (eq (cadr (plist-get captured-extra :tools))
-                      role-tool))
+          (should (equal (llm-tool-name
+                          (cadr (plist-get captured-extra :tools)))
+                         "read_file"))
+          (should-not (eq (cadr (plist-get captured-extra :tools))
+                          role-tool))
           (with-current-buffer worker-buffer
             (should (string-match-p "Main agent:" (buffer-string)))
             (should (string-match-p "Do work" (buffer-string)))

--- a/tests/test-ellama.el
+++ b/tests/test-ellama.el
@@ -1888,6 +1888,106 @@ detailed comparison to help you decide:
         (funcall response-callback '(:text "Summary"))
         (should-not ellama-compaction-mode)))))
 
+(ert-deftest test-ellama-session-compact-request-is-cancellable ()
+  (let* ((provider (make-llm-fake))
+         (session (ellama-test--compact-session provider))
+         (prompt (ellama-session-prompt session))
+         (initial-interactions
+          (mapcar #'llm-chat-prompt-interaction-content
+                  (llm-chat-prompt-interactions prompt)))
+         (response-callback nil)
+         cancelled-request
+         (ellama-spinner-enabled nil)
+         (ellama-session-auto-compact-provider (make-llm-fake))
+         (ellama-session-auto-compact-keep-last-turns 2)
+         (ellama-session-auto-compact-show-message nil))
+    (cl-letf (((symbol-function 'llm-chat-async)
+               (lambda (_provider _summary-prompt callback
+                                  _error-callback &optional _multi-output)
+                 (setq response-callback callback)
+                 'compact-request))
+              ((symbol-function 'llm-cancel-request)
+               (lambda (request)
+                 (setq cancelled-request request))))
+      (with-temp-buffer
+        (should
+         (ellama--session-compact
+          session
+          :provider provider
+          :buffer (current-buffer)))
+        (should response-callback)
+        (should (eq ellama--current-request 'compact-request))
+        (should ellama-request-mode)
+        (should (ellama--session-extra-get
+                 session :auto-compact-in-progress))
+        (should (eq (ellama--session-extra-get
+                     session :auto-compact-request)
+                    'compact-request))
+        (ellama--cancel-current-request)
+        (should (eq cancelled-request 'compact-request))
+        (should-not ellama--current-request)
+        (should-not ellama-request-mode)
+        (should-not (ellama--session-extra-get
+                     session :auto-compact-in-progress))
+        (should-not (ellama--session-extra-get
+                     session :auto-compact-request))
+        (funcall response-callback '(:text "Late summary"))
+        (should
+         (equal
+          initial-interactions
+          (mapcar #'llm-chat-prompt-interaction-content
+                  (llm-chat-prompt-interactions prompt))))))))
+
+(ert-deftest test-ellama-response-handler-cancels-auto-compact-request ()
+  (let* ((provider (make-llm-fake))
+         (session (ellama-test--compact-session provider))
+         (compact-response-callback nil)
+         cancelled-request
+         done-text
+         request-context
+         (ellama-session-auto-compact-enabled t)
+         (ellama-session-auto-compact-token-threshold 100)
+         (ellama-session-auto-compact-provider (make-llm-fake))
+         (ellama-session-auto-compact-keep-last-turns 2)
+         (ellama-session-auto-compact-show-message nil)
+         (ellama-session-hide-org-quotes nil)
+         (ellama-spinner-enabled nil))
+    (cl-letf (((symbol-function 'llm-chat-async)
+               (lambda (_provider _summary-prompt response-callback
+                                  _error-callback &optional _multi-output)
+                 (setq compact-response-callback response-callback)
+                 'compact-request))
+              ((symbol-function 'llm-cancel-request)
+               (lambda (request)
+                 (setq cancelled-request request))))
+      (with-temp-buffer
+        (setq-local ellama--current-session session)
+        (setq-local ellama--change-group (prepare-change-group))
+        (activate-change-group ellama--change-group)
+        (setq request-context
+              (ellama--set-current-request
+               'main-request
+               (list (current-buffer))))
+        (funcall
+         (ellama--response-handler
+          #'ignore nil (current-buffer)
+          (lambda (text) (setq done-text text))
+          #'ignore provider (ellama-session-prompt session) t #'identity
+          request-context)
+         '(:text "answer" :input-tokens 90 :output-tokens 20))
+        (should compact-response-callback)
+        (should-not done-text)
+        (should (eq ellama--current-request 'compact-request))
+        (ellama--cancel-current-request)
+        (should (eq cancelled-request 'compact-request))
+        (should-not done-text)
+        (should-not ellama--current-request)
+        (should-not ellama-request-mode)
+        (should-not (ellama--session-extra-get
+                     session :auto-compact-in-progress))
+        (should-not (ellama--session-extra-get
+                     session :auto-compact-request))))))
+
 (ert-deftest test-ellama-chat-writes-to-session-buffer ()
   (let* ((provider (make-llm-fake
                     :chat-action-func (lambda () "Chat answer")))


### PR DESCRIPTION
## Summary

Detect repetitive tool call patterns that indicate agents are stuck in evaluation loops.

## Changes

### ellama-eval.el (4 additions)
1. **3 configurable defcustoms**:
   - `ellama-eval-loop-detection-enabled` (default: t) - toggle loop detection
   - `ellama-eval-loop-detection-repeated-threshold` (default: 3) - repeated calls threshold
   - `ellama-eval-loop-detection-max-traces` (default: 50) - history size limit

2. **Extended run-state struct** with `loop-state` plist containing:
   - `:tool-history` - recent tool call tracking
   - `:loop-detected` - boolean flag
   - `:loop-reason` - descriptive string

3. **Loop detection in `ellama-eval--trace-tool-call`**:
   - Tracks consecutive identical tool calls
   - Triggers on `threshold` identical calls
   - Sets status to `'loop-detected` with reason
   - Results include `:loop-detection` field when applicable
   - History trimmed to `max-traces` limit

4. **Run state initialization** - loop-state initialized when run starts

### tests/test-ellama-eval.el (6 new tests)
- `test-ellama-eval-loop-detection-identical-calls` - verifies loop triggers on identical args
- `test-ellama-eval-loop-detection-different-args` - verifies no false positives
- `test-ellama-eval-loop-detection-disabled` - verifies toggle works
- `test-ellama-eval-loop-detection-history-trimming` - verifies max-traces limit
- `test-ellama-eval-loop-detection-no-active-run` - verifies graceful handling
- `test-ellama-eval-loop-detection-trace-recorded` - verifies trace completeness

## Files Changed
- `ellama-eval.el`: 64 insertions(+), 3 deletions(-)
- `tests/test-ellama-eval.el`: 160 insertions(+)