### PR TITLE
Normalize stale TMPDIR in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,11 @@ SRT_PARITY_DOCKER_IMAGE ?= ellama-srt-parity:latest
 SRT_PARITY_DOCKERFILE ?= docker/srt-parity-linux.Dockerfile
 SRT_PARITY_DOCKER_RUN_FLAGS ?= --rm --privileged
 
+# Emacs uses TMPDIR while loading Org.  When a sandboxed caller inherits a
+# stale temporary directory, fall back to the system temp root for all recipes.
+override TMPDIR := $(or $(wildcard $(TMPDIR)),/tmp)
+export TMPDIR
+
 # This order is based on the packages dependency graph.
 ELLAMA_COMPILE_ORDER = \
 	ellama-tools-dlp.el \

--- a/NEWS.org
+++ b/NEWS.org
@@ -1,3 +1,10 @@
+* Version 1.27.2
+
+- Fixed ~make~ recipes when a sandboxed caller inherits a stale ~TMPDIR~.
+  Ellama now keeps valid temporary directories and falls back to ~/tmp~ only
+  when the inherited directory no longer exists, which prevents Org from failing
+  while loading during ~srt make check-elisp~.
+
 * Version 1.27.1
 
 - Added copyright notice to ~extract-commands.el~ script.

--- a/ellama.el
+++ b/ellama.el
@@ -6,7 +6,7 @@
 ;; URL: http://github.com/s-kostyaev/ellama
 ;; Keywords: help local tools
 ;; Package-Requires: ((emacs "28.1") (llm "0.30.2") (plz "0.8") (transient "0.7") (compat "29.1") (yaml "1.2.3"))
-;; Version: 1.27.1
+;; Version: 1.27.2
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;; Created: 8th Oct 2023
 


### PR DESCRIPTION
## Summary
- export a valid TMPDIR for make recipes when the inherited value points at a missing directory
- preserve existing valid TMPDIR values and fall back to /tmp only for stale values

## Verification
- srt make check-elisp