### PR TITLE
Add audio input support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Makefile for ellama project
 
-.PHONY: build test test-detailed test-integration test-srt-integration docker-build-srt-parity test-srt-integration-linux check-compile-warnings checkdocs manual format-elisp install-git-hooks refill-news refill-readme check-elisp check-readme check-news check-custom-variables check-commands
+.PHONY: build test test-detailed test-integration test-srt-integration docker-build-srt-parity test-srt-integration-linux check-compile-warnings checkdocs manual format-elisp install-git-hooks refill-news refill-readme check-elisp check-readme check-news check-custom-variables check-commands check-transient-dup-keys
 
 SRT_PARITY_DOCKER_IMAGE ?= ellama-srt-parity:latest
 SRT_PARITY_DOCKERFILE ?= docker/srt-parity-linux.Dockerfile
@@ -117,7 +117,7 @@ refill-news:
 refill-readme:
 	emacs -batch --eval $(subst FILE,./README.org,$(refill-org))
 
-check-elisp: format-elisp build test check-compile-warnings checkdocs
+check-elisp: format-elisp build test check-compile-warnings checkdocs check-transient-dup-keys
 
 check-readme: refill-readme manual check-custom-variables check-commands
 
@@ -128,3 +128,6 @@ check-custom-variables:
 
 check-commands:
 	./scripts/check-commands.sh
+
+check-transient-dup-keys:
+	./scripts/check-transient-dup-keys.sh

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Makefile for ellama project
 
-.PHONY: build test test-detailed test-integration test-srt-integration docker-build-srt-parity test-srt-integration-linux check-compile-warnings checkdocs manual format-elisp install-git-hooks refill-news refill-readme check-elisp check-readme check-news check-custom-variables check-commands check-transient-dup-keys
+.PHONY: build test test-detailed test-integration test-srt-integration docker-build-srt-parity test-srt-integration-linux check-compile-warnings checkdocs manual format-elisp install-git-hooks refill-news refill-readme check-elisp check-readme check-news check-custom-variables check-commands check-transient-dup-keys check-copyright
 
 SRT_PARITY_DOCKER_IMAGE ?= ellama-srt-parity:latest
 SRT_PARITY_DOCKERFILE ?= docker/srt-parity-linux.Dockerfile
@@ -117,7 +117,7 @@ refill-news:
 refill-readme:
 	emacs -batch --eval $(subst FILE,./README.org,$(refill-org))
 
-check-elisp: format-elisp build test check-compile-warnings checkdocs check-transient-dup-keys
+check-elisp: format-elisp build test check-compile-warnings checkdocs check-transient-dup-keys check-copyright
 
 check-readme: refill-readme manual check-custom-variables check-commands
 
@@ -131,3 +131,6 @@ check-commands:
 
 check-transient-dup-keys:
 	./scripts/check-transient-dup-keys.sh
+
+check-copyright:
+	./scripts/check-copyright.sh

--- a/NEWS.org
+++ b/NEWS.org
@@ -11,9 +11,6 @@
 - Recording normalization: default FFmpeg recordings are processed through a
   configurable dynamic audio normalization filter so quiet speech reaches audio
   models at a usable level.
-- Provider transport validation: detects broken OpenAI-compatible audio
-  serialization before sending requests, adding regression coverage for
-  multipart audio context and documenting the ~llm input_audio~ requirement.
 - Provider type selection: ~ellama-transient~ now supports selecting LLM
   provider types (Ollama, Claude, Gemini, etc.) via
   ~ellama-transient-provider-types~ and ~ellama-transient-set-provider-type~,

--- a/NEWS.org
+++ b/NEWS.org
@@ -1,3 +1,45 @@
+* Version 1.28.0
+
+- Audio input support: audio files can now be attached alongside images in
+  prompts, with provider capability validation. Includes transient entries, key
+  bindings, a recording lighter in the mode line, and microphone recording
+  commands. ~ellama-read-file~ can queue audio files for the next model turn,
+  exposing audio mode in customization and tool metadata.
+- Audio recording backends: on startup, auto-selects the available recorder by
+  platform — FFmpeg or SoX on macOS, arecord/FFmpeg/SoX on GNU/Linux. Fallback
+  failures include the recorder's output and a macOS microphone-permission hint.
+- Recording normalization: default FFmpeg recordings are processed through a
+  configurable dynamic audio normalization filter so quiet speech reaches audio
+  models at a usable level.
+- Provider transport validation: detects broken OpenAI-compatible audio
+  serialization before sending requests, adding regression coverage for
+  multipart audio context and documenting the ~llm input_audio~ requirement.
+- Provider type selection: ~ellama-transient~ now supports selecting LLM
+  provider types (Ollama, Claude, Gemini, etc.) via
+  ~ellama-transient-provider-types~ and ~ellama-transient-set-provider-type~,
+  with improved error handling during streamed responses.
+- Self-check step in plan-and-act: the workflow now appends an unstepped "Check
+  yourself" entry to the checklist, allowing manual review before the acting
+  phase.
+- Silent buffer revert after editing file: calls ~revert-buffer~ after
+  ~save-buffer~ to stop Emacs from asking whether to revert a file that was just
+  written.
+- File buffer refresh after shell commands: file-visiting buffers under the
+  shell command working directory are refreshed silently after command
+  completion, without prompting.
+- Non-interactive shell environment: ~shell_command~ sets ~TERM=dumb~ and
+  ~NO_COLOR=true~ for subprocesses, preserving pager normalization.
+- Improved truncated output hints: line-range reporting now shows accurate
+  output and source line counts, includes the configured line budget in
+  guidance, and keeps saved-output hints scoped to results without known
+  sources.
+- Line range edge cases: when the requested end exceeds the file length,
+  ~lines_range~ returns available lines with a warning instead of
+  failing. Ranges that start past EOF still error.
+- Documentation: README sections rewritten for clarity and brevity; audio input
+  commands and workflows documented in a dedicated section; ~ellama.info~
+  regenerated from the updated Org source.
+- Updated ~llm~ dependency from 0.30.2 to 0.31.1.
 * Version 1.27.2
 
 - Fixed ~make~ recipes when a sandboxed caller inherits a stale ~TMPDIR~.

--- a/README.org
+++ b/README.org
@@ -750,6 +750,12 @@ WebM.  Audio is sent as multipart media, the same transport used for image
 input.  Set ~ellama-audio-file-extensions~ if your provider accepts another
 format.
 
+Provider capability alone is not enough: the installed ~llm~ package must also
+serialize audio for that provider.  Gemini and Vertex use their native inline
+media format.  OpenAI-compatible Chat Completions requires ~input_audio~ support
+in ~llm~.  Ellama checks this before sending a request and rejects older ~llm~
+versions that would incorrectly encode audio as an image.
+
 Use ~M-x ellama-ask-audio~ for one audio file, or ~M-x ellama-chat-with-audio~
 inside a chat workflow.  For several files, use ~M-x ellama-chat-with-audios~.
 These commands add audio as ephemeral context for the next request, so the file

--- a/README.org
+++ b/README.org
@@ -780,6 +780,42 @@ device, or extra arguments.  On macOS, allow microphone access for Emacs in
 System Settings under Privacy & Security > Microphone.  If Emacs runs in a
 terminal, allow access for that terminal instead.
 
+*** macOS microphone permission
+
+Emacs may be missing from the Microphone list when its application bundle has no
+~NSMicrophoneUsageDescription~ entry.  This can happen with some ~emacs-plus~
+builds.  In that case macOS cannot display the permission prompt, and FFmpeg may
+exit with ~Abort trap: 6~ or report that no audio device was found.
+
+Quit Emacs, set ~APP~ to the installed application bundle, and check the entry:
+
+#+BEGIN_SRC shell
+  APP=/Applications/Emacs.app
+  plutil -extract NSMicrophoneUsageDescription raw \
+    "$APP/Contents/Info.plist"
+#+END_SRC
+
+If ~plutil~ reports that the key is missing, add it, re-sign the application,
+and reset the microphone permission:
+
+#+BEGIN_SRC shell
+  /usr/libexec/PlistBuddy \
+    -c 'Add :NSMicrophoneUsageDescription string Ellama records audio from the microphone.' \
+    "$APP/Contents/Info.plist"
+
+  codesign --force --deep --sign - "$APP"
+
+  BUNDLE_ID=$(plutil -extract CFBundleIdentifier raw \
+    "$APP/Contents/Info.plist")
+  tccutil reset Microphone "$BUNDLE_ID"
+  open "$APP"
+#+END_SRC
+
+Start a recording after Emacs opens.  macOS should now ask for microphone
+access, and Emacs should appear in System Settings under Privacy & Security >
+Microphone.  A package upgrade may replace the application bundle, so repeat
+these steps if the entry disappears after upgrading Emacs.
+
 For short messages, use ~M-x ellama-ask-audio-recording~ or ~M-x
 ellama-context-add-audio-recording~.  Ellama records for
 ~ellama-audio-recording-duration~ seconds and writes a temporary WAV file by

--- a/README.org
+++ b/README.org
@@ -17,15 +17,15 @@ Ellama is not tied to one backend.  It uses the
 local model, and the same Ellama commands can be configured for
 OpenAI-compatible APIs, OpenAI, Claude, Gemini, Vertex, GPT4All, LlamaCpp, and
 other llm providers.  When a provider supports extra capabilities, Ellama uses
-them: streaming responses, model lists, image input, tool calls, token limits,
-and interactive model switching.
+them: streaming responses, model lists, image and audio input, tool calls, token
+limits, and interactive model switching.
 
 Context is first-class.  A request can include buffers, files, directories, Info
-nodes, selections, and images.  Chat sessions can be saved, resumed, renamed,
-compacted manually, or compacted automatically before they run past the model
-context window.  The everyday commands cover translation, summarization,
-proofreading, code review and editing, extraction, formatting, commit-message
-generation, and provider selection.
+nodes, selections, images, and audio files.  Chat sessions can be saved,
+resumed, renamed, compacted manually, or compacted automatically before they run
+past the model context window.  The everyday commands cover translation,
+summarization, proofreading, code review and editing, extraction, formatting,
+commit-message generation, and provider selection.
 
 For tool-using agents, Ellama reads project instructions from ~AGENTS.md~, can
 load reusable skills and blueprint prompts, and runs plan-and-act loops or
@@ -164,6 +164,25 @@ More sophisticated configuration example:
 - ~ellama-chat-with-images~: Ask Ellama about multiple image files. If called
   with universal argument (~C-u~) will start new session with llm model
   interactive selection.
+- ~ellama-ask-audio~: Ask Ellama about one audio file by adding it as ephemeral
+  context for the request. If called with universal argument (~C-u~) will start
+  new session with llm model interactive selection.
+- ~ellama-chat-with-audio~: Ask Ellama about one audio file. If called with
+  universal argument (~C-u~) will start new session with llm model interactive
+  selection.
+- ~ellama-chat-with-audios~: Ask Ellama about multiple audio files. If called
+  with universal argument (~C-u~) will start new session with llm model
+  interactive selection.
+- ~ellama-ask-audio-recording~: Record a short audio message from the microphone
+  and ask Ellama about it.
+- ~ellama-chat-with-audio-recording~: Record a short audio message from the
+  microphone and send it to chat.
+- ~ellama-record-audio~: Record a short audio message from the microphone and
+  return the recorded file.
+- ~ellama-start-audio-recording~: Start microphone recording without a fixed
+  duration.
+- ~ellama-stop-audio-recording~: Stop microphone recording and return the
+  recorded file.
 - ~ellama-write~: This command allows you to generate text using an LLM. When
   called interactively, it prompts for an instruction that is then used to
   generate text based on the context. If a region is active, the selected text
@@ -231,6 +250,13 @@ More sophisticated configuration example:
 - ~ellama-session-compact~: Select and compact an active Ellama session context.
 - ~ellama-context-add-file~: Add file to context.
 - ~ellama-context-add-image~: Add image file to context.
+- ~ellama-context-add-audio~: Add audio file to context.
+- ~ellama-context-add-audio-recording~: Record a short audio message and add it
+  to context.
+- ~ellama-context-start-audio-recording~: Start microphone recording without a
+  fixed duration.
+- ~ellama-context-stop-audio-recording~: Stop microphone recording and add the
+  recorded file to context.
 - ~ellama-context-add-directory~: Add all files in directory to the context.
 - ~ellama-context-add-buffer~: Add buffer to context.
 - ~ellama-context-add-selection~: Add selected region to context.
@@ -290,47 +316,54 @@ will cancel current stream.
 Here is a table of keybindings and their associated functions in Ellama, using
 the ~ellama-keymap-prefix~ prefix (not set by default):
 
-| Keymap | Function                        | Description                  |
-|--------+---------------------------------+------------------------------|
-| "w"    | ellama-write                    | Write                        |
-| "c c"  | ellama-code-complete            | Code complete                |
-| "c a"  | ellama-code-add                 | Code add                     |
-| "c e"  | ellama-code-edit                | Code edit                    |
-| "c i"  | ellama-code-improve             | Code improve                 |
-| "c r"  | ellama-code-review              | Code review                  |
-| "c m"  | ellama-generate-commit-message  | Generate commit message      |
-| "s s"  | ellama-summarize                | Summarize                    |
-| "s w"  | ellama-summarize-webpage        | Summarize webpage            |
-| "s c"  | ellama-summarize-killring       | Summarize killring           |
-| "s l"  | ellama-load-session             | Session Load                 |
-| "s r"  | ellama-session-rename           | Session rename               |
-| "s d"  | ellama-session-delete           | Session delete               |
-| "s a"  | ellama-session-switch           | Session activate             |
-| "P"    | ellama-proofread                | Proofread                    |
-| "i w"  | ellama-improve-wording          | Improve wording              |
-| "i g"  | ellama-improve-grammar          | Improve grammar and spelling |
-| "i c"  | ellama-improve-conciseness      | Improve conciseness          |
-| "m l"  | ellama-make-list                | Make list                    |
-| "m t"  | ellama-make-table               | Make table                   |
-| "m f"  | ellama-make-format              | Make format                  |
-| "a a"  | ellama-ask-about                | Ask about                    |
-| "a i"  | ellama-chat                     | Chat (ask interactively)     |
-| "a I"  | ellama-ask-image                | Ask image                    |
-| "a l"  | ellama-ask-line                 | Ask current line             |
-| "a s"  | ellama-ask-selection            | Ask selection                |
-| "t t"  | ellama-translate                | Text translate               |
-| "t b"  | ellama-translate-buffer         | Translate buffer             |
-| "t e"  | ellama-chat-translation-enable  | Translation enable           |
-| "t d"  | ellama-chat-translation-disable | Translation disable          |
-| "t c"  | ellama-complete                 | Text complete                |
-| "d w"  | ellama-define-word              | Define word                  |
-| "x b"  | ellama-context-add-buffer       | Context add buffer           |
-| "x f"  | ellama-context-add-file         | Context add file             |
-| "x d"  | ellama-context-add-directory    | Context add directory        |
-| "x s"  | ellama-context-add-selection    | Context add selection        |
-| "x i"  | ellama-context-add-info-node    | Context add info node        |
-| "x r"  | ellama-context-reset            | Context reset                |
-| "p s"  | ellama-provider-select          | Provider select              |
+| Keymap | Function                             | Description                  |
+|--------+--------------------------------------+------------------------------|
+| "w"    | ellama-write                         | Write                        |
+| "c c"  | ellama-code-complete                 | Code complete                |
+| "c a"  | ellama-code-add                      | Code add                     |
+| "c e"  | ellama-code-edit                     | Code edit                    |
+| "c i"  | ellama-code-improve                  | Code improve                 |
+| "c r"  | ellama-code-review                   | Code review                  |
+| "c m"  | ellama-generate-commit-message       | Generate commit message      |
+| "s s"  | ellama-summarize                     | Summarize                    |
+| "s w"  | ellama-summarize-webpage             | Summarize webpage            |
+| "s c"  | ellama-summarize-killring            | Summarize killring           |
+| "s l"  | ellama-load-session                  | Session Load                 |
+| "s r"  | ellama-session-rename                | Session rename               |
+| "s d"  | ellama-session-delete                | Session delete               |
+| "s a"  | ellama-session-switch                | Session activate             |
+| "P"    | ellama-proofread                     | Proofread                    |
+| "i w"  | ellama-improve-wording               | Improve wording              |
+| "i g"  | ellama-improve-grammar               | Improve grammar and spelling |
+| "i c"  | ellama-improve-conciseness           | Improve conciseness          |
+| "m l"  | ellama-make-list                     | Make list                    |
+| "m t"  | ellama-make-table                    | Make table                   |
+| "m f"  | ellama-make-format                   | Make format                  |
+| "a a"  | ellama-ask-about                     | Ask about                    |
+| "a i"  | ellama-chat                          | Chat (ask interactively)     |
+| "a I"  | ellama-ask-image                     | Ask image                    |
+| "a A"  | ellama-ask-audio                     | Ask audio                    |
+| "a R"  | ellama-ask-audio-recording           | Record audio and ask         |
+| "a l"  | ellama-ask-line                      | Ask current line             |
+| "a s"  | ellama-ask-selection                 | Ask selection                |
+| "t t"  | ellama-translate                     | Text translate               |
+| "t b"  | ellama-translate-buffer              | Translate buffer             |
+| "t e"  | ellama-chat-translation-enable       | Translation enable           |
+| "t d"  | ellama-chat-translation-disable      | Translation disable          |
+| "t c"  | ellama-complete                      | Text complete                |
+| "d w"  | ellama-define-word                   | Define word                  |
+| "x b"  | ellama-context-add-buffer            | Context add buffer           |
+| "x f"  | ellama-context-add-file              | Context add file             |
+| "x d"  | ellama-context-add-directory         | Context add directory        |
+| "x I"  | ellama-context-add-image             | Context add image            |
+| "x A"  | ellama-context-add-audio             | Context add audio            |
+| "x R"  | ellama-context-add-audio-recording   | Context record audio         |
+| "x S"  | ellama-context-start-audio-recording | Start audio recording        |
+| "x E"  | ellama-context-stop-audio-recording  | Stop audio recording         |
+| "x s"  | ellama-context-add-selection         | Context add selection        |
+| "x i"  | ellama-context-add-info-node         | Context add info node        |
+| "x r"  | ellama-context-reset                 | Context reset                |
+| "p s"  | ellama-provider-select               | Provider select              |
 
 * Configuration
 
@@ -708,6 +741,59 @@ Tool calls can request image handling explicitly:
   "mode": "image"
 }
 #+END_SRC
+
+** Audio Input
+
+Ellama can also send audio files to providers with the ~audio-input~ capability.
+The default supported extensions are WAV, MP3, M4A, AAC, FLAC, OGG, Opus and
+WebM.  Audio is sent as multipart media, the same transport used for image
+input.  Set ~ellama-audio-file-extensions~ if your provider accepts another
+format.
+
+Use ~M-x ellama-ask-audio~ for one audio file, or ~M-x ellama-chat-with-audio~
+inside a chat workflow.  For several files, use ~M-x ellama-chat-with-audios~.
+These commands add audio as ephemeral context for the next request, so the file
+is not kept around unless you add it as persistent context yourself.
+
+Programmatic calls can pass audio directly:
+
+#+BEGIN_SRC emacs-lisp
+  (ellama-chat "Transcribe this note." nil
+               :audios '("/path/to/note.wav"))
+
+  (ellama-stream "Summarize the meeting."
+                 :audio "/path/to/meeting.mp3")
+#+END_SRC
+
+Use ~:media~ when a request mixes images and audio:
+
+#+BEGIN_SRC emacs-lisp
+  (ellama-chat "Compare the screenshot with the spoken notes." nil
+               :media '("/path/to/screenshot.png"
+                        "/path/to/notes.wav"))
+#+END_SRC
+
+Microphone recording is available when the platform has a recording command. On
+macOS Ellama uses ~afrecord~. On GNU/Linux it uses ~arecord~. Set
+~ellama-audio-recording-command~ if you need another program or extra arguments.
+
+For short messages, use ~M-x ellama-ask-audio-recording~ or ~M-x
+ellama-context-add-audio-recording~.  Ellama records for
+~ellama-audio-recording-duration~ seconds and writes a temporary WAV file by
+default.  Set ~ellama-audio-recording-file-extension~ if your recorder writes
+another format.
+
+For longer messages, start and stop recording yourself:
+
+#+BEGIN_SRC text
+M-x ellama-context-start-audio-recording
+...speak for as long as needed...
+M-x ellama-context-stop-audio-recording
+#+END_SRC
+
+While recording is active, the mode line shows ~ellama:recording~.  Stopping the
+recording adds the file to context, using ~ellama-audio-context-default-scope~
+to decide whether it is ephemeral or persistent.
 
 ** Task Tool Subagents
 
@@ -1405,6 +1491,8 @@ Context Commands:
     - “d” "Add Directory" ~ellama-transient-add-directory~
     - “f” "Add File" ~ellama-transient-add-file~
     - “I” "Add Image" ~ellama-transient-add-image~
+    - “A” "Add Audio" ~ellama-transient-add-audio~
+    - “R” "Record Audio" ~ellama-transient-add-audio-recording~
     - “s” "Add Selection" ~ellama-transient-add-selection~
     - “i” "Add Info Node" ~ellama-transient-add-info-node~
 - Manage: Provides options for managing the global context.
@@ -1414,6 +1502,9 @@ Context Commands:
       element by name.
     - “r” "Context reset" ~ellama-context-reset~ - Clears the entire global
       context.
+- Recording: Provides start and stop commands for long microphone recordings.
+    - “S” "Start Recording" ~ellama-transient-start-audio-recording~
+    - “E” "Stop Recording" ~ellama-transient-stop-audio-recording~
 - Quit: (“q” "Quit" ~transient-quit-one~) - Closes the context commands
   transient menu.
 

--- a/README.org
+++ b/README.org
@@ -215,12 +215,14 @@ More sophisticated configuration example:
   Ellama.
 - ~ellama-provider-select~: Select ellama provider.
 - ~ellama-select-model~: Change the current provider model interactively.  The
-  model transient supports Ollama, OpenAI-compatible providers, and providers
-  with a ~chat-model~ slot.  URL editing is available when the provider has a
-  ~url~ slot.  It can also set the maximum number of output tokens.  Use "Reset
-  model fields" to clear model, temperature, context-length, and max-token
-  overrides and let the provider use its defaults; reset values are shown as
-  ~default~ in the transient.
+  model transient can switch the provider type as well as the model.  Built-in
+  choices include Ollama, OpenAI-compatible, OpenAI, Claude, Gemini, DeepSeek,
+  OpenRouter, Azure OpenAI, GitHub Models, Vertex AI, GPT4All, and Llama.cpp.
+  It also supports providers with a ~chat-model~ slot.  URL editing is available
+  when the provider has a ~url~ slot.  It can also set the maximum number of
+  output tokens.  Use "Reset model fields" to clear model, temperature,
+  context-length, and max-token overrides and let the provider use its defaults;
+  reset values are shown as ~default~ in the transient.
 - ~ellama-code-complete~: Complete selected code or code in the current buffer
   according to a provided change using Ellama.
 - ~ellama-code-add~: Generate and insert new code based on description. This
@@ -503,6 +505,9 @@ generated text string.
   command execution.
 - ~ellama-transient-system-show-limit~: Maximum number of system elements to
   show in transient.
+- ~ellama-transient-provider-types~: Provider types available for interactive
+  switching in the model transient. Each entry specifies the provider record
+  type, display label, library, and constructor.
 - ~ellama-session-remove-reasoning~: Remove internal reasoning from the session
   after ellama provide an answer. This can improve long-term communication with
   reasoning models. Enabled by default.

--- a/README.org
+++ b/README.org
@@ -776,7 +776,9 @@ Use ~:media~ when a request mixes images and audio:
 Ellama selects an installed microphone recorder automatically.  On macOS it
 tries FFmpeg and then SoX.  On GNU/Linux it tries ~arecord~, FFmpeg, and then
 SoX.  Set ~ellama-audio-recording-command~ if you need another program, input
-device, or extra arguments.
+device, or extra arguments.  On macOS, allow microphone access for Emacs in
+System Settings under Privacy & Security > Microphone.  If Emacs runs in a
+terminal, allow access for that terminal instead.
 
 For short messages, use ~M-x ellama-ask-audio-recording~ or ~M-x
 ellama-context-add-audio-recording~.  Ellama records for

--- a/README.org
+++ b/README.org
@@ -1589,233 +1589,127 @@ where you can view, modify, and organize the global context. Within this buffer:
 
 ** Considerations
 
-Large Language Models possess limited context window sizes, restricting the
-total amount of text they can process. Be mindful of the size of your context to
-avoid truncation or performance degradation. Irrelevant context can dilute the
-information and hinder the LLM’s focus. Ensure context remains up-to-date for
-accurate information. Experimentation with different approaches to context
-management can optimize performance for specific use cases.
+Keep context size in check. LLMs have finite context windows, and irrelevant
+information wastes tokens and can distract the model. Remove or refresh stale
+context before switching tasks.
 
 * Minor modes
 
-The Ellama package for Emacs offers a suite of minor modes designed to enhance
-the user experience by providing context-specific information directly within
-the editor's interface. These minor modes focus on updating both the header line
-and mode line with relevant details, making it easier to manage and navigate
-multiple sessions and buffers.
-
-Key features include:
-
-- Context Header Line Modes: ~ellama-context-header-line-mode~ and its global
-  counterpart, ~ellama-context-header-line-global-mode~, update the header line
-  to display what elements are added to the global Ellama context. This is
-  particularly useful for keeping track of what information is currently in
-  context.
-- Context Mode Line Modes: Similarly, ~ellama-context-mode-line-mode~ and
-  ~ellama-context-mode-line-global-mode~ provide information about the current
-  global context directly within the mode line, ensuring that users always have
-  relevant information at a glance.
-- Session Header Line Mode: ~ellama-session-header-line-mode~ and its global
-  version display the current Ellama session ID in the header line, helping
-  users manage multiple sessions efficiently.
-- Session Mode Line Mode: ~ellama-session-mode-line-mode~ and its global
-  counterpart offer an additional way to track session IDs by displaying them in
-  the mode line.
-
-These minor modes are easily toggled on or off using specific commands,
-providing flexibility for users who may want to enable these features globally
-across all buffers or selectively within individual buffers.
+These minor modes show the current context or session ID in the header line or
+mode line. Each has a buffer-local command and a global variant.
 
 ** ellama-context-header-line-mode
 
-Description: Toggle the Ellama Context header line mode. This minor mode updates
-the header line to display context-specific information.
+Shows the Ellama context in the header line. By default, the line appears only
+when the global or ephemeral context is not empty. Set
+~ellama-context-line-always-visible~ to keep it visible.
 
-Usage: To enable or disable ~ellama-context-header-line-mode~, use the command:
+~M-x ellama-context-header-line-mode~ toggles this mode.
 
-    M-x ellama-context-header-line-mode
-
-When enabled, this mode adds a hook to ~window-state-change-hook~ to update the
-header line whenever the window state changes. It also calls
-~ellama-context-update-header-line~ to initialize the header line with
-context-specific information.
-
-When disabled, it removes the evaluation of ~(:eval (ellama-context-line))~ from
-~header-line-format~.
+The mode updates the display on ~window-state-change-hook~. When disabled, it
+removes ~(:eval (ellama-context-line))~ from ~header-line-format~.
 
 ** ellama-context-header-line-global-mode
 
-Description: Globalized version of ~ellama-context-header-line-mode~. This mode
-ensures that ~ellama-context-header-line-mode~ is enabled in all buffers.
+Enables ~ellama-context-header-line-mode~ in all buffers automatically.
 
-Usage: To enable or disable ~ellama-context-header-line-global-mode~, use the
-command:
-
-    M-x ellama-context-header-line-global-mode
-
-This globalized minor mode provides a convenient way to ensure that
-context-specific header line information is always available, regardless of the
-buffer being edited.
+~M-x ellama-context-header-line-global-mode~ toggles this global mode.
 
 ** ellama-context-mode-line-mode
 
-Description: Toggle the Ellama Context mode line mode. This minor mode updates
-the mode line to display context-specific information.
+Shows the Ellama context in the mode line. It follows the same visibility rules
+as ~ellama-context-header-line-mode~.
 
-Usage: To enable or disable ~ellama-context-mode-line-mode~, use the command:
+~M-x ellama-context-mode-line-mode~ toggles this mode.
 
-    M-x ellama-context-mode-line-mode
-
-When enabled, this mode adds a hook to ~window-state-change-hook~ to update the
-mode line whenever the window state changes. It also calls
-~ellama-context-update-mode-line~ to initialize the mode line with
-context-specific information.
-
-When disabled, it removes the evaluation of ~(:eval (ellama-context-line))~ from
-~mode-line-format~.
+The mode updates the display on ~window-state-change-hook~. When disabled, it
+removes ~(:eval (ellama-context-line))~ from ~mode-line-format~.
 
 ** ellama-context-mode-line-global-mode
 
-Description: Globalized version of ~ellama-context-mode-line-mode~. This mode
-ensures that ~ellama-context-mode-line-mode~ is enabled in all buffers.
+Enables ~ellama-context-mode-line-mode~ in all buffers automatically.
 
-Usage: To enable or disable ~ellama-context-mode-line-global-mode~, use the
-command:
+~M-x ellama-context-mode-line-global-mode~ toggles this global mode.
 
-    M-x ellama-context-mode-line-global-mode
+** ellama-session-header-line-mode
 
-This globalized minor mode provides a convenient way to ensure that
-context-specific mode line information is always available, regardless of the
-buffer being edited.
+Displays the current Ellama session ID in the header line.
 
-** Ellama Session Header Line Mode
+~M-x ellama-session-header-line-mode~ toggles it in the current buffer; ~M-x
+ellama-session-header-line-global-mode~ toggles it globally.
 
-The ~ellama-session-header-line-mode~ is a minor mode that allows you to display
-the current Ellama session ID in the header line of your Emacs buffers. This
-feature helps keep track of which session you are working with, especially
-useful when managing multiple sessions.
+The session ID uses the customizable ~ellama-face~ face.
 
-*** Enabling and Disabling
+** ellama-session-mode-line-mode
 
-To enable this mode, use the following command:
-#+BEGIN_SRC emacs-lisp
-M-x ellama-session-header-line-mode
-#+END_SRC
+Displays the current Ellama session ID in the mode line.
 
-This will toggle the display of the session ID in the header line. You can also
-enable or disable it globally across all buffers using:
-#+BEGIN_SRC emacs-lisp
-M-x ellama-session-header-line-global-mode
-#+END_SRC
+~M-x ellama-session-mode-line-mode~ toggles it in the current buffer; ~M-x
+ellama-session-mode-line-global-mode~ toggles it globally. This mode also uses
+~ellama-face~.
 
-*** Customization
-
-The session ID is displayed with a customizable face called ~ellama-face~. You
-can customize this face to change its appearance.
-
-** Ellama Session Mode Line Mode
-
-The ~ellama-session-mode-line-mode~ is a minor mode that allows you to display
-the current Ellama session ID in the mode line of your Emacs buffers. This
-feature provides an additional way to keep track of which session you are
-working with, especially useful when managing multiple sessions.
-
-*** Enabling and Disabling
-
-To enable this mode, use the following command:
-#+BEGIN_SRC emacs-lisp
-M-x ellama-session-mode-line-mode
-#+END_SRC
-
-This will toggle the display of the session ID in the mode line. You can also
-enable or disable it globally across all buffers using:
-#+BEGIN_SRC emacs-lisp
-M-x ellama-session-mode-line-global-mode
-#+END_SRC
-
-*** Customization
-
-The session ID is displayed with a customizable face called ~ellama-face~. You
-can customize this face to change its appearance.
 
 * Using Blueprints
 
-Blueprints in Ellama refer to predefined templates or structures that facilitate
-the creation and management of chat sessions. These blueprints are designed to
-streamline the process of generating consistent and high-quality outputs by
-providing a structured framework for interactions.
+Blueprints are predefined templates for starting chat sessions with a reusable
+prompt.
 
-** Key Components of Ellama Blueprints
+** Key Components
 
-1. Act: This is the primary identifier for a blueprint, representing the
-action or purpose of the blueprint.
-2. Prompt: The content that will be used to initiate the chat session. This
-can include instructions, context, or any other relevant information needed to
-guide the conversation.
-3. For Developers: A flag indicating whether the blueprint is intended for
-developers.
+1.  Act: The blueprint's primary identifier (its name).
+2.  Prompt: Text that initializes the chat session, including instructions and
+   context.
+3.  For Developers: A flag marking the blueprint as developer-facing.
 
-** Creating and Managing Blueprints
+** Creating and Managing
 
-Ellama provides several functions to create, select, and manage blueprints:
+- ~ellama-blueprint-create~: Create a blueprint from the current buffer.
+  Prompts for a name and developer flag, then saves the buffer content as the
+  prompt.
+- ~ellama-blueprint-new~: Create a new buffer for a blueprint, optionally
+  inserting the current region if active.
+- ~ellama-blueprint-select~: Select a prompt and optionally filter by developer
+  status or source (user, community, files, or all sources).
 
-- ~ellama-blueprint-create~: This function allows users to create a new
-  blueprint from the current buffer. It prompts for a name and whether the
-  blueprint is for developers, then saves the content of the current buffer as
-  the prompt.
+** Blueprint Files
 
-- ~ellama-blueprint-new~: This function creates a new buffer for a blueprint,
-  optionally inserting the content of the current region if active.
+Store blueprints as plain text files. Place them in:
 
-- ~ellama-blueprint-select~: This function allows users to select a prompt from
-  the collection of blueprints. It filters prompts based on whether they are for
-  developers and their source (user-defined, community, or all).
+- Global: ~ellama-blueprint-global-dir~
+- Project-local: ~ellama-blueprint-local-dir~, relative to the project root
 
-** Blueprints files
+Files use extensions from ~ellama-blueprint-file-extensions~.
 
-You can also store blueprints as plain text files. You can store it globally
-inside ~ellama-blueprint-global-dir~ or locally in the project local directory
-~ellama-blueprint-local-dir~ with ~ellama-blueprint-file-extensions~.
+** Variables
 
-** Variable Management
+Blueprints can include variables that must be filled before the session runs.
 
-Blueprints can include variables that need to be filled before running the chat
-session. Ellama provides command to fill these variables:
-
-- ~ellama-blueprint-fill-variables~: Prompts the user to enter values for
-  variables found in the current buffer and fills them.
+- ~ellama-blueprint-fill-variables~: Prompts for values for all variables found
+  in the current buffer.
 
 ** Keymap and Mode
 
-Ellama provides a local keymap ~ellama-blueprint-mode-map~ for managing
-blueprints within buffers. The mode includes key bindings for sending the buffer
-to a new chat session, killing the current buffer, creating a new blueprint, and
-filling variables.
+~ellama-blueprint-mode~ is a text-mode derivative that highlights variables in
+curly braces and sets up local keybindings:
 
-The ~ellama-blueprint-mode~ is a derived mode from ~text-mode~, providing syntax
-highlighting for variables in curly braces and setting up the local keymap.
-
-When in ~ellama-blueprint-mode~, the following keybindings are available:
-
-- ~C-c C-c~: Send current buffer to a new chat session and kill the current
-  buffer.
+- ~C-c C-c~: Open ~ellama-transient-blueprint-mode-menu~. From there you can
+  send the buffer to a chat, set it as the system message, create a blueprint,
+  or fill variables.
 - ~C-c C-k~: Kill the current buffer.
-- ~C-c c~: Create a blueprint from the current buffer.
-- ~C-c v~: Fill variables in the current blueprint.
 
 ** Transient Menus
 
-Ellama includes transient menus for easy access to blueprint commands. The
-~ellama-transient-blueprint-menu~ provides options for chatting with a selected
-blueprint, creating a new blueprint, and quitting the menu.
+- ~ellama-transient-blueprint-menu~: Chat with a selected blueprint, create a
+  new blueprint, or manage saved blueprints.
+- ~ellama-transient-blueprint-mode-menu~: Act on the blueprint in the current
+  buffer.
+- ~ellama-transient-main-menu~: Integrates the blueprint menu into the main
+  interface.
 
-The ~ellama-transient-main-menu~ integrates the blueprint menu into the main
-menu, providing a comprehensive interface for all Ellama commands.
+** Running Blueprints Programmatically
 
-** Running Blueprints programmatically
-
-The ~ellama-blueprint-run~ function initiates a chat session using a specified
-blueprint. It pre-fills variables based on the provided arguments.
+~ellama-blueprint-run~ starts a chat session with a blueprint, pre-filling
+variables from the provided arguments.
 
 #+BEGIN_SRC emacs-lisp
   (defun my-chat-with-morpheus ()
@@ -1828,10 +1722,10 @@ blueprint. It pre-fills variables based on the provided arguments.
 
 * MCP Integration
 
-You can also use MCP (Model Context Protocol) tools with ~ellama~. You need
-Emacs 30 or higher version. Install ~mcp.el~ -
-https://github.com/lizqwerscott/mcp.el. For example to add web search capability
-to ~ellama~ you can add duckduckgo mcp server
+Use MCP (Model Context Protocol) tools with ~ellama~. Requires Emacs 30+ and the
+~mcp.el~ package: https://github.com/lizqwerscott/mcp.el
+
+Example: adding DuckDuckGo search via the duckduckgo-mcp-server
 (https://github.com/nickclyde/duckduckgo-mcp-server):
 
 #+begin_src emacs-lisp
@@ -1854,28 +1748,28 @@ to ~ellama~ you can add duckduckgo mcp server
 	       tools)))))
 #+end_src
 
-When ~:categoryp t~ is used, ellama derives stable MCP tool identity as
-~<category>/<tool-name>~ (for example ~mcp-ddg/search~).  Irreversible policy,
-audit, and overrides are keyed by this identity.
+When ~:categoryp t~ is used, Ellama derives a stable MCP tool identity as
+~<category>/<tool-name>~ (e.g., ~mcp-ddg/search~). Irreversible policy, audit,
+and overrides are keyed by this identity.
 
 * Agent Skills
 
-Ellama supports *Agent Skills*, a lightweight format for extending AI
-capabilities. Skills are loaded into context only when needed (Progressive
-Disclosure).
+Agent Skills provide instructions and supporting files for specific tasks.
+Ellama adds only skill metadata to the initial context; the model reads the full
+instructions when it chooses a skill.
 
 ** Directory Structure
 
-Ellama looks for skills in two locations:
-1.  *Global*: =~/.emacs.d/ellama/skills/= (Customizable via
-~ellama-skills-global-path~)
-2.  *Project-Local*: ~skills/~ inside your project root (Customizable via
-~ellama-skills-local-path~)
+Ellama searches for skills in two locations:
 
-A skill is a directory containing a ~SKILL.md~ file. This file includes metadata
-(~name~ and ~description~, at minimum) and instructions that tell an agent how
-to perform a specific task. Skills can also bundle scripts, templates, and
-reference materials.
+1.  *Global*: =~/.emacs.d/ellama/skills/= by default, customizable via
+   ~ellama-skills-global-path~.
+2.  *Project-local*: ~skills/~ inside the project root, customizable via
+   ~ellama-skills-local-path~.
+
+A skill is a directory containing a ~SKILL.md~ file with metadata (~name~,
+~description~) and instructions for the agent. Skills can also include scripts,
+templates, and reference materials.
 
 #+begin_src
 my-project/
@@ -1889,7 +1783,7 @@ my-project/
 
 ** Creating a Skill
 
-SKILL.md must contain YAML frontmatter:
+The ~SKILL.md~ file must include YAML frontmatter:
 
 #+begin_src markdown
 ---
@@ -1901,40 +1795,37 @@ description: Extract text from PDFs and summarize them.
 To extract text from a PDF...
 #+end_src
 
-** How it works
+** How It Works
 
-*Auto-Discovery*: Ellama scans skill directories automatically whenever a chat
- starts.  *Context*: Skill metadata (name, description, location) is injected
- into the system prompt.  *Activation*: The LLM uses the read_file tool to load
- the SKILL.md content when needed.
+- *Auto-Discovery*: Ellama scans skill directories when each chat starts.
+- *Context*: Skill metadata (name, description, location) is injected into the
+  system prompt.
+- *Activation*: The LLM loads ~SKILL.md~ content via ~read_file~ when needed.
 
 * Acknowledgments
 
-Thanks [[https://github.com/jmorganca][Jeffrey Morgan]] for excellent project
-[[https://github.com/jmorganca/ollama][ollama]]. This project cannot exist
-without it.
+Thanks to [[https://github.com/jmorganca][Jeffrey Morgan]] for
+[[https://github.com/jmorganca/ollama][ollama]], which made this project
+possible.
 
-Thanks [[https://github.com/zweifisch][zweifisch]] - I got some ideas from
-[[https://github.com/zweifisch/ollama][ollama.el]] what ollama client in Emacs
-can do.
+Thanks [[https://github.com/zweifisch][zweifisch]] for ideas from
+[[https://github.com/zweifisch/ollama][ollama.el]] about what an Emacs ollama
+client can do.
 
-Thanks [[https://github.com/David-Kunz][Dr. David A. Kunz]] - I got more ideas
-from [[https://github.com/David-Kunz/gen.nvim][gen.nvim]].
+Thanks [[https://github.com/David-Kunz][Dr. David A. Kunz]] for ideas from
+[[https://github.com/David-Kunz/gen.nvim][gen.nvim]].
 
-Thanks [[https://github.com/ahyatt][Andrew Hyatt]] for ~llm~ library. Without it
-only ~ollama~ would be supported.
+Thanks [[https://github.com/ahyatt][Andrew Hyatt]] for the ~llm~ library,
+without which only ~ollama~ would be supported.
 
 * Contributions
 
-To contribute, submit a pull request or report a bug. This library is part of
-GNU ELPA; major contributions must be from someone with FSF
-papers. Alternatively, you can write a module and share it on a different
-archive like MELPA.
+Submit a pull request or report a bug. This library is part of GNU ELPA; major
+contributions require FSF papers. Alternatively, write a module for MELPA.
 
-For local validation, run ~make check-elisp~ before pushing Elisp changes. It
-formats Elisp files, byte-compiles, runs the ERT suite, native-compiles, and
-runs checkdoc. Byte and native compilation warnings are treated as failures, so
-warnings block the same way test failures do.
+Run ~make check-elisp~ before pushing Elisp changes. It formats Elisp files,
+byte-compiles, runs the ERT suite, native-compiles, and runs checkdoc. Byte and
+native compilation warnings are treated as failures.
 
 * GNU Free Documentation License
 :PROPERTIES:

--- a/README.org
+++ b/README.org
@@ -773,9 +773,10 @@ Use ~:media~ when a request mixes images and audio:
                         "/path/to/notes.wav"))
 #+END_SRC
 
-Microphone recording is available when the platform has a recording command. On
-macOS Ellama uses ~afrecord~. On GNU/Linux it uses ~arecord~. Set
-~ellama-audio-recording-command~ if you need another program or extra arguments.
+Ellama selects an installed microphone recorder automatically.  On macOS it
+tries FFmpeg and then SoX.  On GNU/Linux it tries ~arecord~, FFmpeg, and then
+SoX.  Set ~ellama-audio-recording-command~ if you need another program, input
+device, or extra arguments.
 
 For short messages, use ~M-x ellama-ask-audio-recording~ or ~M-x
 ellama-context-add-audio-recording~.  Ellama records for

--- a/README.org
+++ b/README.org
@@ -758,11 +758,9 @@ WebM.  Audio is sent as multipart media, the same transport used for image
 input.  Set ~ellama-audio-file-extensions~ if your provider accepts another
 format.
 
-Provider capability alone is not enough: the installed ~llm~ package must also
-serialize audio for that provider.  Gemini and Vertex use their native inline
-media format.  OpenAI-compatible Chat Completions requires ~input_audio~ support
-in ~llm~.  Ellama checks this before sending a request and rejects older ~llm~
-versions that would incorrectly encode audio as an image.
+Audio transport depends on the installed ~llm~ package.  Ellama requires ~llm~
+0.31.1 or newer, which includes audio serialization for OpenAI-compatible and
+Ollama providers.  Gemini and Vertex use their native inline media format.
 
 Use ~M-x ellama-ask-audio~ for one audio file, or ~M-x ellama-chat-with-audio~
 inside a chat workflow.  For several files, use ~M-x ellama-chat-with-audios~.

--- a/README.org
+++ b/README.org
@@ -780,6 +780,12 @@ device, or extra arguments.  On macOS, allow microphone access for Emacs in
 System Settings under Privacy & Security > Microphone.  If Emacs runs in a
 terminal, allow access for that terminal instead.
 
+FFmpeg recordings use dynamic speech normalization by default.  This helps when
+the microphone input is quiet and reduces the chance that an audio model will
+invent speech from a weak signal.  Set ~ellama-audio-recording-ffmpeg-filter~ to
+nil to keep the original input level, or replace it with another FFmpeg audio
+filter.
+
 *** macOS microphone permission
 
 Emacs may be missing from the Microphone list when its application bundle has no

--- a/README.org
+++ b/README.org
@@ -548,8 +548,8 @@ generated text string.
 - ~ellama-tools-argument-max-length~: Max length of function argument in the
   confirmation prompt. Default value 50.
 - ~ellama-tools-read-file-default-mode~: Default mode for the ~read_file~
-  tool. Use ~auto~ to read text files as text and supported image files as
-  media, ~text~ to force text reading, or ~image~ to force image handling.
+  tool. Use ~auto~ to read text files as text and supported image or audio files
+  as media. Use ~text~, ~image~, or ~audio~ to force a specific mode.
 - ~ellama-tools-dlp-safe-read-file-regexps~: Canonical file-name regexps whose
   ~read_file~-style outputs skip output DLP scans. Defaults to Ellama source
   files in the loaded Ellama directory. Input DLP, other tool outputs, access
@@ -725,13 +725,16 @@ until it is removed or the context is reset. The context transient menu also
 provides "Add Image"; combine it with ~--ephemeral~ to force one-request image
 context.
 
-The built-in ~read_file~ tool supports image files through a configurable read
-mode:
+The built-in ~read_file~ tool supports image and audio files through a
+configurable read mode:
 
-- ~auto~: read text files as text and queue supported image files as image input
+- ~auto~: read text files as text and queue supported media files for model
+  input
 - ~text~: force text reading, even for files with image-like extensions
 - ~image~: force image handling and return a clear text error for unsupported
   image types, missing sessions, or providers without ~image-input~
+- ~audio~: force audio handling and return a clear text error for unsupported
+  audio types, missing sessions, or providers without ~audio-input~
 
 Tool calls can request image handling explicitly:
 
@@ -760,6 +763,19 @@ Use ~M-x ellama-ask-audio~ for one audio file, or ~M-x ellama-chat-with-audio~
 inside a chat workflow.  For several files, use ~M-x ellama-chat-with-audios~.
 These commands add audio as ephemeral context for the next request, so the file
 is not kept around unless you add it as persistent context yourself.
+
+The ~read_file~ tool also accepts audio.  In ~auto~ mode it recognizes supported
+audio extensions; use ~audio~ to request audio handling explicitly:
+
+#+BEGIN_SRC json
+{
+  "file_name": "/path/to/recording.wav",
+  "mode": "audio"
+}
+#+END_SRC
+
+The tool queues the recording as media for the next model turn.  It does not
+return binary audio as text.
 
 Programmatic calls can pass audio directly:
 

--- a/ellama-context.el
+++ b/ellama-context.el
@@ -32,6 +32,11 @@
 (require 'ellama)
 
 (declare-function ellama-image-file-p "ellama" (file-name))
+(declare-function ellama-audio-file-p "ellama" (file-name))
+(declare-function ellama-record-audio "ellama" (&optional duration file-name))
+(declare-function ellama-start-audio-recording "ellama" (&optional file-name))
+(declare-function ellama-stop-audio-recording "ellama" ())
+(defvar ellama-audio-recording-duration)
 
 (defcustom ellama-context-line-always-visible nil
   "Make context header or mode line always visible, even with empty context."
@@ -57,6 +62,14 @@
   "Default scope for image context added interactively.
 Use `ephemeral' to attach images to the next request only.
 Use `persistent' to keep image context until it is removed or reset."
+  :group 'ellama
+  :type '(choice (const ephemeral)
+                 (const persistent)))
+
+(defcustom ellama-audio-context-default-scope 'ephemeral
+  "Default scope for audio context added interactively.
+Use `ephemeral' to attach audio to the next request only.
+Use `persistent' to keep audio context until it is removed or reset."
   :group 'ellama
   :type '(choice (const ephemeral)
                  (const persistent)))
@@ -532,6 +545,44 @@ the context."
   (with-slots (name) element
     (list name)))
 
+;; Audio file context element
+
+(defclass ellama-context-element-audio-file (ellama-context-element)
+  ((name :initarg :name :type string))
+  "A structure for holding audio file context.")
+
+(cl-defmethod ellama-context-element-extract
+  ((element ellama-context-element-audio-file))
+  "Extract a text placeholder for audio context ELEMENT."
+  (with-slots (name) element
+    (format "Audio attached: %s" name)))
+
+(cl-defmethod ellama-context-element-display
+  ((element ellama-context-element-audio-file))
+  "Display the audio context ELEMENT."
+  (with-slots (name) element
+    (file-name-nondirectory name)))
+
+(cl-defmethod ellama-context-element-format
+  ((element ellama-context-element-audio-file) (mode (eql 'markdown-mode)))
+  "Format the audio context ELEMENT for the major MODE."
+  (ignore mode)
+  (with-slots (name) element
+    (format "[%s](<%s>)" (file-name-nondirectory name) name)))
+
+(cl-defmethod ellama-context-element-format
+  ((element ellama-context-element-audio-file) (mode (eql 'org-mode)))
+  "Format the audio context ELEMENT for the major MODE."
+  (ignore mode)
+  (with-slots (name) element
+    (format "[[file:%s][%s]]" name (file-name-nondirectory name))))
+
+(cl-defmethod ellama-context-element-media
+  ((element ellama-context-element-audio-file))
+  "Return audio file media from context ELEMENT."
+  (with-slots (name) element
+    (list name)))
+
 ;; Info node context element
 
 (defclass ellama-context-element-info-node (ellama-context-element)
@@ -839,6 +890,66 @@ or `persistent' to keep the image context."
        (ellama-context-add-image-file file-name))
       (_
        (ellama-context-add-image-file file-name t)))))
+
+;;;###autoload
+(defun ellama-context-add-audio-file (file-name &optional ephemeral)
+  "Add audio FILE-NAME to context.
+For one request only if EPHEMERAL."
+  (unless (ellama-audio-file-p file-name)
+    (user-error "Unsupported audio file: %s" file-name))
+  (let ((element (ellama-context-element-audio-file :name file-name)))
+    (if ephemeral
+        (ellama-context-ephemeral-element-add element)
+      (ellama-context-element-add element))))
+
+;;;###autoload
+(defun ellama-context-add-audio (&optional scope)
+  "Add audio file to context.
+SCOPE controls lifetime and defaults to
+`ellama-audio-context-default-scope'.  Use `ephemeral' for one request only,
+or `persistent' to keep the audio context."
+  (interactive)
+  (let* ((scope (or scope ellama-audio-context-default-scope))
+         (file-name (read-file-name "Select audio: " nil nil t)))
+    (pcase scope
+      ('persistent
+       (ellama-context-add-audio-file file-name))
+      (_
+       (ellama-context-add-audio-file file-name t)))))
+
+;;;###autoload
+(defun ellama-context-add-audio-recording (&optional scope duration)
+  "Record audio from the microphone and add it to context.
+SCOPE controls lifetime and defaults to
+`ellama-audio-context-default-scope'.  Use `ephemeral' for one request only,
+or `persistent' to keep the audio context.  DURATION is the recording
+duration in seconds."
+  (interactive)
+  (let* ((scope (or scope ellama-audio-context-default-scope))
+         (duration (or duration
+                       (read-number "Record seconds: "
+                                    ellama-audio-recording-duration))))
+    (ellama-context-add-audio-file
+     (ellama-record-audio duration)
+     (not (eq scope 'persistent)))))
+
+;;;###autoload
+(defun ellama-context-start-audio-recording ()
+  "Start microphone recording for later context attachment."
+  (interactive)
+  (ellama-start-audio-recording))
+
+;;;###autoload
+(defun ellama-context-stop-audio-recording (&optional scope)
+  "Stop microphone recording and add the resulting audio file to context.
+SCOPE controls lifetime and defaults to
+`ellama-audio-context-default-scope'.  Use `ephemeral' for one request only,
+or `persistent' to keep the audio context."
+  (interactive)
+  (let ((scope (or scope ellama-audio-context-default-scope)))
+    (ellama-context-add-audio-file
+     (ellama-stop-audio-recording)
+     (not (eq scope 'persistent)))))
 
 ;;;###autoload
 (defun ellama-context-add-file-quote (&optional ephemeral)

--- a/ellama-tools.el
+++ b/ellama-tools.el
@@ -3665,26 +3665,38 @@ ANSWER-VARIANT-LIST is a list of possible answer variants."))
          (with-current-buffer (find-file-noselect file-name)
            (save-excursion
              (let ((line-count (count-lines (point-min) (point-max))))
-               (if (> to line-count)
+               (if (> from line-count)
                    (format
-                    "Invalid line range for %s: to (%s) exceeds line count (%s)."
+                    "Invalid line range for %s: from (%s) exceeds line count (%s)."
                     file-name
-                    to
+                    from
                     line-count)
-                 (let ((start (progn
-                                (goto-char (point-min))
-                                (forward-line (1- from))
-                                (beginning-of-line)
-                                (point)))
-                       (end (progn
-                              (goto-char (point-min))
-                              (forward-line (1- to))
-                              (end-of-line)
-                              (point))))
+                 (let* ((actual-to (min to line-count))
+                        (start (progn
+                                 (goto-char (point-min))
+                                 (forward-line (1- from))
+                                 (beginning-of-line)
+                                 (point)))
+                        (end (progn
+                               (goto-char (point-min))
+                               (forward-line (1- actual-to))
+                               (end-of-line)
+                               (point)))
+                        (warning
+                         (when (> to line-count)
+                           (format
+                            (concat
+                             "Warning: file %s contains only %s lines; "
+                             "requested range ends at line %s.\n\n")
+                            file-name
+                            line-count
+                            to))))
                    (prog1
-                       (ellama-tools--sanitize-tool-text-output
-                        (buffer-substring-no-properties start end)
-                        (format "File %s" file-name))
+                       (concat
+                        warning
+                        (ellama-tools--sanitize-tool-text-output
+                         (buffer-substring-no-properties start end)
+                         (format "File %s" file-name)))
                      (ellama-tools--mark-file-read file-name))))))))))))
 
 (ellama-tools-define-tool

--- a/ellama-tools.el
+++ b/ellama-tools.el
@@ -3211,7 +3211,10 @@ TIMEOUT is the optional command timeout in seconds."
             (inhibit-read-only t))
         (erase-buffer)
         (insert content)
-        (save-buffer)))))
+        (save-buffer)
+        ;; Revert the buffer silently to avoid user prompts when
+        ;; Emacs detects that the visited file has changed on disk.
+        (revert-buffer t t t)))))
 
 (defun ellama-tools-edit-file-tool (callback file-name oldcontent newcontent)
   "Edit FILE-NAME and call CALLBACK with the result.

--- a/ellama-tools.el
+++ b/ellama-tools.el
@@ -716,7 +716,11 @@ TOOL-METADATA may include `:tool-origin', `:server-id' and
   "Return line-budget truncation plist for TEXT.
 MAX-LINES limits how many lines are kept.
 MAX-LINE-LENGTH limits one line width in characters."
-  (let* ((lines (split-string text "\n" nil))
+  (let* ((lines (unless (string-empty-p text)
+                  (split-string text "\n" nil)))
+         (lines (if (and lines (string-suffix-p "\n" text))
+                    (butlast lines)
+                  lines))
          (total-lines (length lines))
          (kept 0)
          (long-lines 0)
@@ -782,6 +786,16 @@ MAX-LINE-LENGTH limits one line width in characters."
      (plist-get range :from)
      (plist-get range :to))))
 
+(defun ellama-tools--file-line-count (path)
+  "Return number of lines in file at PATH, or nil when unavailable."
+  (when (stringp path)
+    (condition-case nil
+        (when (file-regular-p path)
+          (with-temp-buffer
+            (insert-file-contents-literally path)
+            (count-lines (point-min) (point-max))))
+      (file-error nil))))
+
 (defun ellama-tools--output-truncation-notice
     (tool-name truncation source-info saved-path)
   "Return tool output truncation notice string.
@@ -794,12 +808,14 @@ SAVED-PATH is optional path to full saved output."
          (long-lines (plist-get truncation :long-lines))
          (snippet (plist-get truncation :text))
          (source-kind (plist-get source-info :kind))
-         (source-path (plist-get source-info :path)))
+         (source-path (plist-get source-info :path))
+         (source-lines (and (eq source-kind 'file)
+                            (ellama-tools--file-line-count source-path))))
     (concat
      "[ELLAMA OUTPUT TRUNCATED]\n"
      (format "Tool `%s` output exceeded line budget and was truncated.\n"
              tool-name)
-     (format "Original lines: %d.  Kept up to %d lines.\n"
+     (format "Full output lines: %d.  Kept up to %d lines.\n"
              total-lines
              (max 0 ellama-tools-output-line-budget-max-lines))
      (when (> dropped-lines 0)
@@ -809,38 +825,44 @@ SAVED-PATH is optional path to full saved output."
         (concat "Truncated long lines: %d (max %d chars per line).\n")
         long-lines
         (max 1 ellama-tools-output-line-budget-max-line-length)))
+     (when source-path
+       (format "Source %s: %s\n"
+               (if (eq source-kind 'directory) "directory" "file")
+               source-path))
+     (when source-lines
+       (format "Source file contains %d lines.\n" source-lines))
      (cond
-      ((and source-path (eq source-kind 'file))
-       (format
-        (concat
-         "Source file: %s\n"
-         "%s"
-         "Use `grep_in_file` with file=%S and a specific search_string "
-         "to locate relevant lines.\n")
-        source-path
-        (or (ellama-tools--output-truncation-range-hint
-             source-path truncation)
-            "")
-        source-path))
-      ((and source-path (eq source-kind 'directory))
-       (format
-        (concat
-         "Source directory: %s\n"
-         "Next suggested tool call: `grep` with dir=%S and a specific "
-         "search_string, then `read_file` or `lines_range` on the target file.\n")
-        source-path source-path))
       (saved-path
        (format
         (concat
          "Full output saved to: %s\n"
+         "Saved output file contains %d lines.\n"
          "%s"
          "Use `grep_in_file` with file=%S and a specific search_string "
          "to search the saved output.\n")
         saved-path
+        total-lines
         (or (ellama-tools--output-truncation-range-hint
              saved-path truncation)
             "")
         saved-path))
+      ((and source-path (eq source-kind 'file))
+       (format
+        (concat
+         "Use `lines_range` with file_name=%S and a range of at most %d lines%s, "
+         "or `grep_in_file` with file=%S and a specific search_string.\n")
+        source-path
+        (max 0 ellama-tools-output-line-budget-max-lines)
+        (if source-lines
+            (format " within 1..%d" source-lines)
+          "")
+        source-path))
+      ((and source-path (eq source-kind 'directory))
+       (format
+        (concat
+         "Next suggested tool call: `grep` with dir=%S and a specific "
+         "search_string, then `read_file` or `lines_range` on the target file.\n")
+        source-path))
       (t
        (concat
         "Full output file was not saved.\n"

--- a/ellama-tools.el
+++ b/ellama-tools.el
@@ -4171,6 +4171,12 @@ TEMPLATE-BASE, ROLE and ARGUMENTS are used for template rendering and hints."
       (error "No active plan-and-act session"))
     (unless steps
       (error "Plan must contain at least one checklist or numbered item"))
+    ;; Append "Check yourself" at the end without reversing user steps.
+    (nconc steps
+           (list (list :id (1+ (cl-loop for s in steps
+                                        maximize (plist-get s :id)))
+                       :title "Check yourself"
+                       :status nil)))
     (setq state (ellama-tools--agent-state-put state :plan steps))
     (setq state (ellama-tools--agent-state-put state :phase 'acting))
     (ellama-tools--agent-put-state session state)

--- a/ellama-tools.el
+++ b/ellama-tools.el
@@ -50,8 +50,11 @@
 (declare-function ellama--scroll "ellama" (&optional buffer point))
 (declare-function ellama-image-file-p "ellama" (file-name))
 (declare-function ellama--image-mime-type "ellama" (file-name))
+(declare-function ellama-audio-file-p "ellama" (file-name))
+(declare-function ellama--audio-mime-type "ellama" (file-name))
 (declare-function ellama--file-size "ellama" (file-name))
 (declare-function ellama--provider-supports-image-input-p "ellama" (provider))
+(declare-function ellama--provider-supports-audio-input-p "ellama" (provider))
 (declare-function ellama--session-add-pending-tool-media
                   "ellama" (session file-name))
 (declare-function ellama-stream "ellama" (prompt &rest args))
@@ -193,12 +196,14 @@ Tools from this list will work without user confirmation."
 
 (defcustom ellama-tools-read-file-default-mode 'auto
   "Default mode for the `read_file' tool.
-Use `auto' to read text files as text and supported image files as media.
+Use `auto' to read text files as text and supported media files as media.
 Use `text' to force text reading.
-Use `image' to force image handling."
+Use `image' to force image handling.
+Use `audio' to force audio handling."
   :type '(choice (const auto)
                  (const text)
-                 (const image))
+                 (const image)
+                 (const audio))
   :group 'ellama)
 
 (defcustom ellama-tools-dlp-safe-read-file-regexps
@@ -2112,9 +2117,37 @@ TIMEOUT is the timeout in seconds used when RESULT reports a timeout."
               (ellama--image-mime-type file-name)
               (ellama--file-size file-name))))))
 
+(defun ellama-tools--read-audio-file-tool (file-name)
+  "Queue audio FILE-NAME for model input and return textual tool output."
+  (cond
+   ((not (ellama-audio-file-p file-name))
+    (format "File %s is not a supported audio file." file-name))
+   ((not (ellama-session-p
+          (or ellama--current-session ellama-tools--current-session)))
+    "Cannot attach audio file: no active Ellama session.")
+   ((not (ellama--provider-supports-audio-input-p
+          (ellama-session-provider
+           (or ellama--current-session ellama-tools--current-session))))
+    (format "Provider %s does not support audio input."
+            (llm-name
+             (ellama-session-provider
+              (or ellama--current-session ellama-tools--current-session)))))
+   (t
+    (ellama--session-add-pending-tool-media
+     (or ellama--current-session ellama-tools--current-session)
+     file-name)
+    (let* ((expanded (expand-file-name file-name))
+           (link (if (provided-mode-derived-p major-mode 'org-mode)
+                     (format "[[file:%s][%s]]" expanded file-name)
+                   (format "[%s](file://%s)" file-name expanded))))
+      (format "Audio file queued for model input: %s (%s, %d bytes)."
+              link
+              (ellama--audio-mime-type file-name)
+              (ellama--file-size file-name))))))
+
 (defun ellama-tools-read-file-tool (file-name &optional mode)
   "Read the file FILE-NAME.
-MODE can be `auto', `text' or `image'."
+MODE can be `auto', `text', `image' or `audio'."
   (or (ellama-tools--tool-check-file-access file-name 'read)
       (let ((result
              (cond
@@ -2126,9 +2159,13 @@ MODE can be `auto', `text' or `image'."
                (pcase (ellama-tools--read-file-mode mode)
                  ('auto
                   (prog1
-                      (if (ellama-image-file-p file-name)
-                          (ellama-tools--read-image-file-tool file-name)
-                        (ellama-tools--read-file-as-text file-name))
+                      (cond
+                       ((ellama-image-file-p file-name)
+                        (ellama-tools--read-image-file-tool file-name))
+                       ((ellama-audio-file-p file-name)
+                        (ellama-tools--read-audio-file-tool file-name))
+                       (t
+                        (ellama-tools--read-file-as-text file-name)))
                     (ellama-tools--mark-file-read file-name)))
                  ('text
                   (prog1
@@ -2138,9 +2175,15 @@ MODE can be `auto', `text' or `image'."
                   (prog1
                       (ellama-tools--read-image-file-tool file-name)
                     (ellama-tools--mark-file-read file-name)))
+                 ('audio
+                  (prog1
+                      (ellama-tools--read-audio-file-tool file-name)
+                    (ellama-tools--mark-file-read file-name)))
                  (_
                   (format
-                   "Unsupported read_file mode %S. Use auto, text or image."
+                   (concat
+                    "Unsupported read_file mode %S. "
+                    "Use auto, text, image or audio.")
                    mode)))))))
         (json-encode result))))
 
@@ -2163,9 +2206,9 @@ MODE can be `auto', `text' or `image'."
      :optional
      t
      :enum
-     ["auto" "text" "image"]
+     ["auto" "text" "image" "audio"]
      :description
-     "Read mode: auto, text, or image."))
+     "Read mode: auto, text, image, or audio."))
    :description
    "Read the file FILE_NAME."))
 

--- a/ellama-tools.el
+++ b/ellama-tools.el
@@ -1985,6 +1985,16 @@ Wrap command with `srt' when `ellama-tools-use-srt' is non-nil."
           (string-prefix-p "GIT_PAGER=" entry)))
     (copy-sequence (or env process-environment)))))
 
+(defun ellama-tools--shell-command-process-environment (&optional env)
+  "Return ENV configured for non-interactive shell command execution."
+  (append
+   '("TERM=dumb" "NO_COLOR=true")
+   (seq-remove
+    (lambda (entry)
+      (or (string-prefix-p "TERM=" entry)
+          (string-prefix-p "NO_COLOR=" entry)))
+    (ellama-tools--process-environment-with-cat-pager env))))
+
 (defun ellama-tools--file-buffer-in-directory-p (buffer directory)
   "Return non-nil when BUFFER visits a file under DIRECTORY."
   (when-let* ((file-name (buffer-file-name buffer)))
@@ -3333,7 +3343,7 @@ TIMEOUT is the optional command timeout in seconds."
                shell-file-name shell-command-switch cmd))
         (timeout (ellama-tools--shell-command-timeout timeout))
         (process-environment
-         (ellama-tools--process-environment-with-cat-pager))
+         (ellama-tools--shell-command-process-environment))
         (file-buffers
          (ellama-tools--prepare-shell-command-file-buffers
           default-directory)))

--- a/ellama-tools.el
+++ b/ellama-tools.el
@@ -58,6 +58,7 @@
 (declare-function ellama--session-add-pending-tool-media
                   "ellama" (session file-name))
 (declare-function ellama-stream "ellama" (prompt &rest args))
+(declare-function auto-revert-mode "autorevert" (&optional arg))
 
 (defvar ellama-provider)
 (defvar ellama-coding-provider)
@@ -65,6 +66,7 @@
 (defvar ellama-user-nick)
 (defvar ellama--current-session)
 (defvar ellama--current-session-id)
+(defvar auto-revert-mode)
 
 (defvar ellama-tools-available nil
   "Alist containing all registered tools.")
@@ -1983,6 +1985,43 @@ Wrap command with `srt' when `ellama-tools-use-srt' is non-nil."
           (string-prefix-p "GIT_PAGER=" entry)))
     (copy-sequence (or env process-environment)))))
 
+(defun ellama-tools--file-buffer-in-directory-p (buffer directory)
+  "Return non-nil when BUFFER visits a file under DIRECTORY."
+  (when-let* ((file-name (buffer-file-name buffer)))
+    (condition-case nil
+        (file-in-directory-p
+         (expand-file-name file-name)
+         (file-name-as-directory (expand-file-name directory)))
+      (error nil))))
+
+(defun ellama-tools--prepare-shell-command-file-buffers (directory)
+  "Prepare file-visiting buffers under DIRECTORY for shell command execution.
+Return a list describing buffers to restore after command completion."
+  (let (buffers)
+    (dolist (buffer (buffer-list) (nreverse buffers))
+      (when (ellama-tools--file-buffer-in-directory-p buffer directory)
+        (with-current-buffer buffer
+          (let ((auto-revert-enabled (bound-and-true-p auto-revert-mode)))
+            (when auto-revert-enabled
+              (auto-revert-mode -1))
+            (push (list :buffer buffer
+                        :auto-revert-mode auto-revert-enabled)
+                  buffers)))))))
+
+(defun ellama-tools--restore-shell-command-file-buffers (buffers)
+  "Silently revert BUFFERS and restore their previous auto-revert state."
+  (dolist (state buffers)
+    (let ((buffer (plist-get state :buffer))
+          (auto-revert-enabled (plist-get state :auto-revert-mode)))
+      (when (buffer-live-p buffer)
+        (with-current-buffer buffer
+          (unwind-protect
+              (condition-case nil
+                  (revert-buffer t t t)
+                (error nil))
+            (when auto-revert-enabled
+              (auto-revert-mode 1))))))))
+
 (defun ellama-tools--call-command-to-string (program &rest args)
   "Run PROGRAM with ARGS and return stdout as a string."
   (cdr (apply #'ellama-tools--call-command program args)))
@@ -3294,7 +3333,10 @@ TIMEOUT is the optional command timeout in seconds."
                shell-file-name shell-command-switch cmd))
         (timeout (ellama-tools--shell-command-timeout timeout))
         (process-environment
-         (ellama-tools--process-environment-with-cat-pager)))
+         (ellama-tools--process-environment-with-cat-pager))
+        (file-buffers
+         (ellama-tools--prepare-shell-command-file-buffers
+          default-directory)))
     (condition-case err
         (let ((buf (get-buffer-create
                     (concat (make-temp-name " *ellama shell command") "*")))
@@ -3320,7 +3362,10 @@ TIMEOUT is the optional command timeout in seconds."
                    (when timer
                      (cancel-timer timer))
                    (unwind-protect
-                       (funcall callback result)
+                       (progn
+                         (ellama-tools--restore-shell-command-file-buffers
+                          file-buffers)
+                         (funcall callback result))
                      (when (buffer-live-p buf)
                        (kill-buffer buf)))))
                (finish-process (proc)
@@ -3361,6 +3406,7 @@ TIMEOUT is the optional command timeout in seconds."
                          (delete-process process)
                          (finish result))))))))
       (error
+       (ellama-tools--restore-shell-command-file-buffers file-buffers)
        (funcall callback
                 (format "Failed to start shell command: %s"
                         (error-message-string err))))))

--- a/ellama-transient.el
+++ b/ellama-transient.el
@@ -52,11 +52,20 @@
 (defvar ellama-transient-provider nil)
 (defvar ellama--current-session-uid)
 (defvar ellama-max-tokens)
+(defvar ellama-audio-recording-duration)
 
 (declare-function ellama-ask-image "ellama"
                   (image prompt &optional create-session &rest args))
+(declare-function ellama-ask-audio "ellama"
+                  (audio prompt &optional create-session &rest args))
+(declare-function ellama-ask-audio-recording "ellama"
+                  (duration prompt &optional create-session &rest args))
 (declare-function ellama-chat-with-image "ellama"
                   (image prompt &optional create-session &rest args))
+(declare-function ellama-chat-with-audio "ellama"
+                  (audio prompt &optional create-session &rest args))
+(declare-function ellama-chat-with-audio-recording "ellama"
+                  (duration prompt &optional create-session &rest args))
 (declare-function ellama--provider-slot-offset "ellama" (provider slot))
 (declare-function ellama--provider-slot-value "ellama" (provider slot))
 (declare-function ellama--provider-with-slot-value "ellama"
@@ -692,6 +701,24 @@ FORMAT is used for non-default VALUE."
    (transient-arg-value "--new-session" args)
    :ephemeral (transient-arg-value "--ephemeral" args)))
 
+(transient-define-suffix ellama-transient-ask-audio (&optional args)
+  "Ask about an audio file.  ARGS used for transient arguments."
+  (interactive (list (transient-args transient-current-command)))
+  (ellama-ask-audio
+   (read-file-name "Audio: " nil nil t)
+   (read-string "Ask Ellama: ")
+   (transient-arg-value "--new-session" args)
+   :ephemeral (transient-arg-value "--ephemeral" args)))
+
+(transient-define-suffix ellama-transient-ask-audio-recording (&optional args)
+  "Record audio and ask about it.  ARGS used for transient arguments."
+  (interactive (list (transient-args transient-current-command)))
+  (ellama-ask-audio-recording
+   (read-number "Record seconds: " ellama-audio-recording-duration)
+   (read-string "Ask Ellama: ")
+   (transient-arg-value "--new-session" args)
+   :ephemeral (transient-arg-value "--ephemeral" args)))
+
 ;;;###autoload (autoload 'ellama-transient-ask-menu "ellama-transient" nil t)
 (transient-define-prefix ellama-transient-ask-menu ()
   "Ask Commands."
@@ -705,7 +732,9 @@ FORMAT is used for non-default VALUE."
     ("l" "Ask Line" ellama-transient-ask-line)
     ("s" "Ask Selection" ellama-transient-ask-selection)
     ("a" "Ask About" ellama-transient-ask-about)
-    ("i" "Ask Image" ellama-transient-ask-image)]
+    ("i" "Ask Image" ellama-transient-ask-image)
+    ("A" "Ask Audio" ellama-transient-ask-audio)
+    ("R" "Record Audio" ellama-transient-ask-audio-recording)]
    ["Quit" ("q" "Quit" transient-quit-one)]])
 
 ;;;###autoload (autoload 'ellama-transient-translate-menu "ellama-transient" nil t)
@@ -752,6 +781,35 @@ ARGS used for transient arguments."
    (when (transient-arg-value "--ephemeral" args)
      'ephemeral)))
 
+(transient-define-suffix ellama-transient-add-audio (&optional args)
+  "Add audio to context.
+ARGS used for transient arguments."
+  (interactive (list (transient-args transient-current-command)))
+  (ellama-context-add-audio
+   (when (transient-arg-value "--ephemeral" args)
+     'ephemeral)))
+
+(transient-define-suffix ellama-transient-add-audio-recording (&optional args)
+  "Record audio and add it to context.
+ARGS used for transient arguments."
+  (interactive (list (transient-args transient-current-command)))
+  (ellama-context-add-audio-recording
+   (when (transient-arg-value "--ephemeral" args)
+     'ephemeral)))
+
+(transient-define-suffix ellama-transient-start-audio-recording ()
+  "Start microphone recording for context."
+  (interactive)
+  (ellama-context-start-audio-recording))
+
+(transient-define-suffix ellama-transient-stop-audio-recording (&optional args)
+  "Stop microphone recording and add it to context.
+ARGS used for transient arguments."
+  (interactive (list (transient-args transient-current-command)))
+  (ellama-context-stop-audio-recording
+   (when (transient-arg-value "--ephemeral" args)
+     'ephemeral)))
+
 (transient-define-suffix ellama-transient-add-selection (&optional args)
   "Add current selection to context.
 ARGS used for transient arguments."
@@ -784,12 +842,19 @@ ARGS used for transient arguments."
     ("d" "Add Directory" ellama-transient-add-directory)
     ("f" "Add File" ellama-transient-add-file)
     ("I" "Add Image" ellama-transient-add-image)
+    ("A" "Add Audio" ellama-transient-add-audio)
+    ("R" "Record Audio" ellama-transient-add-audio-recording)
     ("s" "Add Selection" ellama-transient-add-selection)
     ("i" "Add Info Node" ellama-transient-add-info-node)]
    ["Manage"
     ("m" "Manage context" ellama-context-manage)
     ("D" "Delete element" ellama-context-element-remove-by-name)
     ("r" "Context reset" ellama-context-reset)]
+   ["Recording"
+    ("S" "Start Recording" ellama-transient-start-audio-recording
+     :transient t)
+    ("E" "Stop Recording" ellama-transient-stop-audio-recording
+     :transient t)]
    ["Quit" ("q" "Quit" transient-quit-one)]])
 
 ;;;###autoload (autoload 'ellama-transient-blueprint-menu "ellama-transient" nil t)
@@ -869,6 +934,24 @@ ARGS used for transient arguments."
    (transient-arg-value "--new-session" args)
    :ephemeral (transient-arg-value "--ephemeral" args)))
 
+(transient-define-suffix ellama-transient-chat-with-audio (&optional args)
+  "Chat with Ellama about an audio file.  ARGS used for transient arguments."
+  (interactive (list (transient-args transient-current-command)))
+  (ellama-chat-with-audio
+   (read-file-name "Audio: " nil nil t)
+   (read-string "Ask Ellama: ")
+   (transient-arg-value "--new-session" args)
+   :ephemeral (transient-arg-value "--ephemeral" args)))
+
+(transient-define-suffix ellama-transient-chat-with-audio-recording (&optional args)
+  "Record audio and chat with Ellama about it.  ARGS used for transient arguments."
+  (interactive (list (transient-args transient-current-command)))
+  (ellama-chat-with-audio-recording
+   (read-number "Record seconds: " ellama-audio-recording-duration)
+   (read-string "Ask Ellama: ")
+   (transient-arg-value "--new-session" args)
+   :ephemeral (transient-arg-value "--ephemeral" args)))
+
 ;;;###autoload (autoload 'ellama-transient-main-menu "ellama-transient" nil t)
 (transient-define-prefix ellama-transient-main-menu ()
   "Main Menu."
@@ -881,6 +964,8 @@ ARGS used for transient arguments."
   ["Main"
    [("c" "Chat" ellama-transient-chat)
     ("I" "Chat with image" ellama-transient-chat-with-image)
+    ("E" "Chat with audio" ellama-transient-chat-with-audio)
+    ("M" "Record audio chat" ellama-transient-chat-with-audio-recording)
     ("b" "Chat with blueprint" ellama-blueprint-select)
     ("B" "Blueprint Commands" ellama-transient-blueprint-menu)
     ("T" "Tools Commands" ellama-transient-tools-menu)]

--- a/ellama-transient.el
+++ b/ellama-transient.el
@@ -50,6 +50,7 @@
 (defvar ellama-transient-port 11434)
 (defvar ellama-transient-url nil)
 (defvar ellama-transient-provider nil)
+(defvar ellama-transient-provider-type-selected-p nil)
 (defvar ellama--current-session-uid)
 (defvar ellama-max-tokens)
 (defvar ellama-audio-recording-duration)
@@ -161,6 +162,29 @@ Otherwise, prompt the user to enter a system message."
                                ellama-naming-provider)
   "List of providers.")
 
+(defcustom ellama-transient-provider-types
+  '((llm-ollama "Ollama" llm-ollama make-llm-ollama)
+    (llm-openai-compatible "OpenAI-compatible"
+                           llm-openai make-llm-openai-compatible)
+    (llm-openai "OpenAI" llm-openai make-llm-openai)
+    (llm-claude "Claude" llm-claude make-llm-claude)
+    (llm-gemini "Gemini" llm-gemini make-llm-gemini)
+    (llm-deepseek "DeepSeek" llm-deepseek make-llm-deepseek)
+    (llm-openrouter "OpenRouter" llm-openai make-llm-openrouter)
+    (llm-azure "Azure OpenAI" llm-azure make-llm-azure)
+    (llm-github "GitHub Models" llm-github make-llm-github)
+    (llm-vertex "Vertex AI" llm-vertex make-llm-vertex)
+    (llm-gpt4all "GPT4All" llm-gpt4all make-llm-gpt4all)
+    (llm-llamacpp "Llama.cpp" llm-llamacpp make-llm-llamacpp))
+  "Provider types available in the model transient.
+Each entry has the form (TYPE LABEL LIBRARY CONSTRUCTOR)."
+  :type '(repeat
+          (list (symbol :tag "Provider type")
+                (string :tag "Label")
+                (symbol :tag "Library")
+                (symbol :tag "Constructor")))
+  :group 'ellama)
+
 (defun ellama-transient--provider-symbol (provider)
   "Return provider variable symbol from PROVIDER."
   (cond
@@ -195,6 +219,86 @@ strings, because they may contain API keys."
     (or (cdr (assoc choice candidates))
         (error "Unknown provider: %s" choice))))
 
+(defun ellama-transient--provider-type-entry (type)
+  "Return provider type registry entry for TYPE."
+  (assq type ellama-transient-provider-types))
+
+(defun ellama-transient--provider-type-available-p (entry)
+  "Return non-nil when provider type ENTRY is available."
+  (let ((library (nth 2 entry)))
+    (or (featurep library)
+        (locate-library (symbol-name library)))))
+
+(defun ellama-transient--provider-type-candidates ()
+  "Return available provider type completion candidates."
+  (mapcan
+   (lambda (entry)
+     (when (ellama-transient--provider-type-available-p entry)
+       (list (cons (nth 1 entry) (car entry)))))
+   ellama-transient-provider-types))
+
+(defun ellama-transient--read-provider-type ()
+  "Read and return an available provider type."
+  (let* ((candidates (ellama-transient--provider-type-candidates))
+         (choice (completing-read "Select provider type: "
+                                  candidates nil t)))
+    (or (cdr (assoc choice candidates))
+        (error "Unknown provider type: %s" choice))))
+
+(defun ellama-transient--provider-type-name (&optional provider)
+  "Return display name for PROVIDER type."
+  (when-let* ((provider (or provider ellama-transient-provider))
+              (type (type-of provider)))
+    (if-let ((entry (ellama-transient--provider-type-entry type)))
+        (nth 1 entry)
+      (symbol-name type))))
+
+(defun ellama-transient-provider-type-description ()
+  "Return transient provider type description."
+  (format "Provider Type (%s)"
+          (or (ellama-transient--provider-type-name) "none")))
+
+(defun ellama-transient--configured-providers ()
+  "Return configured provider objects."
+  (append
+   (when ellama-transient-provider
+     (list ellama-transient-provider))
+   (mapcan
+    (lambda (provider)
+      (when-let ((symbol (ellama-transient--provider-symbol provider)))
+        (when (and (boundp symbol) (symbol-value symbol))
+          (list (symbol-value symbol)))))
+    ellama-provider-list)
+   (mapcar #'cdr ellama-providers)))
+
+(defun ellama-transient--make-provider-of-type (type)
+  "Return a configured or new provider of TYPE."
+  (or (seq-find (lambda (provider)
+                  (eq (type-of provider) type))
+                (ellama-transient--configured-providers))
+      (let* ((entry (or (ellama-transient--provider-type-entry type)
+                        (error "Unknown provider type: %s" type)))
+             (library (nth 2 entry))
+             (constructor (nth 3 entry)))
+        (condition-case err
+            (progn
+              (require library)
+              (unless (fboundp constructor)
+                (error "Provider constructor is unavailable: %s" constructor))
+              (funcall constructor))
+          (error
+           (error "Could not create %s provider: %s"
+                  (nth 1 entry) (error-message-string err)))))))
+
+(transient-define-suffix ellama-transient-set-provider-type ()
+  "Select provider type for the transient model."
+  (interactive)
+  (let ((provider
+         (ellama-transient--make-provider-of-type
+          (ellama-transient--read-provider-type))))
+    (ellama-fill-transient-model provider)
+    (setq ellama-transient-provider-type-selected-p t)))
+
 (transient-define-suffix ellama-transient-model-get-from-provider ()
   "Fill transient model from provider."
   (interactive)
@@ -212,10 +316,15 @@ strings, because they may contain API keys."
   "Set transient model to provider."
   (interactive)
   (let* ((provider (ellama-transient--read-provider-symbol))
-         (base-provider (symbol-value provider)))
-    (set provider
-         (let ((ellama-transient-provider base-provider))
-           (ellama-construct-provider-from-transient)))
+         (base-provider
+          (if ellama-transient-provider-type-selected-p
+              ellama-transient-provider
+            (symbol-value provider)))
+         (new-provider
+          (let ((ellama-transient-provider base-provider))
+            (ellama-construct-provider-from-transient))))
+    (set provider new-provider)
+    (setq ellama-transient-provider new-provider)
     ;; if you change `ellama-provider' you probably want new chat session
     (when (equal provider 'ellama-provider)
       (setq ellama--current-session-id nil
@@ -249,6 +358,9 @@ strings, because they may contain API keys."
      :description ellama-transient-max-tokens-description)
     ("r" "Reset model fields" ellama-transient-reset-model-fields
      :transient t)
+    ("P" "Set Provider Type" ellama-transient-set-provider-type
+     :transient t
+     :description ellama-transient-provider-type-description)
     ("S" "Set provider" ellama-transient-set-provider
      :transient t)
     ("s" "Set provider and quit" ellama-transient-set-provider)]
@@ -440,7 +552,8 @@ FORMAT is used for non-default VALUE."
 
 (defun ellama-fill-transient-model (provider)
   "Set transient model fields from PROVIDER."
-  (setq ellama-transient-provider provider)
+  (setq ellama-transient-provider provider
+        ellama-transient-provider-type-selected-p nil)
   (when-let ((model (ellama-transient--provider-model provider)))
     (setq ellama-transient-model-name model))
   (setq ellama-transient-temperature

--- a/ellama.el
+++ b/ellama.el
@@ -6,7 +6,7 @@
 ;; URL: http://github.com/s-kostyaev/ellama
 ;; Keywords: help local tools
 ;; Package-Requires: ((emacs "28.1") (llm "0.31.1") (plz "0.8") (transient "0.7") (compat "29.1") (yaml "1.2.3"))
-;; Version: 1.27.2
+;; Version: 1.28.0
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;; Created: 8th Oct 2023
 

--- a/ellama.el
+++ b/ellama.el
@@ -1316,6 +1316,39 @@ CONTEXT will be ignored.  Use global context instead.
   "Return non-nil when PROVIDER supports audio input."
   (ellama--provider-supports-capability-p provider 'audio-input))
 
+(defun ellama--tree-contains-input-audio-p (value)
+  "Return non-nil if VALUE has an OpenAI input_audio content part."
+  (cond
+   ((vectorp value)
+    (seq-some #'ellama--tree-contains-input-audio-p value))
+   ((consp value)
+    (or (and (eq (car value) :type)
+             (equal (cadr value) "input_audio"))
+        (ellama--tree-contains-input-audio-p (car value))
+        (ellama--tree-contains-input-audio-p (cdr value))))))
+
+(defun ellama--openai-compatible-audio-input-supported-p (provider)
+  "Return non-nil when PROVIDER serializes OpenAI audio input correctly."
+  (condition-case nil
+      (let ((request
+              (llm-provider-chat-request
+               provider
+               (llm-make-chat-prompt
+                (llm-make-multipart
+                 "audio input probe"
+                 (make-llm-media :mime-type "audio/wav" :data "")))
+               nil)))
+        (ellama--tree-contains-input-audio-p request))
+    (error nil)))
+
+(defun ellama--validate-provider-audio-transport (provider)
+  "Validate that PROVIDER can serialize audio media."
+  (when (and (fboundp 'llm-openai-compatible-p)
+             (llm-openai-compatible-p provider)
+             (not (ellama--openai-compatible-audio-input-supported-p provider)))
+    (error
+     "Installed llm does not support OpenAI-compatible audio input; update llm to a version with input_audio support")))
+
 (defun ellama--normalize-media-files (files media-kind)
   "Normalize FILES argument to a list of file names for MEDIA-KIND."
   (cond
@@ -1350,7 +1383,9 @@ CONTEXT will be ignored.  Use global context instead.
                (pcase capability
                  ('image-input "image input")
                  ('audio-input "audio input")
-                 (_ (symbol-name capability))))))))
+                 (_ (symbol-name capability)))))
+      (when (eq capability 'audio-input)
+        (ellama--validate-provider-audio-transport provider)))))
 
 (defun ellama--validate-image-input (provider image-files)
   "Validate IMAGE-FILES for PROVIDER."

--- a/ellama.el
+++ b/ellama.el
@@ -1500,6 +1500,22 @@ DURATION nil means record until the process is interrupted."
                t t))
             command)))
 
+(defun ellama--audio-recording-error (command exit-code output)
+  "Signal an audio recording error for COMMAND, EXIT-CODE, and OUTPUT."
+  (let* ((program (file-name-nondirectory (car command)))
+         (details (string-trim output))
+         (permission-hint
+          (when (and (eq system-type 'darwin)
+                     (equal program "ffmpeg"))
+            (concat " Check System Settings > Privacy & Security > Microphone "
+                    "and allow microphone access for Emacs."))))
+    (error "Audio recorder %s exited with %s%s%s"
+           program exit-code
+           (if (string-empty-p details)
+               ""
+             (format ": %s" details))
+           (or permission-hint ""))))
+
 ;;;###autoload
 (defun ellama-record-audio (&optional duration file-name)
   "Record audio from the microphone and return the recorded FILE-NAME.
@@ -1510,18 +1526,27 @@ DURATION defaults to `ellama-audio-recording-duration'."
                                     ellama-audio-recording-duration)))
          (file-name (or file-name
                         (ellama--audio-recording-file-name)))
-         (command (ellama--audio-recording-command file-name duration)))
+         (command (ellama--audio-recording-command file-name duration))
+         (output-buffer (generate-new-buffer " *ellama-audio-recording*")))
     (condition-case err
-        (let ((exit-code (apply #'call-process
-                                (car command) nil nil nil (cdr command))))
-          (unless (and (integerp exit-code) (zerop exit-code))
-            (error "Audio recording command exited with %s" exit-code))
-          (unless (ellama-audio-file-p file-name)
-            (error "Audio recording did not create a supported file: %s"
-                   file-name))
-          (when (called-interactively-p 'interactive)
-            (message "Recorded audio: %s" file-name))
-          file-name)
+        (unwind-protect
+            (let ((exit-code
+                   (apply #'call-process
+                          (car command) nil
+                          (list output-buffer t) nil
+                          (cdr command))))
+              (unless (and (integerp exit-code) (zerop exit-code))
+                (ellama--audio-recording-error
+                 command exit-code
+                 (with-current-buffer output-buffer
+                   (buffer-string))))
+              (unless (ellama-audio-file-p file-name)
+                (error "Audio recording did not create a supported file: %s"
+                       file-name))
+              (when (called-interactively-p 'interactive)
+                (message "Recorded audio: %s" file-name))
+              file-name)
+          (kill-buffer output-buffer))
       (error
        (error "Failed to record audio: %s" (error-message-string err))))))
 

--- a/ellama.el
+++ b/ellama.el
@@ -186,10 +186,13 @@ SVG is intentionally out of scope for the initial image input support."
   "File extension for microphone recordings."
   :type 'string)
 
-(defcustom ellama-audio-recording-command nil
+(defcustom ellama-audio-recording-command
+  #'ellama--default-audio-recording-command
   "Command used to record audio from the microphone.
-When nil, Ellama uses a platform default: `afrecord' on macOS or
-`arecord' on GNU/Linux when available.
+The default function selects an installed recorder for the current
+platform.  On macOS it tries FFmpeg and SoX.  On GNU/Linux it tries
+`arecord', FFmpeg, and SoX.  A nil value keeps this automatic
+selection for backward compatibility.
 
 When a list of strings, `%f' is replaced with the output file name
 and `%d' with the duration in seconds.  The first element is the
@@ -1446,20 +1449,32 @@ CONTEXT will be ignored.  Use global context instead.
    "ellama-audio-" nil
    (concat "." ellama-audio-recording-file-extension)))
 
-(defun ellama--default-audio-recording-command (&optional duration)
+(defun ellama--default-audio-recording-command (_file-name &optional duration)
   "Return default microphone recording command for current platform.
 DURATION nil means record until the process is interrupted."
-  (cond
-   ((and (eq system-type 'darwin)
-         (executable-find "afrecord"))
-    (append '("afrecord" "-f" "WAVE")
-            (when duration '("-d" "%d"))
-            '("%f")))
-   ((and (eq system-type 'gnu/linux)
-         (executable-find "arecord"))
-    (append '("arecord" "-q" "-f" "cd")
-            (when duration '("-d" "%d"))
-            '("%f")))))
+  (let ((duration-args (when duration '("-t" "%d"))))
+    (cond
+     ((and (eq system-type 'darwin)
+           (executable-find "ffmpeg"))
+      (append '("ffmpeg" "-nostdin" "-hide_banner" "-loglevel" "error"
+                "-f" "avfoundation" "-i" "none:default")
+              duration-args
+              '("-y" "%f")))
+     ((and (eq system-type 'gnu/linux)
+           (executable-find "arecord"))
+      (append '("arecord" "-q" "-f" "cd")
+              (when duration '("-d" "%d"))
+              '("%f")))
+     ((and (eq system-type 'gnu/linux)
+           (executable-find "ffmpeg"))
+      (append '("ffmpeg" "-nostdin" "-hide_banner" "-loglevel" "error"
+                "-f" "pulse" "-i" "default")
+              duration-args
+              '("-y" "%f")))
+     ((and (memq system-type '(darwin gnu/linux))
+           (executable-find "rec"))
+      (append '("rec" "%f")
+              (when duration '("trim" "0" "%d")))))))
 
 (defun ellama--audio-recording-command (file-name &optional duration)
   "Return command list to record FILE-NAME for DURATION seconds."
@@ -1469,7 +1484,8 @@ DURATION nil means record until the process is interrupted."
                   ((and ellama-audio-recording-command
                         (listp ellama-audio-recording-command))
                    ellama-audio-recording-command)
-                  (t (ellama--default-audio-recording-command duration)))))
+                  (t (ellama--default-audio-recording-command
+                      file-name duration)))))
     (unless command
       (error "No audio recording command available; customize ellama-audio-recording-command"))
     (when (and (not duration)

--- a/ellama.el
+++ b/ellama.el
@@ -186,6 +186,13 @@ SVG is intentionally out of scope for the initial image input support."
   "File extension for microphone recordings."
   :type 'string)
 
+(defcustom ellama-audio-recording-ffmpeg-filter
+  "dynaudnorm=f=150:g=7:p=0.9:m=20:r=0.1:b=1"
+  "FFmpeg audio filter used for microphone recordings.
+The default dynamically raises quiet speech while limiting peaks.
+Set this to nil to record without filtering."
+  :type '(choice (const nil) string))
+
 (defcustom ellama-audio-recording-command
   #'ellama--default-audio-recording-command
   "Command used to record audio from the microphone.
@@ -1458,6 +1465,8 @@ DURATION nil means record until the process is interrupted."
            (executable-find "ffmpeg"))
       (append '("ffmpeg" "-nostdin" "-hide_banner" "-loglevel" "error"
                 "-f" "avfoundation" "-i" "none:default")
+              (when ellama-audio-recording-ffmpeg-filter
+                (list "-af" ellama-audio-recording-ffmpeg-filter))
               duration-args
               '("-y" "%f")))
      ((and (eq system-type 'gnu/linux)
@@ -1469,6 +1478,8 @@ DURATION nil means record until the process is interrupted."
            (executable-find "ffmpeg"))
       (append '("ffmpeg" "-nostdin" "-hide_banner" "-loglevel" "error"
                 "-f" "pulse" "-i" "default")
+              (when ellama-audio-recording-ffmpeg-filter
+                (list "-af" ellama-audio-recording-ffmpeg-filter))
               duration-args
               '("-y" "%f")))
      ((and (memq system-type '(darwin gnu/linux))

--- a/ellama.el
+++ b/ellama.el
@@ -1316,39 +1316,6 @@ CONTEXT will be ignored.  Use global context instead.
   "Return non-nil when PROVIDER supports audio input."
   (ellama--provider-supports-capability-p provider 'audio-input))
 
-(defun ellama--tree-contains-input-audio-p (value)
-  "Return non-nil if VALUE has an OpenAI input_audio content part."
-  (cond
-   ((vectorp value)
-    (seq-some #'ellama--tree-contains-input-audio-p value))
-   ((consp value)
-    (or (and (eq (car value) :type)
-             (equal (cadr value) "input_audio"))
-        (ellama--tree-contains-input-audio-p (car value))
-        (ellama--tree-contains-input-audio-p (cdr value))))))
-
-(defun ellama--openai-compatible-audio-input-supported-p (provider)
-  "Return non-nil when PROVIDER serializes OpenAI audio input correctly."
-  (condition-case nil
-      (let ((request
-              (llm-provider-chat-request
-               provider
-               (llm-make-chat-prompt
-                (llm-make-multipart
-                 "audio input probe"
-                 (make-llm-media :mime-type "audio/wav" :data "")))
-               nil)))
-        (ellama--tree-contains-input-audio-p request))
-    (error nil)))
-
-(defun ellama--validate-provider-audio-transport (provider)
-  "Validate that PROVIDER can serialize audio media."
-  (when (and (fboundp 'llm-openai-compatible-p)
-             (llm-openai-compatible-p provider)
-             (not (ellama--openai-compatible-audio-input-supported-p provider)))
-    (error
-     "Installed llm does not support OpenAI-compatible audio input; update llm to a version with input_audio support")))
-
 (defun ellama--normalize-media-files (files media-kind)
   "Normalize FILES argument to a list of file names for MEDIA-KIND."
   (cond
@@ -1383,9 +1350,7 @@ CONTEXT will be ignored.  Use global context instead.
                (pcase capability
                  ('image-input "image input")
                  ('audio-input "audio input")
-                 (_ (symbol-name capability)))))
-      (when (eq capability 'audio-input)
-        (ellama--validate-provider-audio-transport provider)))))
+                 (_ (symbol-name capability))))))))
 
 (defun ellama--validate-image-input (provider image-files)
   "Validate IMAGE-FILES for PROVIDER."

--- a/ellama.el
+++ b/ellama.el
@@ -37,6 +37,7 @@
 
 (require 'eieio)
 (require 'cl-lib)
+(require 'seq)
 (require 'llm)
 (require 'llm-provider-utils)
 (require 'json)
@@ -172,6 +173,34 @@ and restore provider keys from auth-source while loading."
 SVG is intentionally out of scope for the initial image input support."
   :type '(repeat string))
 
+(defcustom ellama-audio-file-extensions
+  '("wav" "mp3" "m4a" "aac" "flac" "ogg" "oga" "opus" "webm")
+  "File extensions supported for audio input."
+  :type '(repeat string))
+
+(defcustom ellama-audio-recording-duration 30
+  "Default microphone recording duration in seconds."
+  :type 'integer)
+
+(defcustom ellama-audio-recording-file-extension "wav"
+  "File extension for microphone recordings."
+  :type 'string)
+
+(defcustom ellama-audio-recording-command nil
+  "Command used to record audio from the microphone.
+When nil, Ellama uses a platform default: `afrecord' on macOS or
+`arecord' on GNU/Linux when available.
+
+When a list of strings, `%f' is replaced with the output file name
+and `%d' with the duration in seconds.  The first element is the
+program name.
+
+When a function, it is called with output file name and duration,
+and must return a command list in the same format."
+  :type '(choice (const nil)
+                 (repeat string)
+                 function))
+
 (defcustom ellama-completion-provider nil
   "LLM provider for completions."
   :type '(sexp :validate llm-standard-provider-p))
@@ -227,6 +256,8 @@ SVG is intentionally out of scope for the initial image input support."
     (define-key map (kbd "a a") 'ellama-ask-about)
     (define-key map (kbd "a i") 'ellama-chat)
     (define-key map (kbd "a I") 'ellama-ask-image)
+    (define-key map (kbd "a A") 'ellama-ask-audio)
+    (define-key map (kbd "a R") 'ellama-ask-audio-recording)
     (define-key map (kbd "a l") 'ellama-ask-line)
     (define-key map (kbd "a s") 'ellama-ask-selection)
     ;; text
@@ -243,6 +274,10 @@ SVG is intentionally out of scope for the initial image input support."
     (define-key map (kbd "x d") 'ellama-context-add-directory)
     (define-key map (kbd "x f") 'ellama-context-add-file)
     (define-key map (kbd "x I") 'ellama-context-add-image)
+    (define-key map (kbd "x A") 'ellama-context-add-audio)
+    (define-key map (kbd "x R") 'ellama-context-add-audio-recording)
+    (define-key map (kbd "x S") 'ellama-context-start-audio-recording)
+    (define-key map (kbd "x E") 'ellama-context-stop-audio-recording)
     (define-key map (kbd "x s") 'ellama-context-add-selection)
     (define-key map (kbd "x i") 'ellama-context-add-info-node)
     (define-key map (kbd "x m") 'ellama-context-manage)
@@ -675,6 +710,13 @@ into the buffer if the LLM call raises an error."
   "Minor mode for `ellama' buffers with active session compaction."
   :interactive nil
   :lighter " ellama:compacting")
+
+;;;###autoload
+(define-minor-mode ellama-audio-recording-mode
+  "Global minor mode enabled while Ellama records audio."
+  :global t
+  :interactive nil
+  :lighter " ellama:recording")
 
 (defvar-local ellama--change-group nil)
 
@@ -1191,15 +1233,58 @@ CONTEXT will be ignored.  Use global context instead.
     ("gif" "image/gif")
     (_ nil)))
 
+(defun ellama-audio-file-p (file-name)
+  "Return non-nil when FILE-NAME is a supported audio file."
+  (and (stringp file-name)
+       (file-exists-p file-name)
+       (let ((ext (file-name-extension file-name)))
+         (and ext
+              (member (downcase ext) ellama-audio-file-extensions)))))
+
+(defun ellama--audio-mime-type (file-name)
+  "Return audio MIME type for FILE-NAME, or nil when unsupported."
+  (pcase (downcase (or (file-name-extension file-name) ""))
+    ("wav" "audio/wav")
+    ("mp3" "audio/mpeg")
+    ("m4a" "audio/mp4")
+    ("aac" "audio/aac")
+    ("flac" "audio/flac")
+    ((or "ogg" "oga") "audio/ogg")
+    ("opus" "audio/opus")
+    ("webm" "audio/webm")
+    (_ nil)))
+
+(defun ellama-media-file-p (file-name)
+  "Return non-nil when FILE-NAME is a supported media file."
+  (or (ellama-image-file-p file-name)
+      (ellama-audio-file-p file-name)))
+
+(defun ellama--media-mime-type (file-name)
+  "Return media MIME type for FILE-NAME, or nil when unsupported."
+  (or (ellama--image-mime-type file-name)
+      (ellama--audio-mime-type file-name)))
+
+(defun ellama--media-kind (file-name)
+  "Return media kind symbol for FILE-NAME, or nil when unsupported."
+  (cond
+   ((ellama-image-file-p file-name) 'image)
+   ((ellama-audio-file-p file-name) 'audio)))
+
+(defun ellama--media-capability (file-name)
+  "Return provider capability needed for FILE-NAME."
+  (pcase (ellama--media-kind file-name)
+    ('image 'image-input)
+    ('audio 'audio-input)))
+
 (defun ellama--file-size (file-name)
   "Return FILE-NAME size in bytes."
   (file-attribute-size (file-attributes file-name)))
 
 (defun ellama--file-to-llm-media (file-name)
-  "Return `llm-media' for image FILE-NAME."
-  (let ((mime-type (ellama--image-mime-type file-name)))
-    (unless (and mime-type (ellama-image-file-p file-name))
-      (error "Unsupported image file: %s" file-name))
+  "Return `llm-media' for media FILE-NAME."
+  (let ((mime-type (ellama--media-mime-type file-name)))
+    (unless (and mime-type (ellama-media-file-p file-name))
+      (error "Unsupported media file: %s" file-name))
     (make-llm-media
      :mime-type mime-type
      :data (with-temp-buffer
@@ -1207,73 +1292,122 @@ CONTEXT will be ignored.  Use global context instead.
              (insert-file-contents-literally file-name)
              (buffer-string)))))
 
+(defun ellama--provider-supports-capability-p (provider capability)
+  "Return non-nil when PROVIDER supports CAPABILITY."
+  (condition-case nil
+      (memq capability (llm-capabilities provider))
+    (error nil)))
+
 (defun ellama--provider-supports-image-input-p (provider)
   "Return non-nil when PROVIDER supports image input."
-  (condition-case nil
-      (memq 'image-input (llm-capabilities provider))
-    (error nil)))
+  (ellama--provider-supports-capability-p provider 'image-input))
+
+(defun ellama--provider-supports-audio-input-p (provider)
+  "Return non-nil when PROVIDER supports audio input."
+  (ellama--provider-supports-capability-p provider 'audio-input))
+
+(defun ellama--normalize-media-files (files media-kind)
+  "Normalize FILES argument to a list of file names for MEDIA-KIND."
+  (cond
+   ((null files) nil)
+   ((stringp files) (list files))
+   ((listp files) files)
+   (t (error "%s must be a file name or list of file names" media-kind))))
 
 (defun ellama--normalize-image-files (images)
   "Normalize IMAGES argument to a list of file names."
-  (cond
-   ((null images) nil)
-   ((stringp images) (list images))
-   ((listp images) images)
-   (t (error "Images must be a file name or list of file names"))))
+  (ellama--normalize-media-files images "Images"))
+
+(defun ellama--normalize-audio-files (audios)
+  "Normalize AUDIOS argument to a list of file names."
+  (ellama--normalize-media-files audios "Audios"))
+
+(defun ellama--validate-media-file (file-name)
+  "Validate FILE-NAME as supported media input."
+  (unless (ellama-media-file-p file-name)
+    (pcase (downcase (or (file-name-extension file-name) ""))
+      ("svg" (error "SVG image input is not supported yet: %s" file-name))
+      (_ (error "Unsupported media file: %s" file-name)))))
+
+(defun ellama--validate-media-input (provider media-files)
+  "Validate MEDIA-FILES for PROVIDER."
+  (dolist (file-name media-files)
+    (ellama--validate-media-file file-name)
+    (let ((capability (ellama--media-capability file-name)))
+      (unless (ellama--provider-supports-capability-p provider capability)
+        (error "Provider %s does not support %s"
+               (if provider (llm-name provider) "unknown")
+               (pcase capability
+                 ('image-input "image input")
+                 ('audio-input "audio input")
+                 (_ (symbol-name capability))))))))
 
 (defun ellama--validate-image-input (provider image-files)
   "Validate IMAGE-FILES for PROVIDER."
-  (when image-files
-    (unless (ellama--provider-supports-image-input-p provider)
-      (error "Provider %s does not support image input"
-             (if provider (llm-name provider) "unknown")))
-    (dolist (file-name image-files)
-      (unless (ellama-image-file-p file-name)
-        (if (string= (downcase (or (file-name-extension file-name) "")) "svg")
-            (error "SVG image input is not supported yet: %s" file-name)
-          (error "Unsupported image file: %s" file-name))))))
+  (ellama--validate-media-input provider image-files))
 
-(defun ellama--prompt-content-with-images (prompt image-files)
-  "Return PROMPT content with IMAGE-FILES attached as media."
-  (if (not image-files)
+(defun ellama--validate-audio-input (provider audio-files)
+  "Validate AUDIO-FILES for PROVIDER."
+  (ellama--validate-media-input provider audio-files))
+
+(defun ellama--prompt-content-with-media (prompt media-files)
+  "Return PROMPT content with MEDIA-FILES attached as media."
+  (if (not media-files)
       prompt
     (apply #'llm-make-multipart
            prompt
-           (mapcar #'ellama--file-to-llm-media image-files))))
+           (mapcar #'ellama--file-to-llm-media media-files))))
 
-(defun ellama--image-link-for-mode (file-name mode)
-  "Return display link for image FILE-NAME in MODE."
+(defun ellama--prompt-content-with-images (prompt image-files)
+  "Return PROMPT content with IMAGE-FILES attached as media."
+  (ellama--prompt-content-with-media prompt image-files))
+
+(defun ellama--media-link-for-mode (file-name mode)
+  "Return display link for media FILE-NAME in MODE."
   (let ((label (file-name-nondirectory file-name)))
     (if (eq mode 'org-mode)
         (format "[[file:%s][%s]]" file-name label)
       (format "[%s](<%s>)" label file-name))))
 
-(defun ellama--prompt-display-with-images (prompt image-files mode)
-  "Return display PROMPT with IMAGE-FILES formatted for MODE."
-  (if (not image-files)
+(defun ellama--image-link-for-mode (file-name mode)
+  "Return display link for image FILE-NAME in MODE."
+  (ellama--media-link-for-mode file-name mode))
+
+(defun ellama--prompt-display-with-media (prompt media-files mode)
+  "Return display PROMPT with MEDIA-FILES formatted for MODE."
+  (if (not media-files)
       prompt
     (concat prompt
-            "\n\nImages:\n"
+            "\n\nMedia:\n"
             (string-join
              (mapcar (lambda (file-name)
-                       (ellama--image-link-for-mode file-name mode))
-                     image-files)
+                       (ellama--media-link-for-mode file-name mode))
+                     media-files)
              "\n"))))
+
+(defun ellama--prompt-display-with-images (prompt image-files mode)
+  "Return display PROMPT with IMAGE-FILES formatted for MODE."
+  (ellama--prompt-display-with-media prompt image-files mode))
 
 (defun ellama--media-placeholder (media &optional file-name)
   "Return text placeholder for MEDIA and optional FILE-NAME."
-  (format "[image: %s, %d bytes%s]"
-          (llm-media-mime-type media)
-          (length (llm-media-data media))
-          (if file-name
-              (format ", %s" file-name)
-            "")))
+  (let* ((mime-type (llm-media-mime-type media))
+         (kind (if (string-match-p "\\`\\([^/]+\\)/" mime-type)
+                   (match-string 1 mime-type)
+                 "media")))
+    (format "[%s: %s, %d bytes%s]"
+            kind
+            mime-type
+            (length (llm-media-data media))
+            (if file-name
+                (format ", %s" file-name)
+              ""))))
 
 (defun ellama--session-add-pending-tool-media (session file-name)
   "Add FILE-NAME to SESSION pending tool media."
   (let* ((path (expand-file-name file-name))
          (item (list :file path
-                     :mime-type (ellama--image-mime-type path)
+                     :mime-type (ellama--media-mime-type path)
                      :size (ellama--file-size path)))
          (pending (copy-sequence
                    (or (ellama--session-extra-get session :pending-tool-media)
@@ -1287,18 +1421,149 @@ CONTEXT will be ignored.  Use global context instead.
   (when-let* (((ellama-session-p session))
               (pending (ellama--session-extra-get
                         session :pending-tool-media)))
-    (ellama--validate-image-input
+    (ellama--validate-media-input
      provider
      (mapcar (lambda (item) (plist-get item :file)) pending))
     (llm-chat-prompt-append-response
      prompt
      (apply #'llm-make-multipart
-            "Images read by tools are attached for visual analysis."
+            "Media read by tools is attached for analysis."
             (mapcar (lambda (item)
                       (ellama--file-to-llm-media
                        (plist-get item :file)))
                     pending)))
     (ellama--session-extra-put session :pending-tool-media nil)))
+
+(defvar ellama--audio-recording-process nil
+  "Current audio recording process.")
+
+(defvar ellama--audio-recording-file nil
+  "Current audio recording output file.")
+
+(defun ellama--audio-recording-file-name ()
+  "Return a new audio recording file name."
+  (make-temp-file
+   "ellama-audio-" nil
+   (concat "." ellama-audio-recording-file-extension)))
+
+(defun ellama--default-audio-recording-command (&optional duration)
+  "Return default microphone recording command for current platform.
+DURATION nil means record until the process is interrupted."
+  (cond
+   ((and (eq system-type 'darwin)
+         (executable-find "afrecord"))
+    (append '("afrecord" "-f" "WAVE")
+            (when duration '("-d" "%d"))
+            '("%f")))
+   ((and (eq system-type 'gnu/linux)
+         (executable-find "arecord"))
+    (append '("arecord" "-q" "-f" "cd")
+            (when duration '("-d" "%d"))
+            '("%f")))))
+
+(defun ellama--audio-recording-command (file-name &optional duration)
+  "Return command list to record FILE-NAME for DURATION seconds."
+  (let ((command (cond
+                  ((functionp ellama-audio-recording-command)
+                   (funcall ellama-audio-recording-command file-name duration))
+                  ((and ellama-audio-recording-command
+                        (listp ellama-audio-recording-command))
+                   ellama-audio-recording-command)
+                  (t (ellama--default-audio-recording-command duration)))))
+    (unless command
+      (error "No audio recording command available; customize ellama-audio-recording-command"))
+    (when (and (not duration)
+               (seq-some (lambda (part)
+                           (string-match-p "%d" part))
+                         command))
+      (error "Audio recording command requires duration and cannot be used for start/stop recording"))
+    (mapcar (lambda (part)
+              (replace-regexp-in-string
+               "%d" (if duration (number-to-string duration) "")
+               (replace-regexp-in-string "%f" file-name part t t)
+               t t))
+            command)))
+
+;;;###autoload
+(defun ellama-record-audio (&optional duration file-name)
+  "Record audio from the microphone and return the recorded FILE-NAME.
+DURATION defaults to `ellama-audio-recording-duration'."
+  (interactive)
+  (let* ((duration (or duration
+                       (read-number "Record seconds: "
+                                    ellama-audio-recording-duration)))
+         (file-name (or file-name
+                        (ellama--audio-recording-file-name)))
+         (command (ellama--audio-recording-command file-name duration)))
+    (condition-case err
+        (let ((exit-code (apply #'call-process
+                                (car command) nil nil nil (cdr command))))
+          (unless (and (integerp exit-code) (zerop exit-code))
+            (error "Audio recording command exited with %s" exit-code))
+          (unless (ellama-audio-file-p file-name)
+            (error "Audio recording did not create a supported file: %s"
+                   file-name))
+          (when (called-interactively-p 'interactive)
+            (message "Recorded audio: %s" file-name))
+          file-name)
+      (error
+       (error "Failed to record audio: %s" (error-message-string err))))))
+
+;;;###autoload
+(defun ellama-start-audio-recording (&optional file-name)
+  "Start recording audio from the microphone.
+Return the output FILE-NAME.  Finish the recording with
+`ellama-stop-audio-recording'."
+  (interactive)
+  (when (and ellama--audio-recording-process
+             (process-live-p ellama--audio-recording-process))
+    (user-error "Audio recording is already running: %s"
+                ellama--audio-recording-file))
+  (let* ((file-name (or file-name (ellama--audio-recording-file-name)))
+         (command (ellama--audio-recording-command file-name))
+         (process (apply #'start-process
+                         "ellama-audio-recording"
+                         nil
+                         (car command)
+                         (cdr command))))
+    (set-process-query-on-exit-flag process nil)
+    (setq ellama--audio-recording-process process
+          ellama--audio-recording-file file-name)
+    (ellama-audio-recording-mode +1)
+    (force-mode-line-update t)
+    (when (called-interactively-p 'interactive)
+      (message "Recording audio; run ellama-stop-audio-recording to finish"))
+    file-name))
+
+;;;###autoload
+(defun ellama-stop-audio-recording ()
+  "Stop current microphone recording and return the recorded file name."
+  (interactive)
+  (unless ellama--audio-recording-process
+    (user-error "Audio recording is not running"))
+  (let ((process ellama--audio-recording-process)
+        (file-name ellama--audio-recording-file))
+    (when (process-live-p process)
+      (interrupt-process process)
+      (let ((limit (+ (float-time) 5)))
+        (while (and (process-live-p process)
+                    (< (float-time) limit))
+          (accept-process-output process 0.1)))
+      (when (process-live-p process)
+        (kill-process process)
+        (accept-process-output process 1)))
+    (unwind-protect
+        (progn
+          (unless (ellama-audio-file-p file-name)
+            (error "Audio recording did not create a supported file: %s"
+                   file-name))
+          (when (called-interactively-p 'interactive)
+            (message "Recorded audio: %s" file-name))
+          file-name)
+      (setq ellama--audio-recording-process nil
+            ellama--audio-recording-file nil)
+      (ellama-audio-recording-mode -1)
+      (force-mode-line-update t))))
 
 (defun ellama--session-compaction-buffer (session buffer)
   "Return live BUFFER for SESSION compaction status."
@@ -3471,6 +3736,10 @@ file by default.
 
 :images FILES -- attach image FILES to the prompt when provider supports it.
 
+:audios FILES -- attach audio FILES to the prompt when provider supports it.
+
+:media FILES -- attach media FILES to the prompt when provider supports it.
+
 :max-tokens INTEGER -- maximum number of tokens to generate.
 
 :on-error ON-ERROR -- ON-ERROR a function that's called with an error message on
@@ -3515,14 +3784,23 @@ failure (with BUFFER current).
           (ellama--normalize-image-files
            (or (plist-get args :images)
                (plist-get args :image))))
-         (context-images
+         (explicit-audios
+          (ellama--normalize-audio-files
+           (or (plist-get args :audios)
+               (plist-get args :audio))))
+         (explicit-media
+          (ellama--normalize-media-files
+           (plist-get args :media) "Media"))
+         (context-media
           (when (fboundp 'ellama-context-media)
             (ellama-context-media)))
-         (image-files (delete-dups (append explicit-images context-images)))
-         (_ (ellama--validate-image-input provider image-files))
+         (media-files
+          (delete-dups
+           (append explicit-media explicit-images explicit-audios context-media)))
+         (_ (ellama--validate-media-input provider media-files))
          (prompt-with-ctx (ellama-context-prompt-with-context prompt))
          (prompt-content
-          (ellama--prompt-content-with-images prompt-with-ctx image-files))
+          (ellama--prompt-content-with-media prompt-with-ctx media-files))
          (system (ellama-get-system-message (plist-get args :system)))
          (session-tools (and session
                              (ellama-session-extra session)
@@ -3859,9 +4137,9 @@ Will call `ellama-chat-done-callback' and ON-DONE on TEXT."
                                  #'ellama--translate-markdown-to-org-filter))))))
 
 (defun ellama--call-llm-with-translated-prompt
-    (buffer session translation-buffer &optional images)
+    (buffer session translation-buffer &optional media-files)
   "Call LLM with translated text in BUFFER with SESSION from TRANSLATION-BUFFER.
-IMAGES are attached to the translated prompt."
+MEDIA-FILES are attached to the translated prompt."
   (declare-function ellama-context-format "ellama-context")
   (lambda (result)
     (ellama-chat-done result)
@@ -3879,15 +4157,15 @@ IMAGES are attached to the translated prompt."
                 (ellama-get-nick-prefix-for-mode) " " ellama-assistant-nick ":\n")
         (ellama-stream result
                        :session session
-                       :images images
+                       :media media-files
                        :on-done (ellama--translate-generated-text-on-done translation-buffer)
                        :filter (when (derived-mode-p 'org-mode)
                                  #'ellama--translate-markdown-to-org-filter))))))
 
 (defun ellama--translate-interaction
-    (prompt translation-buffer buffer session &optional images)
+    (prompt translation-buffer buffer session &optional media-files)
   "Translate chat PROMPT in TRANSLATION-BUFFER for BUFFER with SESSION.
-IMAGES are attached to the final translated request."
+MEDIA-FILES are attached to the final translated request."
   (display-buffer translation-buffer (when ellama-chat-display-action-function
                                        `((ignore . (,ellama-chat-display-action-function)))))
   (with-current-buffer translation-buffer
@@ -3907,7 +4185,7 @@ IMAGES are attached to the final translated request."
                                #'ellama--translate-markdown-to-org-filter)
                      :on-done
                      (ellama--call-llm-with-translated-prompt
-                      buffer session translation-buffer images)))))
+                      buffer session translation-buffer media-files)))))
 
 ;;;###autoload
 (defun ellama-ask-image (image prompt &optional create-session &rest args)
@@ -3956,6 +4234,80 @@ If CREATE-SESSION set, create a new session."
    :ephemeral (plist-get args :ephemeral)))
 
 ;;;###autoload
+(defun ellama-ask-audio (audio prompt &optional create-session &rest args)
+  "Ask ellama PROMPT about AUDIO using ephemeral context.
+If CREATE-SESSION set, create a new session."
+  (interactive
+   (list (read-file-name "Audio: " nil nil t)
+         (read-string "Ask ellama: ")
+         current-prefix-arg))
+  (declare-function ellama-context-add-audio-file "ellama-context")
+  (require 'ellama-context)
+  (ellama-context-add-audio-file audio t)
+  (ellama-chat
+   prompt
+   create-session
+   :ephemeral (plist-get args :ephemeral)))
+
+;;;###autoload
+(defun ellama-chat-with-audio (audio prompt &optional create-session &rest args)
+  "Send PROMPT with AUDIO to ellama chat.
+If CREATE-SESSION set, create a new session."
+  (interactive
+   (list (read-file-name "Audio: " nil nil t)
+         (read-string "Ask ellama: ")
+         current-prefix-arg))
+  (apply #'ellama-ask-audio audio prompt create-session args))
+
+;;;###autoload
+(defun ellama-chat-with-audios (audios prompt &optional create-session &rest args)
+  "Send PROMPT with AUDIOS to ellama chat.
+If CREATE-SESSION set, create a new session."
+  (interactive
+   (let ((files (list (read-file-name "Audio: " nil nil t))))
+     (while (y-or-n-p "Add another audio file? ")
+       (push (read-file-name "Audio: " nil nil t) files))
+     (list (nreverse files)
+           (read-string "Ask ellama: ")
+           current-prefix-arg)))
+  (declare-function ellama-context-add-audio-file "ellama-context")
+  (require 'ellama-context)
+  (dolist (audio audios)
+    (ellama-context-add-audio-file audio t))
+  (ellama-chat
+   prompt
+   create-session
+   :ephemeral (plist-get args :ephemeral)))
+
+;;;###autoload
+(defun ellama-ask-audio-recording (duration prompt &optional create-session
+                                            &rest args)
+  "Record audio for DURATION seconds and ask ellama PROMPT about it.
+If CREATE-SESSION set, create a new session.
+ARGS contains options forwarded to `ellama-ask-audio'."
+  (interactive
+   (list (read-number "Record seconds: " ellama-audio-recording-duration)
+         (read-string "Ask ellama: ")
+         current-prefix-arg))
+  (apply #'ellama-ask-audio
+         (ellama-record-audio duration)
+         prompt
+         create-session
+         args))
+
+;;;###autoload
+(defun ellama-chat-with-audio-recording (duration prompt &optional create-session
+                                                  &rest args)
+  "Record audio for DURATION seconds and send PROMPT to ellama chat.
+If CREATE-SESSION set, create a new session.
+ARGS contains options forwarded to `ellama-ask-audio-recording'."
+  (interactive
+   (list (read-number "Record seconds: " ellama-audio-recording-duration)
+         (read-string "Ask ellama: ")
+         current-prefix-arg))
+  (apply #'ellama-ask-audio-recording duration prompt create-session args))
+
+;;;###autoload
 (defun ellama-chat (prompt &optional create-session &rest args)
   "Send PROMPT to ellama chat with conversation history.
 
@@ -3971,6 +4323,10 @@ ARGS contains keys for fine control.
 :system STR -- send STR to model as system message.
 
 :images FILES -- attach image FILES to the prompt when provider supports it.
+
+:audios FILES -- attach audio FILES to the prompt when provider supports it.
+
+:media FILES -- attach media FILES to the prompt when provider supports it.
 
 :max-tokens INTEGER -- maximum number of tokens to generate.
 
@@ -3990,6 +4346,14 @@ the full response text when the request completes (with BUFFER current)."
          (images (ellama--normalize-image-files
                   (or (plist-get args :images)
                       (plist-get args :image))))
+         (audios (ellama--normalize-audio-files
+                  (or (plist-get args :audios)
+                      (plist-get args :audio))))
+         (explicit-media
+          (ellama--normalize-media-files
+           (plist-get args :media) "Media"))
+         (display-media (delete-dups
+                         (append explicit-media images audios)))
          (provider (if current-prefix-arg
                        (eval (alist-get
                               (completing-read "Select model: " variants)
@@ -3997,11 +4361,11 @@ the full response text when the request completes (with BUFFER current)."
                      (or (plist-get args :provider)
                          ellama-provider
                          (ellama-get-first-ollama-chat-model))))
-         (context-images
+         (context-media
           (when (fboundp 'ellama-context-media)
             (ellama-context-media)))
-         (_ (ellama--validate-image-input
-             provider (delete-dups (append images context-images))))
+         (_ (ellama--validate-media-input
+             provider (delete-dups (append display-media context-media))))
          (ephemeral (plist-get args :ephemeral))
          (explicit-session-arg (plist-get args :session))
          (explicit-session-id (plist-get args :session-id))
@@ -4056,7 +4420,7 @@ the full response text when the request completes (with BUFFER current)."
         (add-hook 'org-ctrl-c-ctrl-c-hook #'ellama-chat-send-last-message 10 t)))
     (if ellama-chat-translation-enabled
         (ellama--translate-interaction
-         prompt translation-buffer buffer session images)
+         prompt translation-buffer buffer session display-media)
       (display-buffer
        buffer
        (when ellama-chat-display-action-function
@@ -4065,8 +4429,8 @@ the full response text when the request completes (with BUFFER current)."
         (save-excursion
           (goto-char (point-max))
           (let ((display-prompt
-                 (ellama--prompt-display-with-images
-                  prompt images
+                 (ellama--prompt-display-with-media
+                  prompt display-media
                   (if (derived-mode-p 'org-mode)
                       'org-mode
                     'markdown-mode))))
@@ -4087,7 +4451,7 @@ the full response text when the request completes (with BUFFER current)."
            prompt
            :session session
            :system system
-           :images images
+           :media display-media
            :max-tokens max-tokens
            :on-done (if donecb
                         (list 'ellama-chat-done donecb)

--- a/ellama.el
+++ b/ellama.el
@@ -5,7 +5,7 @@
 ;; Author: Sergey Kostyaev <sskostyaev@gmail.com>
 ;; URL: http://github.com/s-kostyaev/ellama
 ;; Keywords: help local tools
-;; Package-Requires: ((emacs "28.1") (llm "0.30.2") (plz "0.8") (transient "0.7") (compat "29.1") (yaml "1.2.3"))
+;; Package-Requires: ((emacs "28.1") (llm "0.31.1") (plz "0.8") (transient "0.7") (compat "29.1") (yaml "1.2.3"))
 ;; Version: 1.27.2
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;; Created: 8th Oct 2023

--- a/ellama.info
+++ b/ellama.info
@@ -744,8 +744,8 @@ argument generated text string.
      in the confirmation prompt.  Default value 50.
    • ‘ellama-tools-read-file-default-mode’: Default mode for the
      ‘read_file’ tool.  Use ‘auto’ to read text files as text and
-     supported image files as media, ‘text’ to force text reading, or
-     ‘image’ to force image handling.
+     supported image or audio files as media.  Use ‘text’, ‘image’, or
+     ‘audio’ to force a specific mode.
    • ‘ellama-tools-dlp-safe-read-file-regexps’: Canonical file-name
      regexps whose ‘read_file’-style outputs skip output DLP scans.
      Defaults to Ellama source files in the loaded Ellama directory.
@@ -953,16 +953,19 @@ and then removed.  Set ‘ellama-image-context-default-scope’ to
 reset.  The context transient menu also provides "Add Image"; combine it
 with ‘--ephemeral’ to force one-request image context.
 
-The built-in ‘read_file’ tool supports image files through a
+The built-in ‘read_file’ tool supports image and audio files through a
 configurable read mode:
 
-   • ‘auto’: read text files as text and queue supported image files as
-     image input
+   • ‘auto’: read text files as text and queue supported media files for
+     model input
    • ‘text’: force text reading, even for files with image-like
      extensions
    • ‘image’: force image handling and return a clear text error for
      unsupported image types, missing sessions, or providers without
      ‘image-input’
+   • ‘audio’: force audio handling and return a clear text error for
+     unsupported audio types, missing sessions, or providers without
+     ‘audio-input’
 
 Tool calls can request image handling explicitly:
 
@@ -995,6 +998,18 @@ ellama-chat-with-audio’ inside a chat workflow.  For several files, use
 ‘M-x ellama-chat-with-audios’.  These commands add audio as ephemeral
 context for the next request, so the file is not kept around unless you
 add it as persistent context yourself.
+
+The ‘read_file’ tool also accepts audio.  In ‘auto’ mode it recognizes
+supported audio extensions; use ‘audio’ to request audio handling
+explicitly:
+
+     {
+       "file_name": "/path/to/recording.wav",
+       "mode": "audio"
+     }
+
+The tool queues the recording as media for the next model turn.  It does
+not return binary audio as text.
 
 Programmatic calls can pass audio directly:
 
@@ -2862,47 +2877,47 @@ Node: Installation6373
 Node: Commands11387
 Node: Keymap22321
 Node: Configuration25880
-Node: Session Provider Keys42469
-Node: Session Compaction44330
-Node: Image Input46624
-Node: Audio Input48761
-Node: macOS microphone permission51227
-Node: Task Tool Subagents53388
-Node: Plan-and-Act Agent Loop56562
-Node: Edit Tool Shell Hooks59143
-Node: DLP for Tool Input/Output61436
-Node: SRT Filesystem Policy for Tools77435
-Node: Context Management83104
-Node: Transient Menus for Context Management84172
-Node: Managing the Context86246
-Node: Considerations87021
-Node: Minor modes87614
-Node: ellama-context-header-line-mode89602
-Node: ellama-context-header-line-global-mode90427
-Node: ellama-context-mode-line-mode91147
-Node: ellama-context-mode-line-global-mode91995
-Node: Ellama Session Header Line Mode92699
-Node: Enabling and Disabling93268
-Node: Customization93715
-Node: Ellama Session Mode Line Mode94003
-Node: Enabling and Disabling (1)94588
-Node: Customization (1)95035
-Node: Using Blueprints95329
-Node: Key Components of Ellama Blueprints95969
-Node: Creating and Managing Blueprints96576
-Node: Blueprints files97554
-Node: Variable Management97975
-Node: Keymap and Mode98428
-Node: Transient Menus99364
-Node: Running Blueprints programmatically99910
-Node: MCP Integration100497
-Node: Agent Skills101732
-Node: Directory Structure102095
-Node: Creating a Skill103122
-Node: How it works103497
-Node: Acknowledgments103888
-Node: Contributions104599
-Node: GNU Free Documentation License105273
+Node: Session Provider Keys42475
+Node: Session Compaction44336
+Node: Image Input46630
+Node: Audio Input48945
+Node: macOS microphone permission51764
+Node: Task Tool Subagents53925
+Node: Plan-and-Act Agent Loop57099
+Node: Edit Tool Shell Hooks59680
+Node: DLP for Tool Input/Output61973
+Node: SRT Filesystem Policy for Tools77972
+Node: Context Management83641
+Node: Transient Menus for Context Management84709
+Node: Managing the Context86783
+Node: Considerations87558
+Node: Minor modes88151
+Node: ellama-context-header-line-mode90139
+Node: ellama-context-header-line-global-mode90964
+Node: ellama-context-mode-line-mode91684
+Node: ellama-context-mode-line-global-mode92532
+Node: Ellama Session Header Line Mode93236
+Node: Enabling and Disabling93805
+Node: Customization94252
+Node: Ellama Session Mode Line Mode94540
+Node: Enabling and Disabling (1)95125
+Node: Customization (1)95572
+Node: Using Blueprints95866
+Node: Key Components of Ellama Blueprints96506
+Node: Creating and Managing Blueprints97113
+Node: Blueprints files98091
+Node: Variable Management98512
+Node: Keymap and Mode98965
+Node: Transient Menus99901
+Node: Running Blueprints programmatically100447
+Node: MCP Integration101034
+Node: Agent Skills102269
+Node: Directory Structure102632
+Node: Creating a Skill103659
+Node: How it works104034
+Node: Acknowledgments104425
+Node: Contributions105136
+Node: GNU Free Documentation License105810
 
 End Tag Table
 

--- a/ellama.info
+++ b/ellama.info
@@ -1011,6 +1011,12 @@ access for Emacs in System Settings under Privacy & Security >
 Microphone.  If Emacs runs in a terminal, allow access for that terminal
 instead.
 
+FFmpeg recordings use dynamic speech normalization by default.  This
+helps when the microphone input is quiet and reduces the chance that an
+audio model will invent speech from a weak signal.  Set
+‘ellama-audio-recording-ffmpeg-filter’ to nil to keep the original input
+level, or replace it with another FFmpeg audio filter.
+
 * Menu:
 
 * macOS microphone permission::
@@ -2853,43 +2859,43 @@ Node: Session Provider Keys42469
 Node: Session Compaction44330
 Node: Image Input46624
 Node: Audio Input48761
-Node: macOS microphone permission50505
-Node: Task Tool Subagents52666
-Node: Plan-and-Act Agent Loop55840
-Node: Edit Tool Shell Hooks58421
-Node: DLP for Tool Input/Output60714
-Node: SRT Filesystem Policy for Tools76713
-Node: Context Management82382
-Node: Transient Menus for Context Management83450
-Node: Managing the Context85524
-Node: Considerations86299
-Node: Minor modes86892
-Node: ellama-context-header-line-mode88880
-Node: ellama-context-header-line-global-mode89705
-Node: ellama-context-mode-line-mode90425
-Node: ellama-context-mode-line-global-mode91273
-Node: Ellama Session Header Line Mode91977
-Node: Enabling and Disabling92546
-Node: Customization92993
-Node: Ellama Session Mode Line Mode93281
-Node: Enabling and Disabling (1)93866
-Node: Customization (1)94313
-Node: Using Blueprints94607
-Node: Key Components of Ellama Blueprints95247
-Node: Creating and Managing Blueprints95854
-Node: Blueprints files96832
-Node: Variable Management97253
-Node: Keymap and Mode97706
-Node: Transient Menus98642
-Node: Running Blueprints programmatically99188
-Node: MCP Integration99775
-Node: Agent Skills101010
-Node: Directory Structure101373
-Node: Creating a Skill102400
-Node: How it works102775
-Node: Acknowledgments103166
-Node: Contributions103877
-Node: GNU Free Documentation License104551
+Node: macOS microphone permission50835
+Node: Task Tool Subagents52996
+Node: Plan-and-Act Agent Loop56170
+Node: Edit Tool Shell Hooks58751
+Node: DLP for Tool Input/Output61044
+Node: SRT Filesystem Policy for Tools77043
+Node: Context Management82712
+Node: Transient Menus for Context Management83780
+Node: Managing the Context85854
+Node: Considerations86629
+Node: Minor modes87222
+Node: ellama-context-header-line-mode89210
+Node: ellama-context-header-line-global-mode90035
+Node: ellama-context-mode-line-mode90755
+Node: ellama-context-mode-line-global-mode91603
+Node: Ellama Session Header Line Mode92307
+Node: Enabling and Disabling92876
+Node: Customization93323
+Node: Ellama Session Mode Line Mode93611
+Node: Enabling and Disabling (1)94196
+Node: Customization (1)94643
+Node: Using Blueprints94937
+Node: Key Components of Ellama Blueprints95577
+Node: Creating and Managing Blueprints96184
+Node: Blueprints files97162
+Node: Variable Management97583
+Node: Keymap and Mode98036
+Node: Transient Menus98972
+Node: Running Blueprints programmatically99518
+Node: MCP Integration100105
+Node: Agent Skills101340
+Node: Directory Structure101703
+Node: Creating a Skill102730
+Node: How it works103105
+Node: Acknowledgments103496
+Node: Contributions104207
+Node: GNU Free Documentation License104881
 
 End Tag Table
 

--- a/ellama.info
+++ b/ellama.info
@@ -358,13 +358,16 @@ File: ellama.info,  Node: Commands,  Next: Keymap,  Prev: Installation,  Up: Top
      using Ellama.
    • ‘ellama-provider-select’: Select ellama provider.
    • ‘ellama-select-model’: Change the current provider model
-     interactively.  The model transient supports Ollama,
-     OpenAI-compatible providers, and providers with a ‘chat-model’
-     slot.  URL editing is available when the provider has a ‘url’ slot.
-     It can also set the maximum number of output tokens.  Use "Reset
-     model fields" to clear model, temperature, context-length, and
-     max-token overrides and let the provider use its defaults; reset
-     values are shown as ‘default’ in the transient.
+     interactively.  The model transient can switch the provider type as
+     well as the model.  Built-in choices include Ollama,
+     OpenAI-compatible, OpenAI, Claude, Gemini, DeepSeek, OpenRouter,
+     Azure OpenAI, GitHub Models, Vertex AI, GPT4All, and Llama.cpp.  It
+     also supports providers with a ‘chat-model’ slot.  URL editing is
+     available when the provider has a ‘url’ slot.  It can also set the
+     maximum number of output tokens.  Use "Reset model fields" to clear
+     model, temperature, context-length, and max-token overrides and let
+     the provider use its defaults; reset values are shown as ‘default’
+     in the transient.
    • ‘ellama-code-complete’: Complete selected code or code in the
      current buffer according to a provided change using Ellama.
    • ‘ellama-code-add’: Generate and insert new code based on
@@ -683,6 +686,9 @@ argument generated text string.
      shell command execution.
    • ‘ellama-transient-system-show-limit’: Maximum number of system
      elements to show in transient.
+   • ‘ellama-transient-provider-types’: Provider types available for
+     interactive switching in the model transient.  Each entry specifies
+     the provider record type, display label, library, and constructor.
    • ‘ellama-session-remove-reasoning’: Remove internal reasoning from
      the session after ellama provide an answer.  This can improve
      long-term communication with reasoning models.  Enabled by default.
@@ -2726,45 +2732,45 @@ Tag Table:
 Node: Top2548
 Node: Installation6129
 Node: Commands11143
-Node: Keymap22077
-Node: Configuration25636
-Node: Session Provider Keys42231
-Node: Session Compaction44092
-Node: Image Input46386
-Node: Audio Input48701
-Node: macOS microphone permission51520
-Node: Task Tool Subagents53681
-Node: Plan-and-Act Agent Loop56855
-Node: Edit Tool Shell Hooks59436
-Node: DLP for Tool Input/Output61729
-Node: SRT Filesystem Policy for Tools77728
-Node: Context Management83397
-Node: Transient Menus for Context Management84465
-Node: Managing the Context86539
-Node: Considerations87314
-Node: Minor modes87641
-Node: ellama-context-header-line-mode88153
-Node: ellama-context-header-line-global-mode88771
-Node: ellama-context-mode-line-mode89175
-Node: ellama-context-mode-line-global-mode89754
-Node: ellama-session-header-line-mode90148
-Node: ellama-session-mode-line-mode90652
-Node: Using Blueprints91079
-Node: Key Components91475
-Node: Creating and Managing91834
-Node: Blueprint Files92472
-Node: Variables92891
-Node: Keymap and Mode93227
-Node: Transient Menus93751
-Node: Running Blueprints Programmatically94265
-Node: MCP Integration94819
-Node: Agent Skills95997
-Node: Directory Structure96396
-Node: Creating a Skill97376
-Node: How It Works97766
-Node: Acknowledgments98172
-Node: Contributions98858
-Node: GNU Free Documentation License99383
+Node: Keymap22275
+Node: Configuration25834
+Node: Session Provider Keys42649
+Node: Session Compaction44510
+Node: Image Input46804
+Node: Audio Input49119
+Node: macOS microphone permission51938
+Node: Task Tool Subagents54099
+Node: Plan-and-Act Agent Loop57273
+Node: Edit Tool Shell Hooks59854
+Node: DLP for Tool Input/Output62147
+Node: SRT Filesystem Policy for Tools78146
+Node: Context Management83815
+Node: Transient Menus for Context Management84883
+Node: Managing the Context86957
+Node: Considerations87732
+Node: Minor modes88059
+Node: ellama-context-header-line-mode88571
+Node: ellama-context-header-line-global-mode89189
+Node: ellama-context-mode-line-mode89593
+Node: ellama-context-mode-line-global-mode90172
+Node: ellama-session-header-line-mode90566
+Node: ellama-session-mode-line-mode91070
+Node: Using Blueprints91497
+Node: Key Components91893
+Node: Creating and Managing92252
+Node: Blueprint Files92890
+Node: Variables93309
+Node: Keymap and Mode93645
+Node: Transient Menus94169
+Node: Running Blueprints Programmatically94683
+Node: MCP Integration95237
+Node: Agent Skills96415
+Node: Directory Structure96814
+Node: Creating a Skill97794
+Node: How It Works98184
+Node: Acknowledgments98590
+Node: Contributions99276
+Node: GNU Free Documentation License99801
 
 End Tag Table
 

--- a/ellama.info
+++ b/ellama.info
@@ -999,10 +999,10 @@ Use ‘:media’ when a request mixes images and audio:
                   :media '("/path/to/screenshot.png"
                            "/path/to/notes.wav"))
 
-Microphone recording is available when the platform has a recording
-command.  On macOS Ellama uses ‘afrecord’.  On GNU/Linux it uses
-‘arecord’.  Set ‘ellama-audio-recording-command’ if you need another
-program or extra arguments.
+Ellama selects an installed microphone recorder automatically.  On macOS
+it tries FFmpeg and then SoX.  On GNU/Linux it tries ‘arecord’, FFmpeg,
+and then SoX.  Set ‘ellama-audio-recording-command’ if you need another
+program, input device, or extra arguments.
 
 For short messages, use ‘M-x ellama-ask-audio-recording’ or ‘M-x
 ellama-context-add-audio-recording’.  Ellama records for
@@ -2803,42 +2803,42 @@ Node: Session Provider Keys42423
 Node: Session Compaction44284
 Node: Image Input46578
 Node: Audio Input48715
-Node: Task Tool Subagents50933
-Node: Plan-and-Act Agent Loop54107
-Node: Edit Tool Shell Hooks56688
-Node: DLP for Tool Input/Output58981
-Node: SRT Filesystem Policy for Tools74980
-Node: Context Management80649
-Node: Transient Menus for Context Management81717
-Node: Managing the Context83791
-Node: Considerations84566
-Node: Minor modes85159
-Node: ellama-context-header-line-mode87147
-Node: ellama-context-header-line-global-mode87972
-Node: ellama-context-mode-line-mode88692
-Node: ellama-context-mode-line-global-mode89540
-Node: Ellama Session Header Line Mode90244
-Node: Enabling and Disabling90813
-Node: Customization91260
-Node: Ellama Session Mode Line Mode91548
-Node: Enabling and Disabling (1)92133
-Node: Customization (1)92580
-Node: Using Blueprints92874
-Node: Key Components of Ellama Blueprints93514
-Node: Creating and Managing Blueprints94121
-Node: Blueprints files95099
-Node: Variable Management95520
-Node: Keymap and Mode95973
-Node: Transient Menus96909
-Node: Running Blueprints programmatically97455
-Node: MCP Integration98042
-Node: Agent Skills99277
-Node: Directory Structure99640
-Node: Creating a Skill100667
-Node: How it works101042
-Node: Acknowledgments101433
-Node: Contributions102144
-Node: GNU Free Documentation License102818
+Node: Task Tool Subagents50959
+Node: Plan-and-Act Agent Loop54133
+Node: Edit Tool Shell Hooks56714
+Node: DLP for Tool Input/Output59007
+Node: SRT Filesystem Policy for Tools75006
+Node: Context Management80675
+Node: Transient Menus for Context Management81743
+Node: Managing the Context83817
+Node: Considerations84592
+Node: Minor modes85185
+Node: ellama-context-header-line-mode87173
+Node: ellama-context-header-line-global-mode87998
+Node: ellama-context-mode-line-mode88718
+Node: ellama-context-mode-line-global-mode89566
+Node: Ellama Session Header Line Mode90270
+Node: Enabling and Disabling90839
+Node: Customization91286
+Node: Ellama Session Mode Line Mode91574
+Node: Enabling and Disabling (1)92159
+Node: Customization (1)92606
+Node: Using Blueprints92900
+Node: Key Components of Ellama Blueprints93540
+Node: Creating and Managing Blueprints94147
+Node: Blueprints files95125
+Node: Variable Management95546
+Node: Keymap and Mode95999
+Node: Transient Menus96935
+Node: Running Blueprints programmatically97481
+Node: MCP Integration98068
+Node: Agent Skills99303
+Node: Directory Structure99666
+Node: Creating a Skill100693
+Node: How it works101068
+Node: Acknowledgments101459
+Node: Contributions102170
+Node: GNU Free Documentation License102844
 
 End Tag Table
 

--- a/ellama.info
+++ b/ellama.info
@@ -26,15 +26,16 @@ local model, and the same Ellama commands can be configured for
 OpenAI-compatible APIs, OpenAI, Claude, Gemini, Vertex, GPT4All,
 LlamaCpp, and other llm providers.  When a provider supports extra
 capabilities, Ellama uses them: streaming responses, model lists, image
-input, tool calls, token limits, and interactive model switching.
+and audio input, tool calls, token limits, and interactive model
+switching.
 
 Context is first-class.  A request can include buffers, files,
-directories, Info nodes, selections, and images.  Chat sessions can be
-saved, resumed, renamed, compacted manually, or compacted automatically
-before they run past the model context window.  The everyday commands
-cover translation, summarization, proofreading, code review and editing,
-extraction, formatting, commit-message generation, and provider
-selection.
+directories, Info nodes, selections, images, and audio files.  Chat
+sessions can be saved, resumed, renamed, compacted manually, or
+compacted automatically before they run past the model context window.
+The everyday commands cover translation, summarization, proofreading,
+code review and editing, extraction, formatting, commit-message
+generation, and provider selection.
 
 For tool-using agents, Ellama reads project instructions from
 ‘AGENTS.md’, can load reusable skills and blueprint prompts, and runs
@@ -82,15 +83,16 @@ local model, and the same Ellama commands can be configured for
 OpenAI-compatible APIs, OpenAI, Claude, Gemini, Vertex, GPT4All,
 LlamaCpp, and other llm providers.  When a provider supports extra
 capabilities, Ellama uses them: streaming responses, model lists, image
-input, tool calls, token limits, and interactive model switching.
+and audio input, tool calls, token limits, and interactive model
+switching.
 
 Context is first-class.  A request can include buffers, files,
-directories, Info nodes, selections, and images.  Chat sessions can be
-saved, resumed, renamed, compacted manually, or compacted automatically
-before they run past the model context window.  The everyday commands
-cover translation, summarization, proofreading, code review and editing,
-extraction, formatting, commit-message generation, and provider
-selection.
+directories, Info nodes, selections, images, and audio files.  Chat
+sessions can be saved, resumed, renamed, compacted manually, or
+compacted automatically before they run past the model context window.
+The everyday commands cover translation, summarization, proofreading,
+code review and editing, extraction, formatting, commit-message
+generation, and provider selection.
 
 For tool-using agents, Ellama reads project instructions from
 ‘AGENTS.md’, can load reusable skills and blueprint prompts, and runs
@@ -124,6 +126,7 @@ Configuration
 * Session Provider Keys::
 * Session Compaction::
 * Image Input::
+* Audio Input::
 * Task Tool Subagents::
 * Plan-and-Act Agent Loop::
 * Edit Tool Shell Hooks::
@@ -306,6 +309,26 @@ File: ellama.info,  Node: Commands,  Next: Keymap,  Prev: Installation,  Up: Top
    • ‘ellama-chat-with-images’: Ask Ellama about multiple image files.
      If called with universal argument (‘C-u’) will start new session
      with llm model interactive selection.
+   • ‘ellama-ask-audio’: Ask Ellama about one audio file by adding it as
+     ephemeral context for the request.  If called with universal
+     argument (‘C-u’) will start new session with llm model interactive
+     selection.
+   • ‘ellama-chat-with-audio’: Ask Ellama about one audio file.  If
+     called with universal argument (‘C-u’) will start new session with
+     llm model interactive selection.
+   • ‘ellama-chat-with-audios’: Ask Ellama about multiple audio files.
+     If called with universal argument (‘C-u’) will start new session
+     with llm model interactive selection.
+   • ‘ellama-ask-audio-recording’: Record a short audio message from the
+     microphone and ask Ellama about it.
+   • ‘ellama-chat-with-audio-recording’: Record a short audio message
+     from the microphone and send it to chat.
+   • ‘ellama-record-audio’: Record a short audio message from the
+     microphone and return the recorded file.
+   • ‘ellama-start-audio-recording’: Start microphone recording without
+     a fixed duration.
+   • ‘ellama-stop-audio-recording’: Stop microphone recording and return
+     the recorded file.
    • ‘ellama-write’: This command allows you to generate text using an
      LLM.  When called interactively, it prompts for an instruction that
      is then used to generate text based on the context.  If a region is
@@ -380,6 +403,13 @@ File: ellama.info,  Node: Commands,  Next: Keymap,  Prev: Installation,  Up: Top
      session context.
    • ‘ellama-context-add-file’: Add file to context.
    • ‘ellama-context-add-image’: Add image file to context.
+   • ‘ellama-context-add-audio’: Add audio file to context.
+   • ‘ellama-context-add-audio-recording’: Record a short audio message
+     and add it to context.
+   • ‘ellama-context-start-audio-recording’: Start microphone recording
+     without a fixed duration.
+   • ‘ellama-context-stop-audio-recording’: Stop microphone recording
+     and add the recorded file to context.
    • ‘ellama-context-add-directory’: Add all files in directory to the
      context.
    • ‘ellama-context-add-buffer’: Add buffer to context.
@@ -451,47 +481,54 @@ In any buffer where there is active ellama streaming, you can press
 Here is a table of keybindings and their associated functions in Ellama,
 using the ‘ellama-keymap-prefix’ prefix (not set by default):
 
-Keymap   Function                          Description
---------------------------------------------------------------------------
-"w"      ellama-write                      Write
-"c c"    ellama-code-complete              Code complete
-"c a"    ellama-code-add                   Code add
-"c e"    ellama-code-edit                  Code edit
-"c i"    ellama-code-improve               Code improve
-"c r"    ellama-code-review                Code review
-"c m"    ellama-generate-commit-message    Generate commit message
-"s s"    ellama-summarize                  Summarize
-"s w"    ellama-summarize-webpage          Summarize webpage
-"s c"    ellama-summarize-killring         Summarize killring
-"s l"    ellama-load-session               Session Load
-"s r"    ellama-session-rename             Session rename
-"s d"    ellama-session-delete             Session delete
-"s a"    ellama-session-switch             Session activate
-"P"      ellama-proofread                  Proofread
-"i w"    ellama-improve-wording            Improve wording
-"i g"    ellama-improve-grammar            Improve grammar and spelling
-"i c"    ellama-improve-conciseness        Improve conciseness
-"m l"    ellama-make-list                  Make list
-"m t"    ellama-make-table                 Make table
-"m f"    ellama-make-format                Make format
-"a a"    ellama-ask-about                  Ask about
-"a i"    ellama-chat                       Chat (ask interactively)
-"a I"    ellama-ask-image                  Ask image
-"a l"    ellama-ask-line                   Ask current line
-"a s"    ellama-ask-selection              Ask selection
-"t t"    ellama-translate                  Text translate
-"t b"    ellama-translate-buffer           Translate buffer
-"t e"    ellama-chat-translation-enable    Translation enable
-"t d"    ellama-chat-translation-disable   Translation disable
-"t c"    ellama-complete                   Text complete
-"d w"    ellama-define-word                Define word
-"x b"    ellama-context-add-buffer         Context add buffer
-"x f"    ellama-context-add-file           Context add file
-"x d"    ellama-context-add-directory      Context add directory
-"x s"    ellama-context-add-selection      Context add selection
-"x i"    ellama-context-add-info-node      Context add info node
-"x r"    ellama-context-reset              Context reset
-"p s"    ellama-provider-select            Provider select
+Keymap   Function                               Description
+-------------------------------------------------------------------------------
+"w"      ellama-write                           Write
+"c c"    ellama-code-complete                   Code complete
+"c a"    ellama-code-add                        Code add
+"c e"    ellama-code-edit                       Code edit
+"c i"    ellama-code-improve                    Code improve
+"c r"    ellama-code-review                     Code review
+"c m"    ellama-generate-commit-message         Generate commit message
+"s s"    ellama-summarize                       Summarize
+"s w"    ellama-summarize-webpage               Summarize webpage
+"s c"    ellama-summarize-killring              Summarize killring
+"s l"    ellama-load-session                    Session Load
+"s r"    ellama-session-rename                  Session rename
+"s d"    ellama-session-delete                  Session delete
+"s a"    ellama-session-switch                  Session activate
+"P"      ellama-proofread                       Proofread
+"i w"    ellama-improve-wording                 Improve wording
+"i g"    ellama-improve-grammar                 Improve grammar and spelling
+"i c"    ellama-improve-conciseness             Improve conciseness
+"m l"    ellama-make-list                       Make list
+"m t"    ellama-make-table                      Make table
+"m f"    ellama-make-format                     Make format
+"a a"    ellama-ask-about                       Ask about
+"a i"    ellama-chat                            Chat (ask interactively)
+"a I"    ellama-ask-image                       Ask image
+"a A"    ellama-ask-audio                       Ask audio
+"a R"    ellama-ask-audio-recording             Record audio and ask
+"a l"    ellama-ask-line                        Ask current line
+"a s"    ellama-ask-selection                   Ask selection
+"t t"    ellama-translate                       Text translate
+"t b"    ellama-translate-buffer                Translate buffer
+"t e"    ellama-chat-translation-enable         Translation enable
+"t d"    ellama-chat-translation-disable        Translation disable
+"t c"    ellama-complete                        Text complete
+"d w"    ellama-define-word                     Define word
+"x b"    ellama-context-add-buffer              Context add buffer
+"x f"    ellama-context-add-file                Context add file
+"x d"    ellama-context-add-directory           Context add directory
+"x I"    ellama-context-add-image               Context add image
+"x A"    ellama-context-add-audio               Context add audio
+"x R"    ellama-context-add-audio-recording     Context record audio
+"x S"    ellama-context-start-audio-recording   Start audio recording
+"x E"    ellama-context-stop-audio-recording    Stop audio recording
+"x s"    ellama-context-add-selection           Context add selection
+"x i"    ellama-context-add-info-node           Context add info node
+"x r"    ellama-context-reset                   Context reset
+"p s"    ellama-provider-select                 Provider select
 
 
 File: ellama.info,  Node: Configuration,  Next: Context Management,  Prev: Keymap,  Up: Top
@@ -780,6 +817,7 @@ argument generated text string.
 * Session Provider Keys::
 * Session Compaction::
 * Image Input::
+* Audio Input::
 * Task Tool Subagents::
 * Plan-and-Act Agent Loop::
 * Edit Tool Shell Hooks::
@@ -877,7 +915,7 @@ Example configuration:
      (setopt ellama-session-auto-compact-provider ellama-summarization-provider)
 
 
-File: ellama.info,  Node: Image Input,  Next: Task Tool Subagents,  Prev: Session Compaction,  Up: Configuration
+File: ellama.info,  Node: Image Input,  Next: Audio Input,  Prev: Session Compaction,  Up: Configuration
 
 4.3 Image Input
 ===============
@@ -930,9 +968,63 @@ Tool calls can request image handling explicitly:
      }
 
 
-File: ellama.info,  Node: Task Tool Subagents,  Next: Plan-and-Act Agent Loop,  Prev: Image Input,  Up: Configuration
+File: ellama.info,  Node: Audio Input,  Next: Task Tool Subagents,  Prev: Image Input,  Up: Configuration
 
-4.4 Task Tool Subagents
+4.4 Audio Input
+===============
+
+Ellama can also send audio files to providers with the ‘audio-input’
+capability.  The default supported extensions are WAV, MP3, M4A, AAC,
+FLAC, OGG, Opus and WebM.  Audio is sent as multipart media, the same
+transport used for image input.  Set ‘ellama-audio-file-extensions’ if
+your provider accepts another format.
+
+Use ‘M-x ellama-ask-audio’ for one audio file, or ‘M-x
+ellama-chat-with-audio’ inside a chat workflow.  For several files, use
+‘M-x ellama-chat-with-audios’.  These commands add audio as ephemeral
+context for the next request, so the file is not kept around unless you
+add it as persistent context yourself.
+
+Programmatic calls can pass audio directly:
+
+     (ellama-chat "Transcribe this note." nil
+                  :audios '("/path/to/note.wav"))
+
+     (ellama-stream "Summarize the meeting."
+                    :audio "/path/to/meeting.mp3")
+
+Use ‘:media’ when a request mixes images and audio:
+
+     (ellama-chat "Compare the screenshot with the spoken notes." nil
+                  :media '("/path/to/screenshot.png"
+                           "/path/to/notes.wav"))
+
+Microphone recording is available when the platform has a recording
+command.  On macOS Ellama uses ‘afrecord’.  On GNU/Linux it uses
+‘arecord’.  Set ‘ellama-audio-recording-command’ if you need another
+program or extra arguments.
+
+For short messages, use ‘M-x ellama-ask-audio-recording’ or ‘M-x
+ellama-context-add-audio-recording’.  Ellama records for
+‘ellama-audio-recording-duration’ seconds and writes a temporary WAV
+file by default.  Set ‘ellama-audio-recording-file-extension’ if your
+recorder writes another format.
+
+For longer messages, start and stop recording yourself:
+
+     M-x ellama-context-start-audio-recording
+     ...speak for as long as needed...
+     M-x ellama-context-stop-audio-recording
+
+While recording is active, the mode line shows ‘ellama:recording’.
+Stopping the recording adds the file to context, using
+‘ellama-audio-context-default-scope’ to decide whether it is ephemeral
+or persistent.
+
+
+File: ellama.info,  Node: Task Tool Subagents,  Next: Plan-and-Act Agent Loop,  Prev: Audio Input,  Up: Configuration
+
+4.5 Task Tool Subagents
 =======================
 
 The ‘task’ tool delegates work to an asynchronous sub-agent.  The parent
@@ -1002,7 +1094,7 @@ files.
 
 File: ellama.info,  Node: Plan-and-Act Agent Loop,  Next: Edit Tool Shell Hooks,  Prev: Task Tool Subagents,  Up: Configuration
 
-4.5 Plan-and-Act Agent Loop
+4.6 Plan-and-Act Agent Loop
 ===========================
 
 ‘ellama-plan-and-act’ runs a local agent in the current Ellama chat
@@ -1053,7 +1145,7 @@ canonical state is the session state used by the continuation handler.
 
 File: ellama.info,  Node: Edit Tool Shell Hooks,  Next: DLP for Tool Input/Output,  Prev: Plan-and-Act Agent Loop,  Up: Configuration
 
-4.6 Edit Tool Shell Hooks
+4.7 Edit Tool Shell Hooks
 =========================
 
 Projects can define shell commands that run around mutating edit tools:
@@ -1102,7 +1194,7 @@ and is not scanned by tool output DLP.
 
 File: ellama.info,  Node: DLP for Tool Input/Output,  Next: SRT Filesystem Policy for Tools,  Prev: Edit Tool Shell Hooks,  Up: Configuration
 
-4.7 DLP for Tool Input/Output
+4.8 DLP for Tool Input/Output
 =============================
 
 Ellama includes an optional DLP (Data Loss Prevention) layer for tool
@@ -1451,7 +1543,7 @@ Troubleshooting:
 
 File: ellama.info,  Node: SRT Filesystem Policy for Tools,  Prev: DLP for Tool Input/Output,  Up: Configuration
 
-4.8 SRT Filesystem Policy for Tools
+4.9 SRT Filesystem Policy for Tools
 ===================================
 
 When ‘ellama-tools-use-srt’ is non-nil, the ‘srt’ settings file is the
@@ -1685,6 +1777,8 @@ Context Commands:
         • “d” "Add Directory" ‘ellama-transient-add-directory’
         • “f” "Add File" ‘ellama-transient-add-file’
         • “I” "Add Image" ‘ellama-transient-add-image’
+        • “A” "Add Audio" ‘ellama-transient-add-audio’
+        • “R” "Record Audio" ‘ellama-transient-add-audio-recording’
         • “s” "Add Selection" ‘ellama-transient-add-selection’
         • “i” "Add Info Node" ‘ellama-transient-add-info-node’
    • Manage: Provides options for managing the global context.
@@ -1694,6 +1788,10 @@ Context Commands:
           Deletes an element by name.
         • “r” "Context reset" ‘ellama-context-reset’ - Clears the entire
           global context.
+   • Recording: Provides start and stop commands for long microphone
+     recordings.
+        • “S” "Start Recording" ‘ellama-transient-start-audio-recording’
+        • “E” "Stop Recording" ‘ellama-transient-stop-audio-recording’
    • Quit: (“q” "Quit" ‘transient-quit-one’) - Closes the context
      commands transient menu.
 
@@ -2696,50 +2794,51 @@ their use in free software.
 
 
 Tag Table:
-Node: Top2526
-Node: Installation6267
-Node: Commands11281
-Node: Keymap20632
-Node: Configuration23519
-Node: Session Provider Keys40092
-Node: Session Compaction41953
-Node: Image Input44247
-Node: Task Tool Subagents46392
-Node: Plan-and-Act Agent Loop49566
-Node: Edit Tool Shell Hooks52147
-Node: DLP for Tool Input/Output54440
-Node: SRT Filesystem Policy for Tools70439
-Node: Context Management76108
-Node: Transient Menus for Context Management77176
-Node: Managing the Context78855
-Node: Considerations79630
-Node: Minor modes80223
-Node: ellama-context-header-line-mode82211
-Node: ellama-context-header-line-global-mode83036
-Node: ellama-context-mode-line-mode83756
-Node: ellama-context-mode-line-global-mode84604
-Node: Ellama Session Header Line Mode85308
-Node: Enabling and Disabling85877
-Node: Customization86324
-Node: Ellama Session Mode Line Mode86612
-Node: Enabling and Disabling (1)87197
-Node: Customization (1)87644
-Node: Using Blueprints87938
-Node: Key Components of Ellama Blueprints88578
-Node: Creating and Managing Blueprints89185
-Node: Blueprints files90163
-Node: Variable Management90584
-Node: Keymap and Mode91037
-Node: Transient Menus91973
-Node: Running Blueprints programmatically92519
-Node: MCP Integration93106
-Node: Agent Skills94341
-Node: Directory Structure94704
-Node: Creating a Skill95731
-Node: How it works96106
-Node: Acknowledgments96497
-Node: Contributions97208
-Node: GNU Free Documentation License97882
+Node: Top2548
+Node: Installation6327
+Node: Commands11341
+Node: Keymap22275
+Node: Configuration25834
+Node: Session Provider Keys42423
+Node: Session Compaction44284
+Node: Image Input46578
+Node: Audio Input48715
+Node: Task Tool Subagents50933
+Node: Plan-and-Act Agent Loop54107
+Node: Edit Tool Shell Hooks56688
+Node: DLP for Tool Input/Output58981
+Node: SRT Filesystem Policy for Tools74980
+Node: Context Management80649
+Node: Transient Menus for Context Management81717
+Node: Managing the Context83791
+Node: Considerations84566
+Node: Minor modes85159
+Node: ellama-context-header-line-mode87147
+Node: ellama-context-header-line-global-mode87972
+Node: ellama-context-mode-line-mode88692
+Node: ellama-context-mode-line-global-mode89540
+Node: Ellama Session Header Line Mode90244
+Node: Enabling and Disabling90813
+Node: Customization91260
+Node: Ellama Session Mode Line Mode91548
+Node: Enabling and Disabling (1)92133
+Node: Customization (1)92580
+Node: Using Blueprints92874
+Node: Key Components of Ellama Blueprints93514
+Node: Creating and Managing Blueprints94121
+Node: Blueprints files95099
+Node: Variable Management95520
+Node: Keymap and Mode95973
+Node: Transient Menus96909
+Node: Running Blueprints programmatically97455
+Node: MCP Integration98042
+Node: Agent Skills99277
+Node: Directory Structure99640
+Node: Creating a Skill100667
+Node: How it works101042
+Node: Acknowledgments101433
+Node: Contributions102144
+Node: GNU Free Documentation License102818
 
 End Tag Table
 

--- a/ellama.info
+++ b/ellama.info
@@ -133,6 +133,10 @@ Configuration
 * DLP for Tool Input/Output::
 * SRT Filesystem Policy for Tools::
 
+Audio Input
+
+* macOS microphone permission::
+
 Context Management
 
 * Transient Menus for Context Management::
@@ -1006,6 +1010,49 @@ program, input device, or extra arguments.  On macOS, allow microphone
 access for Emacs in System Settings under Privacy & Security >
 Microphone.  If Emacs runs in a terminal, allow access for that terminal
 instead.
+
+* Menu:
+
+* macOS microphone permission::
+
+
+File: ellama.info,  Node: macOS microphone permission,  Up: Audio Input
+
+4.4.1 macOS microphone permission
+---------------------------------
+
+Emacs may be missing from the Microphone list when its application
+bundle has no ‘NSMicrophoneUsageDescription’ entry.  This can happen
+with some ‘emacs-plus’ builds.  In that case macOS cannot display the
+permission prompt, and FFmpeg may exit with ‘Abort trap: 6’ or report
+that no audio device was found.
+
+Quit Emacs, set ‘APP’ to the installed application bundle, and check the
+entry:
+
+     APP=/Applications/Emacs.app
+     plutil -extract NSMicrophoneUsageDescription raw \
+       "$APP/Contents/Info.plist"
+
+If ‘plutil’ reports that the key is missing, add it, re-sign the
+application, and reset the microphone permission:
+
+     /usr/libexec/PlistBuddy \
+       -c 'Add :NSMicrophoneUsageDescription string Ellama records audio from the microphone.' \
+       "$APP/Contents/Info.plist"
+
+     codesign --force --deep --sign - "$APP"
+
+     BUNDLE_ID=$(plutil -extract CFBundleIdentifier raw \
+       "$APP/Contents/Info.plist")
+     tccutil reset Microphone "$BUNDLE_ID"
+     open "$APP"
+
+Start a recording after Emacs opens.  macOS should now ask for
+microphone access, and Emacs should appear in System Settings under
+Privacy & Security > Microphone.  A package upgrade may replace the
+application bundle, so repeat these steps if the entry disappears after
+upgrading Emacs.
 
 For short messages, use ‘M-x ellama-ask-audio-recording’ or ‘M-x
 ellama-context-add-audio-recording’.  Ellama records for
@@ -2798,50 +2845,51 @@ their use in free software.
 
 Tag Table:
 Node: Top2548
-Node: Installation6327
-Node: Commands11341
-Node: Keymap22275
-Node: Configuration25834
-Node: Session Provider Keys42423
-Node: Session Compaction44284
-Node: Image Input46578
-Node: Audio Input48715
-Node: Task Tool Subagents51132
-Node: Plan-and-Act Agent Loop54306
-Node: Edit Tool Shell Hooks56887
-Node: DLP for Tool Input/Output59180
-Node: SRT Filesystem Policy for Tools75179
-Node: Context Management80848
-Node: Transient Menus for Context Management81916
-Node: Managing the Context83990
-Node: Considerations84765
-Node: Minor modes85358
-Node: ellama-context-header-line-mode87346
-Node: ellama-context-header-line-global-mode88171
-Node: ellama-context-mode-line-mode88891
-Node: ellama-context-mode-line-global-mode89739
-Node: Ellama Session Header Line Mode90443
-Node: Enabling and Disabling91012
-Node: Customization91459
-Node: Ellama Session Mode Line Mode91747
-Node: Enabling and Disabling (1)92332
-Node: Customization (1)92779
-Node: Using Blueprints93073
-Node: Key Components of Ellama Blueprints93713
-Node: Creating and Managing Blueprints94320
-Node: Blueprints files95298
-Node: Variable Management95719
-Node: Keymap and Mode96172
-Node: Transient Menus97108
-Node: Running Blueprints programmatically97654
-Node: MCP Integration98241
-Node: Agent Skills99476
-Node: Directory Structure99839
-Node: Creating a Skill100866
-Node: How it works101241
-Node: Acknowledgments101632
-Node: Contributions102343
-Node: GNU Free Documentation License103017
+Node: Installation6373
+Node: Commands11387
+Node: Keymap22321
+Node: Configuration25880
+Node: Session Provider Keys42469
+Node: Session Compaction44330
+Node: Image Input46624
+Node: Audio Input48761
+Node: macOS microphone permission50505
+Node: Task Tool Subagents52666
+Node: Plan-and-Act Agent Loop55840
+Node: Edit Tool Shell Hooks58421
+Node: DLP for Tool Input/Output60714
+Node: SRT Filesystem Policy for Tools76713
+Node: Context Management82382
+Node: Transient Menus for Context Management83450
+Node: Managing the Context85524
+Node: Considerations86299
+Node: Minor modes86892
+Node: ellama-context-header-line-mode88880
+Node: ellama-context-header-line-global-mode89705
+Node: ellama-context-mode-line-mode90425
+Node: ellama-context-mode-line-global-mode91273
+Node: Ellama Session Header Line Mode91977
+Node: Enabling and Disabling92546
+Node: Customization92993
+Node: Ellama Session Mode Line Mode93281
+Node: Enabling and Disabling (1)93866
+Node: Customization (1)94313
+Node: Using Blueprints94607
+Node: Key Components of Ellama Blueprints95247
+Node: Creating and Managing Blueprints95854
+Node: Blueprints files96832
+Node: Variable Management97253
+Node: Keymap and Mode97706
+Node: Transient Menus98642
+Node: Running Blueprints programmatically99188
+Node: MCP Integration99775
+Node: Agent Skills101010
+Node: Directory Structure101373
+Node: Creating a Skill102400
+Node: How it works102775
+Node: Acknowledgments103166
+Node: Contributions103877
+Node: GNU Free Documentation License104551
 
 End Tag Table
 

--- a/ellama.info
+++ b/ellama.info
@@ -982,12 +982,10 @@ FLAC, OGG, Opus and WebM.  Audio is sent as multipart media, the same
 transport used for image input.  Set ‘ellama-audio-file-extensions’ if
 your provider accepts another format.
 
-Provider capability alone is not enough: the installed ‘llm’ package
-must also serialize audio for that provider.  Gemini and Vertex use
-their native inline media format.  OpenAI-compatible Chat Completions
-requires ‘input_audio’ support in ‘llm’.  Ellama checks this before
-sending a request and rejects older ‘llm’ versions that would
-incorrectly encode audio as an image.
+Audio transport depends on the installed ‘llm’ package.  Ellama requires
+‘llm’ 0.31.1 or newer, which includes audio serialization for
+OpenAI-compatible and Ollama providers.  Gemini and Vertex use their
+native inline media format.
 
 Use ‘M-x ellama-ask-audio’ for one audio file, or ‘M-x
 ellama-chat-with-audio’ inside a chat workflow.  For several files, use
@@ -2738,39 +2736,39 @@ Node: Session Provider Keys42649
 Node: Session Compaction44510
 Node: Image Input46804
 Node: Audio Input49119
-Node: macOS microphone permission51938
-Node: Task Tool Subagents54099
-Node: Plan-and-Act Agent Loop57273
-Node: Edit Tool Shell Hooks59854
-Node: DLP for Tool Input/Output62147
-Node: SRT Filesystem Policy for Tools78146
-Node: Context Management83815
-Node: Transient Menus for Context Management84883
-Node: Managing the Context86957
-Node: Considerations87732
-Node: Minor modes88059
-Node: ellama-context-header-line-mode88571
-Node: ellama-context-header-line-global-mode89189
-Node: ellama-context-mode-line-mode89593
-Node: ellama-context-mode-line-global-mode90172
-Node: ellama-session-header-line-mode90566
-Node: ellama-session-mode-line-mode91070
-Node: Using Blueprints91497
-Node: Key Components91893
-Node: Creating and Managing92252
-Node: Blueprint Files92890
-Node: Variables93309
-Node: Keymap and Mode93645
-Node: Transient Menus94169
-Node: Running Blueprints Programmatically94683
-Node: MCP Integration95237
-Node: Agent Skills96415
-Node: Directory Structure96814
-Node: Creating a Skill97794
-Node: How It Works98184
-Node: Acknowledgments98590
-Node: Contributions99276
-Node: GNU Free Documentation License99801
+Node: macOS microphone permission51787
+Node: Task Tool Subagents53948
+Node: Plan-and-Act Agent Loop57122
+Node: Edit Tool Shell Hooks59703
+Node: DLP for Tool Input/Output61996
+Node: SRT Filesystem Policy for Tools77995
+Node: Context Management83664
+Node: Transient Menus for Context Management84732
+Node: Managing the Context86806
+Node: Considerations87581
+Node: Minor modes87908
+Node: ellama-context-header-line-mode88420
+Node: ellama-context-header-line-global-mode89038
+Node: ellama-context-mode-line-mode89442
+Node: ellama-context-mode-line-global-mode90021
+Node: ellama-session-header-line-mode90415
+Node: ellama-session-mode-line-mode90919
+Node: Using Blueprints91346
+Node: Key Components91742
+Node: Creating and Managing92101
+Node: Blueprint Files92739
+Node: Variables93158
+Node: Keymap and Mode93494
+Node: Transient Menus94018
+Node: Running Blueprints Programmatically94532
+Node: MCP Integration95086
+Node: Agent Skills96264
+Node: Directory Structure96663
+Node: Creating a Skill97643
+Node: How It Works98033
+Node: Acknowledgments98439
+Node: Contributions99125
+Node: GNU Free Documentation License99650
 
 End Tag Table
 

--- a/ellama.info
+++ b/ellama.info
@@ -149,34 +149,24 @@ Minor modes
 * ellama-context-header-line-global-mode::
 * ellama-context-mode-line-mode::
 * ellama-context-mode-line-global-mode::
-* Ellama Session Header Line Mode::
-* Ellama Session Mode Line Mode::
-
-Ellama Session Header Line Mode
-
-* Enabling and Disabling::
-* Customization::
-
-Ellama Session Mode Line Mode
-
-* Enabling and Disabling: Enabling and Disabling (1).
-* Customization: Customization (1).
+* ellama-session-header-line-mode::
+* ellama-session-mode-line-mode::
 
 Using Blueprints
 
-* Key Components of Ellama Blueprints::
-* Creating and Managing Blueprints::
-* Blueprints files::
-* Variable Management::
+* Key Components::
+* Creating and Managing::
+* Blueprint Files::
+* Variables::
 * Keymap and Mode::
 * Transient Menus::
-* Running Blueprints programmatically::
+* Running Blueprints Programmatically::
 
 Agent Skills
 
 * Directory Structure::
 * Creating a Skill::
-* How it works::
+* How It Works::
 
 
 
@@ -1898,13 +1888,9 @@ File: ellama.info,  Node: Considerations,  Prev: Managing the Context,  Up: Cont
 5.3 Considerations
 ==================
 
-Large Language Models possess limited context window sizes, restricting
-the total amount of text they can process.  Be mindful of the size of
-your context to avoid truncation or performance degradation.  Irrelevant
-context can dilute the information and hinder the LLM’s focus.  Ensure
-context remains up-to-date for accurate information.  Experimentation
-with different approaches to context management can optimize performance
-for specific use cases.
+Keep context size in check.  LLMs have finite context windows, and
+irrelevant information wastes tokens and can distract the model.  Remove
+or refresh stale context before switching tasks.
 
 
 File: ellama.info,  Node: Minor modes,  Next: Using Blueprints,  Prev: Context Management,  Up: Top
@@ -1912,33 +1898,9 @@ File: ellama.info,  Node: Minor modes,  Next: Using Blueprints,  Prev: Context M
 6 Minor modes
 *************
 
-The Ellama package for Emacs offers a suite of minor modes designed to
-enhance the user experience by providing context-specific information
-directly within the editor's interface.  These minor modes focus on
-updating both the header line and mode line with relevant details,
-making it easier to manage and navigate multiple sessions and buffers.
-
-Key features include:
-
-   • Context Header Line Modes: ‘ellama-context-header-line-mode’ and
-     its global counterpart, ‘ellama-context-header-line-global-mode’,
-     update the header line to display what elements are added to the
-     global Ellama context.  This is particularly useful for keeping
-     track of what information is currently in context.
-   • Context Mode Line Modes: Similarly, ‘ellama-context-mode-line-mode’
-     and ‘ellama-context-mode-line-global-mode’ provide information
-     about the current global context directly within the mode line,
-     ensuring that users always have relevant information at a glance.
-   • Session Header Line Mode: ‘ellama-session-header-line-mode’ and its
-     global version display the current Ellama session ID in the header
-     line, helping users manage multiple sessions efficiently.
-   • Session Mode Line Mode: ‘ellama-session-mode-line-mode’ and its
-     global counterpart offer an additional way to track session IDs by
-     displaying them in the mode line.
-
-These minor modes are easily toggled on or off using specific commands,
-providing flexibility for users who may want to enable these features
-globally across all buffers or selectively within individual buffers.
+These minor modes show the current context or session ID in the header
+line or mode line.  Each has a buffer-local command and a global
+variant.
 
 * Menu:
 
@@ -1946,8 +1908,8 @@ globally across all buffers or selectively within individual buffers.
 * ellama-context-header-line-global-mode::
 * ellama-context-mode-line-mode::
 * ellama-context-mode-line-global-mode::
-* Ellama Session Header Line Mode::
-* Ellama Session Mode Line Mode::
+* ellama-session-header-line-mode::
+* ellama-session-mode-line-mode::
 
 
 File: ellama.info,  Node: ellama-context-header-line-mode,  Next: ellama-context-header-line-global-mode,  Up: Minor modes
@@ -1955,21 +1917,15 @@ File: ellama.info,  Node: ellama-context-header-line-mode,  Next: ellama-context
 6.1 ellama-context-header-line-mode
 ===================================
 
-Description: Toggle the Ellama Context header line mode.  This minor
-mode updates the header line to display context-specific information.
+Shows the Ellama context in the header line.  By default, the line
+appears only when the global or ephemeral context is not empty.  Set
+‘ellama-context-line-always-visible’ to keep it visible.
 
-Usage: To enable or disable ‘ellama-context-header-line-mode’, use the
-command:
+‘M-x ellama-context-header-line-mode’ toggles this mode.
 
-M-x ellama-context-header-line-mode
-
-When enabled, this mode adds a hook to ‘window-state-change-hook’ to
-update the header line whenever the window state changes.  It also calls
-‘ellama-context-update-header-line’ to initialize the header line with
-context-specific information.
-
-When disabled, it removes the evaluation of ‘(:eval
-(ellama-context-line))’ from ‘header-line-format’.
+The mode updates the display on ‘window-state-change-hook’.  When
+disabled, it removes ‘(:eval (ellama-context-line))’ from
+‘header-line-format’.
 
 
 File: ellama.info,  Node: ellama-context-header-line-global-mode,  Next: ellama-context-mode-line-mode,  Prev: ellama-context-header-line-mode,  Up: Minor modes
@@ -1977,18 +1933,9 @@ File: ellama.info,  Node: ellama-context-header-line-global-mode,  Next: ellama-
 6.2 ellama-context-header-line-global-mode
 ==========================================
 
-Description: Globalized version of ‘ellama-context-header-line-mode’.
-This mode ensures that ‘ellama-context-header-line-mode’ is enabled in
-all buffers.
+Enables ‘ellama-context-header-line-mode’ in all buffers automatically.
 
-Usage: To enable or disable ‘ellama-context-header-line-global-mode’,
-use the command:
-
-M-x ellama-context-header-line-global-mode
-
-This globalized minor mode provides a convenient way to ensure that
-context-specific header line information is always available, regardless
-of the buffer being edited.
+‘M-x ellama-context-header-line-global-mode’ toggles this global mode.
 
 
 File: ellama.info,  Node: ellama-context-mode-line-mode,  Next: ellama-context-mode-line-global-mode,  Prev: ellama-context-header-line-global-mode,  Up: Minor modes
@@ -1996,117 +1943,49 @@ File: ellama.info,  Node: ellama-context-mode-line-mode,  Next: ellama-context-m
 6.3 ellama-context-mode-line-mode
 =================================
 
-Description: Toggle the Ellama Context mode line mode.  This minor mode
-updates the mode line to display context-specific information.
+Shows the Ellama context in the mode line.  It follows the same
+visibility rules as ‘ellama-context-header-line-mode’.
 
-Usage: To enable or disable ‘ellama-context-mode-line-mode’, use the
-command:
+‘M-x ellama-context-mode-line-mode’ toggles this mode.
 
-M-x ellama-context-mode-line-mode
-
-When enabled, this mode adds a hook to ‘window-state-change-hook’ to
-update the mode line whenever the window state changes.  It also calls
-‘ellama-context-update-mode-line’ to initialize the mode line with
-context-specific information.
-
-When disabled, it removes the evaluation of ‘(:eval
-(ellama-context-line))’ from ‘mode-line-format’.
+The mode updates the display on ‘window-state-change-hook’.  When
+disabled, it removes ‘(:eval (ellama-context-line))’ from
+‘mode-line-format’.
 
 
-File: ellama.info,  Node: ellama-context-mode-line-global-mode,  Next: Ellama Session Header Line Mode,  Prev: ellama-context-mode-line-mode,  Up: Minor modes
+File: ellama.info,  Node: ellama-context-mode-line-global-mode,  Next: ellama-session-header-line-mode,  Prev: ellama-context-mode-line-mode,  Up: Minor modes
 
 6.4 ellama-context-mode-line-global-mode
 ========================================
 
-Description: Globalized version of ‘ellama-context-mode-line-mode’.
-This mode ensures that ‘ellama-context-mode-line-mode’ is enabled in all
-buffers.
+Enables ‘ellama-context-mode-line-mode’ in all buffers automatically.
 
-Usage: To enable or disable ‘ellama-context-mode-line-global-mode’, use
-the command:
-
-M-x ellama-context-mode-line-global-mode
-
-This globalized minor mode provides a convenient way to ensure that
-context-specific mode line information is always available, regardless
-of the buffer being edited.
+‘M-x ellama-context-mode-line-global-mode’ toggles this global mode.
 
 
-File: ellama.info,  Node: Ellama Session Header Line Mode,  Next: Ellama Session Mode Line Mode,  Prev: ellama-context-mode-line-global-mode,  Up: Minor modes
+File: ellama.info,  Node: ellama-session-header-line-mode,  Next: ellama-session-mode-line-mode,  Prev: ellama-context-mode-line-global-mode,  Up: Minor modes
 
-6.5 Ellama Session Header Line Mode
+6.5 ellama-session-header-line-mode
 ===================================
 
-The ‘ellama-session-header-line-mode’ is a minor mode that allows you to
-display the current Ellama session ID in the header line of your Emacs
-buffers.  This feature helps keep track of which session you are working
-with, especially useful when managing multiple sessions.
+Displays the current Ellama session ID in the header line.
 
-* Menu:
+‘M-x ellama-session-header-line-mode’ toggles it in the current buffer;
+‘M-x ellama-session-header-line-global-mode’ toggles it globally.
 
-* Enabling and Disabling::
-* Customization::
+The session ID uses the customizable ‘ellama-face’ face.
 
 
-File: ellama.info,  Node: Enabling and Disabling,  Next: Customization,  Up: Ellama Session Header Line Mode
+File: ellama.info,  Node: ellama-session-mode-line-mode,  Prev: ellama-session-header-line-mode,  Up: Minor modes
 
-6.5.1 Enabling and Disabling
-----------------------------
-
-To enable this mode, use the following command:
-     M-x ellama-session-header-line-mode
-
-This will toggle the display of the session ID in the header line.  You
-can also enable or disable it globally across all buffers using:
-     M-x ellama-session-header-line-global-mode
-
-
-File: ellama.info,  Node: Customization,  Prev: Enabling and Disabling,  Up: Ellama Session Header Line Mode
-
-6.5.2 Customization
--------------------
-
-The session ID is displayed with a customizable face called
-‘ellama-face’.  You can customize this face to change its appearance.
-
-
-File: ellama.info,  Node: Ellama Session Mode Line Mode,  Prev: Ellama Session Header Line Mode,  Up: Minor modes
-
-6.6 Ellama Session Mode Line Mode
+6.6 ellama-session-mode-line-mode
 =================================
 
-The ‘ellama-session-mode-line-mode’ is a minor mode that allows you to
-display the current Ellama session ID in the mode line of your Emacs
-buffers.  This feature provides an additional way to keep track of which
-session you are working with, especially useful when managing multiple
-sessions.
+Displays the current Ellama session ID in the mode line.
 
-* Menu:
-
-* Enabling and Disabling: Enabling and Disabling (1).
-* Customization: Customization (1).
-
-
-File: ellama.info,  Node: Enabling and Disabling (1),  Next: Customization (1),  Up: Ellama Session Mode Line Mode
-
-6.6.1 Enabling and Disabling
-----------------------------
-
-To enable this mode, use the following command:
-     M-x ellama-session-mode-line-mode
-
-This will toggle the display of the session ID in the mode line.  You
-can also enable or disable it globally across all buffers using:
-     M-x ellama-session-mode-line-global-mode
-
-
-File: ellama.info,  Node: Customization (1),  Prev: Enabling and Disabling (1),  Up: Ellama Session Mode Line Mode
-
-6.6.2 Customization
--------------------
-
-The session ID is displayed with a customizable face called
-‘ellama-face’.  You can customize this face to change its appearance.
+‘M-x ellama-session-mode-line-mode’ toggles it in the current buffer;
+‘M-x ellama-session-mode-line-global-mode’ toggles it globally.  This
+mode also uses ‘ellama-face’.
 
 
 File: ellama.info,  Node: Using Blueprints,  Next: MCP Integration,  Prev: Minor modes,  Up: Top
@@ -2114,131 +1993,106 @@ File: ellama.info,  Node: Using Blueprints,  Next: MCP Integration,  Prev: Minor
 7 Using Blueprints
 ******************
 
-Blueprints in Ellama refer to predefined templates or structures that
-facilitate the creation and management of chat sessions.  These
-blueprints are designed to streamline the process of generating
-consistent and high-quality outputs by providing a structured framework
-for interactions.
+Blueprints are predefined templates for starting chat sessions with a
+reusable prompt.
 
 * Menu:
 
-* Key Components of Ellama Blueprints::
-* Creating and Managing Blueprints::
-* Blueprints files::
-* Variable Management::
+* Key Components::
+* Creating and Managing::
+* Blueprint Files::
+* Variables::
 * Keymap and Mode::
 * Transient Menus::
-* Running Blueprints programmatically::
+* Running Blueprints Programmatically::
 
 
-File: ellama.info,  Node: Key Components of Ellama Blueprints,  Next: Creating and Managing Blueprints,  Up: Using Blueprints
+File: ellama.info,  Node: Key Components,  Next: Creating and Managing,  Up: Using Blueprints
 
-7.1 Key Components of Ellama Blueprints
-=======================================
+7.1 Key Components
+==================
 
-  1. Act: This is the primary identifier for a blueprint, representing
-     the
-action or purpose of the blueprint.
-  1. Prompt: The content that will be used to initiate the chat session.
-     This
-can include instructions, context, or any other relevant information
-needed to guide the conversation.
-  1. For Developers: A flag indicating whether the blueprint is intended
-     for
-developers.
+  1. Act: The blueprint's primary identifier (its name).
+  2. Prompt: Text that initializes the chat session, including
+     instructions and context.
+  3. For Developers: A flag marking the blueprint as developer-facing.
 
 
-File: ellama.info,  Node: Creating and Managing Blueprints,  Next: Blueprints files,  Prev: Key Components of Ellama Blueprints,  Up: Using Blueprints
+File: ellama.info,  Node: Creating and Managing,  Next: Blueprint Files,  Prev: Key Components,  Up: Using Blueprints
 
-7.2 Creating and Managing Blueprints
-====================================
+7.2 Creating and Managing
+=========================
 
-Ellama provides several functions to create, select, and manage
-blueprints:
-
-   • ‘ellama-blueprint-create’: This function allows users to create a
-     new blueprint from the current buffer.  It prompts for a name and
-     whether the blueprint is for developers, then saves the content of
-     the current buffer as the prompt.
-
-   • ‘ellama-blueprint-new’: This function creates a new buffer for a
-     blueprint, optionally inserting the content of the current region
-     if active.
-
-   • ‘ellama-blueprint-select’: This function allows users to select a
-     prompt from the collection of blueprints.  It filters prompts based
-     on whether they are for developers and their source (user-defined,
-     community, or all).
+   • ‘ellama-blueprint-create’: Create a blueprint from the current
+     buffer.  Prompts for a name and developer flag, then saves the
+     buffer content as the prompt.
+   • ‘ellama-blueprint-new’: Create a new buffer for a blueprint,
+     optionally inserting the current region if active.
+   • ‘ellama-blueprint-select’: Select a prompt and optionally filter by
+     developer status or source (user, community, files, or all
+     sources).
 
 
-File: ellama.info,  Node: Blueprints files,  Next: Variable Management,  Prev: Creating and Managing Blueprints,  Up: Using Blueprints
+File: ellama.info,  Node: Blueprint Files,  Next: Variables,  Prev: Creating and Managing,  Up: Using Blueprints
 
-7.3 Blueprints files
-====================
+7.3 Blueprint Files
+===================
 
-You can also store blueprints as plain text files.  You can store it
-globally inside ‘ellama-blueprint-global-dir’ or locally in the project
-local directory ‘ellama-blueprint-local-dir’ with
-‘ellama-blueprint-file-extensions’.
+Store blueprints as plain text files.  Place them in:
 
-
-File: ellama.info,  Node: Variable Management,  Next: Keymap and Mode,  Prev: Blueprints files,  Up: Using Blueprints
+   • Global: ‘ellama-blueprint-global-dir’
+   • Project-local: ‘ellama-blueprint-local-dir’, relative to the
+     project root
 
-7.4 Variable Management
-=======================
-
-Blueprints can include variables that need to be filled before running
-the chat session.  Ellama provides command to fill these variables:
-
-   • ‘ellama-blueprint-fill-variables’: Prompts the user to enter values
-     for variables found in the current buffer and fills them.
+Files use extensions from ‘ellama-blueprint-file-extensions’.
 
 
-File: ellama.info,  Node: Keymap and Mode,  Next: Transient Menus,  Prev: Variable Management,  Up: Using Blueprints
+File: ellama.info,  Node: Variables,  Next: Keymap and Mode,  Prev: Blueprint Files,  Up: Using Blueprints
+
+7.4 Variables
+=============
+
+Blueprints can include variables that must be filled before the session
+runs.
+
+   • ‘ellama-blueprint-fill-variables’: Prompts for values for all
+     variables found in the current buffer.
+
+
+File: ellama.info,  Node: Keymap and Mode,  Next: Transient Menus,  Prev: Variables,  Up: Using Blueprints
 
 7.5 Keymap and Mode
 ===================
 
-Ellama provides a local keymap ‘ellama-blueprint-mode-map’ for managing
-blueprints within buffers.  The mode includes key bindings for sending
-the buffer to a new chat session, killing the current buffer, creating a
-new blueprint, and filling variables.
+‘ellama-blueprint-mode’ is a text-mode derivative that highlights
+variables in curly braces and sets up local keybindings:
 
-The ‘ellama-blueprint-mode’ is a derived mode from ‘text-mode’,
-providing syntax highlighting for variables in curly braces and setting
-up the local keymap.
-
-When in ‘ellama-blueprint-mode’, the following keybindings are
-available:
-
-   • ‘C-c C-c’: Send current buffer to a new chat session and kill the
-     current buffer.
+   • ‘C-c C-c’: Open ‘ellama-transient-blueprint-mode-menu’.  From there
+     you can send the buffer to a chat, set it as the system message,
+     create a blueprint, or fill variables.
    • ‘C-c C-k’: Kill the current buffer.
-   • ‘C-c c’: Create a blueprint from the current buffer.
-   • ‘C-c v’: Fill variables in the current blueprint.
 
 
-File: ellama.info,  Node: Transient Menus,  Next: Running Blueprints programmatically,  Prev: Keymap and Mode,  Up: Using Blueprints
+File: ellama.info,  Node: Transient Menus,  Next: Running Blueprints Programmatically,  Prev: Keymap and Mode,  Up: Using Blueprints
 
 7.6 Transient Menus
 ===================
 
-Ellama includes transient menus for easy access to blueprint commands.
-The ‘ellama-transient-blueprint-menu’ provides options for chatting with
-a selected blueprint, creating a new blueprint, and quitting the menu.
-
-The ‘ellama-transient-main-menu’ integrates the blueprint menu into the
-main menu, providing a comprehensive interface for all Ellama commands.
+   • ‘ellama-transient-blueprint-menu’: Chat with a selected blueprint,
+     create a new blueprint, or manage saved blueprints.
+   • ‘ellama-transient-blueprint-mode-menu’: Act on the blueprint in the
+     current buffer.
+   • ‘ellama-transient-main-menu’: Integrates the blueprint menu into
+     the main interface.
 
 
-File: ellama.info,  Node: Running Blueprints programmatically,  Prev: Transient Menus,  Up: Using Blueprints
+File: ellama.info,  Node: Running Blueprints Programmatically,  Prev: Transient Menus,  Up: Using Blueprints
 
-7.7 Running Blueprints programmatically
+7.7 Running Blueprints Programmatically
 =======================================
 
-The ‘ellama-blueprint-run’ function initiates a chat session using a
-specified blueprint.  It pre-fills variables based on the provided
-arguments.
+‘ellama-blueprint-run’ starts a chat session with a blueprint,
+pre-filling variables from the provided arguments.
 
      (defun my-chat-with-morpheus ()
        "Start chat with Morpheus."
@@ -2253,10 +2107,10 @@ File: ellama.info,  Node: MCP Integration,  Next: Agent Skills,  Prev: Using Blu
 8 MCP Integration
 *****************
 
-You can also use MCP (Model Context Protocol) tools with ‘ellama’.  You
-need Emacs 30 or higher version.  Install ‘mcp.el’ -
-<https://github.com/lizqwerscott/mcp.el>.  For example to add web search
-capability to ‘ellama’ you can add duckduckgo mcp server
+Use MCP (Model Context Protocol) tools with ‘ellama’.  Requires Emacs
+30+ and the ‘mcp.el’ package: <https://github.com/lizqwerscott/mcp.el>
+
+Example: adding DuckDuckGo search via the duckduckgo-mcp-server
 (<https://github.com/nickclyde/duckduckgo-mcp-server>):
 
      (use-package mcp
@@ -2277,8 +2131,8 @@ capability to ‘ellama’ you can add duckduckgo mcp server
                                (list tool)))
                     tools)))))
 
-When ‘:categoryp t’ is used, ellama derives stable MCP tool identity as
-‘<category>/<tool-name>’ (for example ‘mcp-ddg/search’).  Irreversible
+When ‘:categoryp t’ is used, Ellama derives a stable MCP tool identity
+as ‘<category>/<tool-name>’ (e.g., ‘mcp-ddg/search’).  Irreversible
 policy, audit, and overrides are keyed by this identity.
 
 
@@ -2287,15 +2141,15 @@ File: ellama.info,  Node: Agent Skills,  Next: Acknowledgments,  Prev: MCP Integ
 9 Agent Skills
 **************
 
-Ellama supports *Agent Skills*, a lightweight format for extending AI
-capabilities.  Skills are loaded into context only when needed
-(Progressive Disclosure).
+Agent Skills provide instructions and supporting files for specific
+tasks.  Ellama adds only skill metadata to the initial context; the
+model reads the full instructions when it chooses a skill.
 
 * Menu:
 
 * Directory Structure::
 * Creating a Skill::
-* How it works::
+* How It Works::
 
 
 File: ellama.info,  Node: Directory Structure,  Next: Creating a Skill,  Up: Agent Skills
@@ -2303,17 +2157,16 @@ File: ellama.info,  Node: Directory Structure,  Next: Creating a Skill,  Up: Age
 9.1 Directory Structure
 =======================
 
-Ellama looks for skills in two locations:
-  1. *Global*: ‘~/.emacs.d/ellama/skills/’ (Customizable via
-‘ellama-skills-global-path’)
-  1. *Project-Local*: ‘skills/’ inside your project root (Customizable
-     via
-‘ellama-skills-local-path’)
+Ellama searches for skills in two locations:
 
-A skill is a directory containing a ‘SKILL.md’ file.  This file includes
-metadata (‘name’ and ‘description’, at minimum) and instructions that
-tell an agent how to perform a specific task.  Skills can also bundle
-scripts, templates, and reference materials.
+  1. *Global*: ‘~/.emacs.d/ellama/skills/’ by default, customizable via
+     ‘ellama-skills-global-path’.
+  2. *Project-local*: ‘skills/’ inside the project root, customizable
+     via ‘ellama-skills-local-path’.
+
+A skill is a directory containing a ‘SKILL.md’ file with metadata
+(‘name’, ‘description’) and instructions for the agent.  Skills can also
+include scripts, templates, and reference materials.
 
      my-project/
      └──skills/
@@ -2324,12 +2177,12 @@ scripts, templates, and reference materials.
             └── assets/           # Optional: templates, resources
 
 
-File: ellama.info,  Node: Creating a Skill,  Next: How it works,  Prev: Directory Structure,  Up: Agent Skills
+File: ellama.info,  Node: Creating a Skill,  Next: How It Works,  Prev: Directory Structure,  Up: Agent Skills
 
 9.2 Creating a Skill
 ====================
 
-SKILL.md must contain YAML frontmatter:
+The ‘SKILL.md’ file must include YAML frontmatter:
 
      ---
      name: pdf-processing
@@ -2340,15 +2193,17 @@ SKILL.md must contain YAML frontmatter:
      To extract text from a PDF...
 
 
-File: ellama.info,  Node: How it works,  Prev: Creating a Skill,  Up: Agent Skills
+File: ellama.info,  Node: How It Works,  Prev: Creating a Skill,  Up: Agent Skills
 
-9.3 How it works
+9.3 How It Works
 ================
 
-*Auto-Discovery*: Ellama scans skill directories automatically whenever
-a chat starts.  *Context*: Skill metadata (name, description, location)
-is injected into the system prompt.  *Activation*: The LLM uses the
-read_file tool to load the SKILL.md content when needed.
+   • *Auto-Discovery*: Ellama scans skill directories when each chat
+     starts.
+   • *Context*: Skill metadata (name, description, location) is injected
+     into the system prompt.
+   • *Activation*: The LLM loads ‘SKILL.md’ content via ‘read_file’ when
+     needed.
 
 
 File: ellama.info,  Node: Acknowledgments,  Next: Contributions,  Prev: Agent Skills,  Up: Top
@@ -2356,19 +2211,18 @@ File: ellama.info,  Node: Acknowledgments,  Next: Contributions,  Prev: Agent Sk
 10 Acknowledgments
 ******************
 
-Thanks Jeffrey Morgan (https://github.com/jmorganca) for excellent
-project ollama (https://github.com/jmorganca/ollama).  This project
-cannot exist without it.
+Thanks to Jeffrey Morgan (https://github.com/jmorganca) for ollama
+(https://github.com/jmorganca/ollama), which made this project possible.
 
-Thanks zweifisch (https://github.com/zweifisch) - I got some ideas from
-ollama.el (https://github.com/zweifisch/ollama) what ollama client in
-Emacs can do.
+Thanks zweifisch (https://github.com/zweifisch) for ideas from ollama.el
+(https://github.com/zweifisch/ollama) about what an Emacs ollama client
+can do.
 
-Thanks Dr.  David A.  Kunz (https://github.com/David-Kunz) - I got more
-ideas from gen.nvim (https://github.com/David-Kunz/gen.nvim).
+Thanks Dr.  David A.  Kunz (https://github.com/David-Kunz) for ideas
+from gen.nvim (https://github.com/David-Kunz/gen.nvim).
 
-Thanks Andrew Hyatt (https://github.com/ahyatt) for ‘llm’ library.
-Without it only ‘ollama’ would be supported.
+Thanks Andrew Hyatt (https://github.com/ahyatt) for the ‘llm’ library,
+without which only ‘ollama’ would be supported.
 
 
 File: ellama.info,  Node: Contributions,  Next: GNU Free Documentation License,  Prev: Acknowledgments,  Up: Top
@@ -2376,16 +2230,13 @@ File: ellama.info,  Node: Contributions,  Next: GNU Free Documentation License, 
 11 Contributions
 ****************
 
-To contribute, submit a pull request or report a bug.  This library is
-part of GNU ELPA; major contributions must be from someone with FSF
-papers.  Alternatively, you can write a module and share it on a
-different archive like MELPA.
+Submit a pull request or report a bug.  This library is part of GNU
+ELPA; major contributions require FSF papers.  Alternatively, write a
+module for MELPA.
 
-For local validation, run ‘make check-elisp’ before pushing Elisp
-changes.  It formats Elisp files, byte-compiles, runs the ERT suite,
-native-compiles, and runs checkdoc.  Byte and native compilation
-warnings are treated as failures, so warnings block the same way test
-failures do.
+Run ‘make check-elisp’ before pushing Elisp changes.  It formats Elisp
+files, byte-compiles, runs the ERT suite, native-compiles, and runs
+checkdoc.  Byte and native compilation warnings are treated as failures.
 
 
 File: ellama.info,  Node: GNU Free Documentation License,  Prev: Contributions,  Up: Top
@@ -2873,51 +2724,47 @@ their use in free software.
 
 Tag Table:
 Node: Top2548
-Node: Installation6373
-Node: Commands11387
-Node: Keymap22321
-Node: Configuration25880
-Node: Session Provider Keys42475
-Node: Session Compaction44336
-Node: Image Input46630
-Node: Audio Input48945
-Node: macOS microphone permission51764
-Node: Task Tool Subagents53925
-Node: Plan-and-Act Agent Loop57099
-Node: Edit Tool Shell Hooks59680
-Node: DLP for Tool Input/Output61973
-Node: SRT Filesystem Policy for Tools77972
-Node: Context Management83641
-Node: Transient Menus for Context Management84709
-Node: Managing the Context86783
-Node: Considerations87558
-Node: Minor modes88151
-Node: ellama-context-header-line-mode90139
-Node: ellama-context-header-line-global-mode90964
-Node: ellama-context-mode-line-mode91684
-Node: ellama-context-mode-line-global-mode92532
-Node: Ellama Session Header Line Mode93236
-Node: Enabling and Disabling93805
-Node: Customization94252
-Node: Ellama Session Mode Line Mode94540
-Node: Enabling and Disabling (1)95125
-Node: Customization (1)95572
-Node: Using Blueprints95866
-Node: Key Components of Ellama Blueprints96506
-Node: Creating and Managing Blueprints97113
-Node: Blueprints files98091
-Node: Variable Management98512
-Node: Keymap and Mode98965
-Node: Transient Menus99901
-Node: Running Blueprints programmatically100447
-Node: MCP Integration101034
-Node: Agent Skills102269
-Node: Directory Structure102632
-Node: Creating a Skill103659
-Node: How it works104034
-Node: Acknowledgments104425
-Node: Contributions105136
-Node: GNU Free Documentation License105810
+Node: Installation6129
+Node: Commands11143
+Node: Keymap22077
+Node: Configuration25636
+Node: Session Provider Keys42231
+Node: Session Compaction44092
+Node: Image Input46386
+Node: Audio Input48701
+Node: macOS microphone permission51520
+Node: Task Tool Subagents53681
+Node: Plan-and-Act Agent Loop56855
+Node: Edit Tool Shell Hooks59436
+Node: DLP for Tool Input/Output61729
+Node: SRT Filesystem Policy for Tools77728
+Node: Context Management83397
+Node: Transient Menus for Context Management84465
+Node: Managing the Context86539
+Node: Considerations87314
+Node: Minor modes87641
+Node: ellama-context-header-line-mode88153
+Node: ellama-context-header-line-global-mode88771
+Node: ellama-context-mode-line-mode89175
+Node: ellama-context-mode-line-global-mode89754
+Node: ellama-session-header-line-mode90148
+Node: ellama-session-mode-line-mode90652
+Node: Using Blueprints91079
+Node: Key Components91475
+Node: Creating and Managing91834
+Node: Blueprint Files92472
+Node: Variables92891
+Node: Keymap and Mode93227
+Node: Transient Menus93751
+Node: Running Blueprints Programmatically94265
+Node: MCP Integration94819
+Node: Agent Skills95997
+Node: Directory Structure96396
+Node: Creating a Skill97376
+Node: How It Works97766
+Node: Acknowledgments98172
+Node: Contributions98858
+Node: GNU Free Documentation License99383
 
 End Tag Table
 

--- a/ellama.info
+++ b/ellama.info
@@ -983,6 +983,13 @@ FLAC, OGG, Opus and WebM.  Audio is sent as multipart media, the same
 transport used for image input.  Set ‘ellama-audio-file-extensions’ if
 your provider accepts another format.
 
+Provider capability alone is not enough: the installed ‘llm’ package
+must also serialize audio for that provider.  Gemini and Vertex use
+their native inline media format.  OpenAI-compatible Chat Completions
+requires ‘input_audio’ support in ‘llm’.  Ellama checks this before
+sending a request and rejects older ‘llm’ versions that would
+incorrectly encode audio as an image.
+
 Use ‘M-x ellama-ask-audio’ for one audio file, or ‘M-x
 ellama-chat-with-audio’ inside a chat workflow.  For several files, use
 ‘M-x ellama-chat-with-audios’.  These commands add audio as ephemeral
@@ -2859,43 +2866,43 @@ Node: Session Provider Keys42469
 Node: Session Compaction44330
 Node: Image Input46624
 Node: Audio Input48761
-Node: macOS microphone permission50835
-Node: Task Tool Subagents52996
-Node: Plan-and-Act Agent Loop56170
-Node: Edit Tool Shell Hooks58751
-Node: DLP for Tool Input/Output61044
-Node: SRT Filesystem Policy for Tools77043
-Node: Context Management82712
-Node: Transient Menus for Context Management83780
-Node: Managing the Context85854
-Node: Considerations86629
-Node: Minor modes87222
-Node: ellama-context-header-line-mode89210
-Node: ellama-context-header-line-global-mode90035
-Node: ellama-context-mode-line-mode90755
-Node: ellama-context-mode-line-global-mode91603
-Node: Ellama Session Header Line Mode92307
-Node: Enabling and Disabling92876
-Node: Customization93323
-Node: Ellama Session Mode Line Mode93611
-Node: Enabling and Disabling (1)94196
-Node: Customization (1)94643
-Node: Using Blueprints94937
-Node: Key Components of Ellama Blueprints95577
-Node: Creating and Managing Blueprints96184
-Node: Blueprints files97162
-Node: Variable Management97583
-Node: Keymap and Mode98036
-Node: Transient Menus98972
-Node: Running Blueprints programmatically99518
-Node: MCP Integration100105
-Node: Agent Skills101340
-Node: Directory Structure101703
-Node: Creating a Skill102730
-Node: How it works103105
-Node: Acknowledgments103496
-Node: Contributions104207
-Node: GNU Free Documentation License104881
+Node: macOS microphone permission51227
+Node: Task Tool Subagents53388
+Node: Plan-and-Act Agent Loop56562
+Node: Edit Tool Shell Hooks59143
+Node: DLP for Tool Input/Output61436
+Node: SRT Filesystem Policy for Tools77435
+Node: Context Management83104
+Node: Transient Menus for Context Management84172
+Node: Managing the Context86246
+Node: Considerations87021
+Node: Minor modes87614
+Node: ellama-context-header-line-mode89602
+Node: ellama-context-header-line-global-mode90427
+Node: ellama-context-mode-line-mode91147
+Node: ellama-context-mode-line-global-mode91995
+Node: Ellama Session Header Line Mode92699
+Node: Enabling and Disabling93268
+Node: Customization93715
+Node: Ellama Session Mode Line Mode94003
+Node: Enabling and Disabling (1)94588
+Node: Customization (1)95035
+Node: Using Blueprints95329
+Node: Key Components of Ellama Blueprints95969
+Node: Creating and Managing Blueprints96576
+Node: Blueprints files97554
+Node: Variable Management97975
+Node: Keymap and Mode98428
+Node: Transient Menus99364
+Node: Running Blueprints programmatically99910
+Node: MCP Integration100497
+Node: Agent Skills101732
+Node: Directory Structure102095
+Node: Creating a Skill103122
+Node: How it works103497
+Node: Acknowledgments103888
+Node: Contributions104599
+Node: GNU Free Documentation License105273
 
 End Tag Table
 

--- a/ellama.info
+++ b/ellama.info
@@ -1002,7 +1002,10 @@ Use ‘:media’ when a request mixes images and audio:
 Ellama selects an installed microphone recorder automatically.  On macOS
 it tries FFmpeg and then SoX.  On GNU/Linux it tries ‘arecord’, FFmpeg,
 and then SoX.  Set ‘ellama-audio-recording-command’ if you need another
-program, input device, or extra arguments.
+program, input device, or extra arguments.  On macOS, allow microphone
+access for Emacs in System Settings under Privacy & Security >
+Microphone.  If Emacs runs in a terminal, allow access for that terminal
+instead.
 
 For short messages, use ‘M-x ellama-ask-audio-recording’ or ‘M-x
 ellama-context-add-audio-recording’.  Ellama records for
@@ -2803,42 +2806,42 @@ Node: Session Provider Keys42423
 Node: Session Compaction44284
 Node: Image Input46578
 Node: Audio Input48715
-Node: Task Tool Subagents50959
-Node: Plan-and-Act Agent Loop54133
-Node: Edit Tool Shell Hooks56714
-Node: DLP for Tool Input/Output59007
-Node: SRT Filesystem Policy for Tools75006
-Node: Context Management80675
-Node: Transient Menus for Context Management81743
-Node: Managing the Context83817
-Node: Considerations84592
-Node: Minor modes85185
-Node: ellama-context-header-line-mode87173
-Node: ellama-context-header-line-global-mode87998
-Node: ellama-context-mode-line-mode88718
-Node: ellama-context-mode-line-global-mode89566
-Node: Ellama Session Header Line Mode90270
-Node: Enabling and Disabling90839
-Node: Customization91286
-Node: Ellama Session Mode Line Mode91574
-Node: Enabling and Disabling (1)92159
-Node: Customization (1)92606
-Node: Using Blueprints92900
-Node: Key Components of Ellama Blueprints93540
-Node: Creating and Managing Blueprints94147
-Node: Blueprints files95125
-Node: Variable Management95546
-Node: Keymap and Mode95999
-Node: Transient Menus96935
-Node: Running Blueprints programmatically97481
-Node: MCP Integration98068
-Node: Agent Skills99303
-Node: Directory Structure99666
-Node: Creating a Skill100693
-Node: How it works101068
-Node: Acknowledgments101459
-Node: Contributions102170
-Node: GNU Free Documentation License102844
+Node: Task Tool Subagents51132
+Node: Plan-and-Act Agent Loop54306
+Node: Edit Tool Shell Hooks56887
+Node: DLP for Tool Input/Output59180
+Node: SRT Filesystem Policy for Tools75179
+Node: Context Management80848
+Node: Transient Menus for Context Management81916
+Node: Managing the Context83990
+Node: Considerations84765
+Node: Minor modes85358
+Node: ellama-context-header-line-mode87346
+Node: ellama-context-header-line-global-mode88171
+Node: ellama-context-mode-line-mode88891
+Node: ellama-context-mode-line-global-mode89739
+Node: Ellama Session Header Line Mode90443
+Node: Enabling and Disabling91012
+Node: Customization91459
+Node: Ellama Session Mode Line Mode91747
+Node: Enabling and Disabling (1)92332
+Node: Customization (1)92779
+Node: Using Blueprints93073
+Node: Key Components of Ellama Blueprints93713
+Node: Creating and Managing Blueprints94320
+Node: Blueprints files95298
+Node: Variable Management95719
+Node: Keymap and Mode96172
+Node: Transient Menus97108
+Node: Running Blueprints programmatically97654
+Node: MCP Integration98241
+Node: Agent Skills99476
+Node: Directory Structure99839
+Node: Creating a Skill100866
+Node: How it works101241
+Node: Acknowledgments101632
+Node: Contributions102343
+Node: GNU Free Documentation License103017
 
 End Tag Table
 

--- a/scripts/check-copyright.sh
+++ b/scripts/check-copyright.sh
@@ -1,0 +1,64 @@
+#\!/bin/bash
+# check-copyright.sh - Verify FSF copyright headers in Elisp files
+#
+# Usage: ./scripts/check-copyright.sh [project-dir]
+# If project-dir is omitted, uses the current directory.
+#
+# Exit code 0 = all files have FSF copyright, 1 = some files missing it
+
+set -euo pipefail
+
+# Determine project root (resolve to absolute path)
+PROJECT_DIR="${1:-$(pwd)}"
+PROJECT_DIR="$(cd "$PROJECT_DIR" && pwd)"
+
+echo "=== Ellama FSF Copyright Checker ==="
+echo "Project directory: $PROJECT_DIR"
+echo ""
+
+# Find all .el files in the project (excluding compiled and vendor files)
+# Using -not instead of \! to avoid shell history expansion issues
+EL_FILES=$(find "$PROJECT_DIR" -name "*.el" -type f \
+     -not -name "*.elc" \
+     -not -name "*.eln" \
+     -not -name ".dir-locals.el" \
+     -not -path "*/deps/*" \
+     -not -path "*/30_*" \
+     -not -path "*/elpa/*" \
+     -not -path "*/tests/fixtures/*/workspace/*" \
+     | sort)
+
+echo "--- Checking FSF copyright headers ---"
+echo ""
+
+MISSING_FILES=()
+
+for file in $EL_FILES; do
+    # Check if file contains Free Software Foundation copyright
+    HAS_COPYRIGHT=0
+    if head -20 "$file" | grep -q "Free Software Foundation"; then
+        HAS_COPYRIGHT=1
+    fi
+    if [ "$HAS_COPYRIGHT" -eq 0 ]; then
+        MISSING_FILES+=("$file")
+    fi
+done
+
+FILE_COUNT=$(echo "$EL_FILES" | wc -l)
+MISSING_COUNT=${#MISSING_FILES[@]}
+
+echo "Scanned $FILE_COUNT Elisp files."
+echo ""
+
+if [ "$MISSING_COUNT" -eq 0 ]; then
+    echo "PASS: All files have FSF copyright headers."
+    exit 0
+else
+    echo "FAIL: $MISSING_COUNT file(s) missing FSF copyright headers:"
+    echo ""
+    for file in "${MISSING_FILES[@]}"; do
+        echo "  - $file"
+    done
+    echo ""
+    exit 1
+fi

--- a/scripts/check-transient-dup-keys.el
+++ b/scripts/check-transient-dup-keys.el
@@ -1,0 +1,159 @@
+;;; check-transient-dup-keys.el --- Check transient menus for duplicate keys
+
+;; Copyright (C) 2026  Free Software Foundation, Inc.
+
+;; This script reads ellama-transient.el as forms to find duplicate keys
+;; within transient menus.  It does not load the project, because loading
+;; depends on user packages and local runtime state.
+
+;; Run with:
+;;   ELLAMA_DIR=/path/to/project emacs -Q -batch -l scripts/check-transient-dup-keys.el
+
+(require 'cl-lib)
+
+(defun check-transient-dup-keys--parse-file (file)
+  "Parse FILE looking for transient-define-prefix definitions.
+Prints any duplicate keys found within each menu."
+  (let ((menu-entries nil)
+        (form-count 0)
+        (prefix-count 0))
+    (with-temp-buffer
+      (insert-file-contents file)
+      (goto-char (point-min))
+      (emacs-lisp-mode)
+
+      ;; Parse forms one by one
+      (while (not (eobp))
+        (condition-case err
+            (progn
+              (forward-comment (point-max))
+              (unless (eobp)
+                (let ((form (read (current-buffer))))
+                  (setq form-count (1+ form-count))
+                  (when (and (consp form)
+                             (eq (car form) 'transient-define-prefix))
+                    (setq prefix-count (1+ prefix-count))
+                    (let* ((menu-name (cadr form))
+                           (menu-body (cddr form))
+                           (this-menu-keys
+                            (check-transient-dup-keys--extract-keys menu-body)))
+                      (message "Menu %s: found %d keys"
+                               (symbol-name menu-name)
+                               (length this-menu-keys))
+                      (when this-menu-keys
+                        (push (cons (symbol-name menu-name) this-menu-keys)
+                              menu-entries)))))))
+          (error (message "Error at position %d: %s" (point) err))))
+
+      ;; Report results
+      (message "Parsed %d forms, found %d transient-define-prefix definitions"
+               form-count prefix-count)
+
+      (when menu-entries
+        (check-transient-dup-keys--report-duplicates menu-entries)))
+    )
+  )
+
+(defun check-transient-dup-keys--is-key-entry (sexp)
+  "Return t if SEXp looks like a transient key binding entry.
+A key binding has the form (\"key\" \"description\" command ...)."
+  (when (and (consp sexp)
+             (>= (length sexp) 3)
+             (stringp (car sexp))
+             (stringp (cadr sexp)))
+    (let ((key (car sexp)))
+      (unless (string= key "-")
+        t))))
+
+(defun check-transient-dup-keys--get-binding (sexp)
+  "Extract (key . command) from a transient key binding SEXp.
+Returns a cons cell (key . command-symbol) or nil if not a valid binding."
+  (let ((key (car sexp))
+        (cmd nil))
+    ;; Find the first symbol that's not a keyword (the command)
+    (dolist (item (cdr sexp))
+      (unless cmd
+        (when (and (symbolp item)
+                   (not (keywordp item)))
+          (setq cmd item))))
+    (when cmd
+      (cons key cmd))))
+
+(defun check-transient-dup-keys--extract-keys (sexp)
+  "Extract key-command pairs from SEXp recursively.
+Traverses nested lists and vectors to find transient entry patterns.
+Returns list of (key . command) cons cells."
+  (let ((result nil))
+    ;; Check if this is a key binding entry (list case)
+    (when (check-transient-dup-keys--is-key-entry sexp)
+      (let ((binding (check-transient-dup-keys--get-binding sexp)))
+        (when binding
+          (push binding result))))
+    
+    ;; Recurse into all elements of lists and vectors
+    (cond
+     ;; Handle vectors (transient menus use vectors for sections)
+     ((vectorp sexp)
+      (dotimes (i (length sexp))
+        (let ((item (aref sexp i)))
+          (when (or (consp item) (vectorp item))
+            (let ((sub-keys (check-transient-dup-keys--extract-keys item)))
+              (setq result (append sub-keys result)))))))
+     
+     ;; Handle lists
+     ((consp sexp)
+      (dolist (item sexp)
+        (when (or (consp item) (vectorp item))
+          (let ((sub-keys (check-transient-dup-keys--extract-keys item)))
+            (setq result (append sub-keys result)))))))
+    
+    (nreverse result)))
+
+(defun check-transient-dup-keys--report-duplicates (menu-entries)
+  "Report duplicate keys from MENU-ENTRIES.
+MENU-ENTRIES is (menu-name (key . command) ...)."
+  (let ((found-any nil))
+    (dolist (menu menu-entries)
+      (let* ((menu-name (car menu))
+             (keys (cdr menu))
+             (key-maps (check-transient-dup-keys--find-duplicates keys)))
+        (when key-maps
+          (setq found-any t)
+          (message "=== %s ===" menu-name)
+          (dolist (dup key-maps)
+            (message "  key '%s: %s" (car dup)
+                     (mapconcat #'identity (cdr dup) ", "))))))
+    (unless found-any
+      (message "No duplicate keys found."))))
+
+(defun check-transient-dup-keys--find-duplicates (keys)
+  "Find duplicate keys in KEYS list.
+KEYS is a list of (key . command) cons cells.
+Returns list of (key string string ...) where strings are command names."
+  (let ((seen (make-hash-table :test #'equal))
+        (results nil))
+    (dolist (key-entry keys)
+      (let* ((key (car key-entry))
+             (cmd (cdr key-entry))
+             (cmd-name (symbol-name cmd)))
+        (if (gethash key seen)
+            ;; Duplicate - add to list if not already there
+            (let ((existing (gethash key seen)))
+              (unless (member cmd-name existing)
+                (puthash key (cons cmd-name existing) seen)))
+          ;; First occurrence - store as single-element list
+          (puthash key (list cmd-name) seen))))
+    (maphash (lambda (key cmd-list)
+               (when (cdr cmd-list)
+                 (push (cons key (nreverse cmd-list)) results)))
+             seen)
+    results))
+
+(when (and noninteractive (getenv "ELLAMA_DIR"))
+  (let* ((dir (getenv "ELLAMA_DIR"))
+         (transient-file (expand-file-name "ellama-transient.el" dir)))
+    (when (file-exists-p transient-file)
+      (check-transient-dup-keys--parse-file transient-file))))
+
+(provide 'check-transient-dup-keys)
+;;; check-transient-dup-keys.el ends here

--- a/scripts/check-transient-dup-keys.sh
+++ b/scripts/check-transient-dup-keys.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+# check-transient-dup-keys.sh - Check transient menus for duplicate keys
+#
+# Usage: ./scripts/check-transient-dup-keys.sh [project-dir]
+# If project-dir is omitted, uses the current directory.
+#
+# Exit code 0 = no duplicates found, 1 = duplicates found or error
+
+set -euo pipefail
+
+# Determine project root (resolve to absolute path)
+PROJECT_DIR="${1:-$(pwd)}"
+PROJECT_DIR="$(cd "$PROJECT_DIR" && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+TRANSIENT_FILE="$PROJECT_DIR/ellama-transient.el"
+
+echo "=== Ellama Transient Key Duplication Checker ==="
+echo "Project directory: $PROJECT_DIR"
+echo "Transient file: $TRANSIENT_FILE"
+echo ""
+
+# Validate ellama-transient.el exists
+if [ ! -f "$TRANSIENT_FILE" ]; then
+    echo "ERROR: ellama-transient.el not found at $TRANSIENT_FILE"
+    exit 1
+fi
+
+# Validate Elisp script exists
+if [ ! -f "$SCRIPT_DIR/check-transient-dup-keys.el" ]; then
+    echo "ERROR: Elisp script not found at $SCRIPT_DIR/check-transient-dup-keys.el"
+    exit 1
+fi
+
+# Create temp file for output
+OUTPUT_FILE=$(mktemp)
+
+trap "rm -f '$OUTPUT_FILE'" EXIT
+
+echo "--- Checking for duplicate keys in transient menus ---"
+echo ""
+
+# Run Emacs in batch mode to check for duplicate keys
+if ELLAMA_DIR="$PROJECT_DIR" emacs -Q -batch \
+	     -l "$SCRIPT_DIR/check-transient-dup-keys.el" \
+	     > "$OUTPUT_FILE" 2>&1; then
+    cat "$OUTPUT_FILE"
+else
+    echo "ERROR: Emacs execution failed."
+    exit 1
+fi
+
+# Check if any output means duplicates were found
+if [ -s "$OUTPUT_FILE" ] && grep -q "===" "$OUTPUT_FILE"; then
+    echo ""
+    echo "FAIL: Duplicate keys found in transient menus."
+    exit 1
+fi
+
+echo "PASS: No duplicate keys found in transient menus."
+exit 0

--- a/tests/test-ellama-context.el
+++ b/tests/test-ellama-context.el
@@ -60,6 +60,19 @@
     (should (equal "[[file:/tmp/image.png][image.png]]"
                    (ellama-context-element-format element 'org-mode)))))
 
+(ert-deftest test-ellama-context-element-format-audio-markdown ()
+  (let ((element (ellama-context-element-audio-file
+                  :name "/tmp/audio.wav")))
+    (should (equal "[audio.wav](</tmp/audio.wav>)"
+                   (ellama-context-element-format
+                    element 'markdown-mode)))))
+
+(ert-deftest test-ellama-context-element-format-audio-org-mode ()
+  (let ((element (ellama-context-element-audio-file
+                  :name "/tmp/audio.wav")))
+    (should (equal "[[file:/tmp/audio.wav][audio.wav]]"
+                   (ellama-context-element-format element 'org-mode)))))
+
 (ert-deftest test-ellama-context-element-format-info-node-markdown ()
   (let ((element (ellama-context-element-info-node :name "(dir)Top")))
     (should (equal "```emacs-lisp\n(info \"(dir)Top\")\n```\n"
@@ -203,6 +216,11 @@
                   :name "/tmp/image.png")))
     (should (equal "image.png" (ellama-context-element-display element)))))
 
+(ert-deftest test-ellama-context-element-display-audio ()
+  (let ((element (ellama-context-element-audio-file
+                  :name "/tmp/audio.wav")))
+    (should (equal "audio.wav" (ellama-context-element-display element)))))
+
 (ert-deftest test-ellama-context-element-display-info-node ()
   (let ((element (ellama-context-element-info-node :name "(dir)Top")))
     (should (equal "(info \"(dir)Top\")" (ellama-context-element-display element)))))
@@ -255,6 +273,27 @@
                 :name "/tmp/ephemeral.png"))))
     (should (equal (ellama-context-media)
                    '("/tmp/global.png" "/tmp/ephemeral.png")))))
+
+(ert-deftest test-ellama-context-media-collects-audio-files ()
+  (let ((ellama-context-global
+         (list (ellama-context-element-audio-file
+                :name "/tmp/global.wav")))
+        (ellama-context-ephemeral
+         (list (ellama-context-element-audio-file
+                :name "/tmp/ephemeral.wav"))))
+    (should (equal (ellama-context-media)
+                   '("/tmp/global.wav" "/tmp/ephemeral.wav")))))
+
+(ert-deftest test-ellama-context-stop-audio-recording-adds-file ()
+  (let ((ellama-audio-context-default-scope 'ephemeral)
+        added)
+    (cl-letf (((symbol-function 'ellama-stop-audio-recording)
+               (lambda () "/tmp/audio.wav"))
+              ((symbol-function 'ellama-context-add-audio-file)
+               (lambda (file-name &optional ephemeral)
+                 (setq added (list file-name ephemeral)))))
+      (ellama-context-stop-audio-recording))
+    (should (equal added '("/tmp/audio.wav" t)))))
 
 (provide 'test-ellama-context)
 

--- a/tests/test-ellama-tools.el
+++ b/tests/test-ellama-tools.el
@@ -2218,6 +2218,7 @@ Return list with result and prompt."
            (result (funcall wrapped-func "ok"))
            saved-path)
       (should (string-match-p "\\[ELLAMA OUTPUT TRUNCATED\\]" result))
+      (should (string-match-p "Full output lines: 4" result))
       (should (string-match "Full output saved to: \\([^\n]+\\)" result))
       (setq saved-path (match-string 1 result))
       (unwind-protect
@@ -2250,29 +2251,35 @@ Return list with result and prompt."
         (ellama-tools-allowed nil))
     (let ((source-path (make-temp-file "ellama-line-budget-source-")))
       (unwind-protect
-          (let* ((tool-plist `(:function ,(lambda (_file-name)
-                                            "line-1\nline-2\nline-3")
-                                         :name "read_file"
-                                         :args ((:name "file_name" :type string))))
-                 (wrapped (ellama-tools-wrap-with-confirm tool-plist))
-                 (wrapped-func (plist-get wrapped :function))
-                 (result (funcall wrapped-func source-path)))
-            (should (string-match-p "\\[ELLAMA OUTPUT TRUNCATED\\]" result))
-            (should
-             (string-match-p
-              (regexp-quote (format "Source file: %s" source-path))
-              result))
-            (should-not (string-match-p "Full output saved to:" result))
-            (should
-             (string-match-p
-              (regexp-quote
-               (format
-                "Next suggested tool call: `lines_range` with file_name=%S, from=3, to=3."
-                source-path))
-              result))
-            (should (string-match-p "grep_in_file" result)))
+          (progn
+            (with-temp-file source-path
+              (insert "line-1\nline-2\nline-3\n"))
+            (let* ((tool-plist `(:function ,(lambda (_file-name)
+                                              "line-1\nline-2\nline-3")
+                                           :name "read_file"
+                                           :args ((:name "file_name" :type string))))
+                   (wrapped (ellama-tools-wrap-with-confirm tool-plist))
+                   (wrapped-func (plist-get wrapped :function))
+                   (result (funcall wrapped-func source-path)))
+              (should (string-match-p "\\[ELLAMA OUTPUT TRUNCATED\\]" result))
+              (should
+               (string-match-p
+                (regexp-quote (format "Source file: %s" source-path))
+                result))
+              (should (string-match-p "Source file contains 3 lines" result))
+              (should-not (string-match-p "Full output saved to:" result))
+              (should (string-match-p "lines_range" result))
+              (should (string-match-p "at most 2 lines" result))
+              (should (string-match-p "within 1\\.\\.3" result))
+              (should (string-match-p "grep_in_file" result))))
         (when (file-exists-p source-path)
           (delete-file source-path))))))
+
+(ert-deftest test-ellama-tools-line-budget-counts-file-lines ()
+  (ellama-test--ensure-local-ellama-tools)
+  (let ((truncation (ellama-tools--line-budget-truncate "one\ntwo\n" 1 200)))
+    (should (= (plist-get truncation :total-lines) 2))
+    (should (= (plist-get truncation :dropped-lines) 1))))
 
 (ert-deftest
     test-ellama-tools-wrap-with-confirm-output-line-budget-truncates-long-line ()

--- a/tests/test-ellama-tools.el
+++ b/tests/test-ellama-tools.el
@@ -396,6 +396,16 @@ Return list with result and prompt."
        "printf '%s|%s' \"$PAGER\" \"$GIT_PAGER\"")
       "cat|cat"))))
 
+(ert-deftest test-ellama-shell-command-tool-uses-non-interactive-environment ()
+  (let ((process-environment (copy-sequence process-environment)))
+    (setenv "TERM" "xterm-256color")
+    (setenv "NO_COLOR" "false")
+    (should
+     (string=
+      (ellama-test--wait-shell-command-result
+       "printf '%s|%s' \"$TERM\" \"$NO_COLOR\"")
+      "dumb|true"))))
+
 (ert-deftest test-ellama-enabled-shell-command-tool-async-contract ()
   (ellama-test--ensure-local-ellama-tools)
   (let ((ellama-tools-dlp-enabled t)

--- a/tests/test-ellama-tools.el
+++ b/tests/test-ellama-tools.el
@@ -234,6 +234,19 @@ Return list with result and prompt."
       (when (file-exists-p file-name)
         (delete-file file-name)))))
 
+(defun ellama-test--with-temp-tool-audio-file (body)
+  "Call BODY with a tiny temporary WAV file."
+  (let ((file-name (make-temp-file "ellama-tool-audio-" nil ".wav")))
+    (unwind-protect
+        (progn
+          (with-temp-buffer
+            (set-buffer-multibyte nil)
+            (insert "RIFF\0\0\0\0WAVE")
+            (write-region nil nil file-name nil 'silent))
+          (funcall body file-name))
+      (when (file-exists-p file-name)
+        (delete-file file-name)))))
+
 (ert-deftest test-ellama-read-file-tool-text-mode ()
   (let ((file-name (make-temp-file "ellama-read-file-" nil ".txt")))
     (unwind-protect
@@ -259,6 +272,44 @@ Return list with result and prompt."
          (let ((result (json-read-from-string
                         (ellama-tools-read-file-tool file-name "image"))))
            (should (string-match-p "Image file queued" result))
+           (should (ellama--session-extra-get
+                    session :pending-tool-media))))))))
+
+(ert-deftest test-ellama-read-file-tool-audio-mode-queues-media ()
+  (ellama-test--with-temp-tool-audio-file
+   (lambda (file-name)
+     (let* ((provider (make-llm-fake))
+            (session (make-ellama-session :id "tool-audio"
+                                          :provider provider))
+            (ellama-tools--current-session session)
+            (ellama--current-session nil))
+       (cl-letf (((symbol-function 'llm-capabilities)
+                  (lambda (_provider) '(audio-input))))
+         (let* ((result
+                 (json-read-from-string
+                  (ellama-tools-read-file-tool file-name "audio")))
+                (pending
+                 (ellama--session-extra-get session :pending-tool-media)))
+           (should (string-match-p "Audio file queued" result))
+           (should (equal (plist-get (car pending) :file)
+                          (expand-file-name file-name)))
+           (should (equal (plist-get (car pending) :mime-type)
+                          "audio/wav"))))))))
+
+(ert-deftest test-ellama-read-file-tool-auto-detects-audio ()
+  (ellama-test--with-temp-tool-audio-file
+   (lambda (file-name)
+     (let* ((provider (make-llm-fake))
+            (session (make-ellama-session :id "tool-audio-auto"
+                                          :provider provider))
+            (ellama-tools--current-session session)
+            (ellama--current-session nil))
+       (cl-letf (((symbol-function 'llm-capabilities)
+                  (lambda (_provider) '(audio-input))))
+         (let ((result
+                (json-read-from-string
+                 (ellama-tools-read-file-tool file-name "auto"))))
+           (should (string-match-p "Audio file queued" result))
            (should (ellama--session-extra-get
                     session :pending-tool-media))))))))
 

--- a/tests/test-ellama-tools.el
+++ b/tests/test-ellama-tools.el
@@ -3142,9 +3142,17 @@ Return list with result and prompt."
              file)))
           (should
            (equal
-            (json-parse-string (ellama-tools-lines-range-tool file 1 3))
+            (json-parse-string (ellama-tools-lines-range-tool file 2 3))
             (format
-             "Invalid line range for %s: to (3) exceeds line count (2)."
+             (concat
+              "Warning: file %s contains only 2 lines; "
+              "requested range ends at line 3.\n\nbeta")
+             file)))
+          (should
+           (equal
+            (json-parse-string (ellama-tools-lines-range-tool file 3 4))
+            (format
+             "Invalid line range for %s: from (3) exceeds line count (2)."
              file))))
       (when (file-exists-p file)
         (delete-file file)))))

--- a/tests/test-ellama-tools.el
+++ b/tests/test-ellama-tools.el
@@ -331,6 +331,50 @@ Return list with result and prompt."
     (ellama-test--wait-shell-command-result "printf 'ok\\n'")
     "ok")))
 
+(ert-deftest test-ellama-shell-command-tool-reverts-workdir-file-buffers ()
+  (ellama-test--ensure-local-ellama-tools)
+  (require 'autorevert)
+  (let* ((dir (make-temp-file "ellama-shell-buffer-revert-" t))
+         (file (expand-file-name "note.txt" dir))
+         (outside-file (make-temp-file "ellama-shell-outside-buffer-"))
+         (default-directory (file-name-as-directory dir))
+         buffer outside-buffer)
+    (unwind-protect
+        (progn
+          (with-temp-file file
+            (insert "old"))
+          (with-temp-file outside-file
+            (insert "outside-old"))
+          (setq buffer (find-file-noselect file))
+          (setq outside-buffer (find-file-noselect outside-file))
+          (with-current-buffer buffer
+            (auto-revert-mode 1)
+            (should auto-revert-mode)
+            (should (equal (buffer-string) "old")))
+          (with-current-buffer outside-buffer
+            (should (equal (buffer-string) "outside-old")))
+          (write-region "outside-new" nil outside-file nil 'silent)
+          (should
+           (equal
+            (ellama-test--wait-shell-command-result
+             "printf shell-new > note.txt")
+            "Command completed successfully with no output."))
+          (with-current-buffer buffer
+            (should (equal (buffer-string) "shell-new"))
+            (should auto-revert-mode))
+          (with-current-buffer outside-buffer
+            (should (equal (buffer-string) "outside-old"))))
+      (when (buffer-live-p buffer)
+        (kill-buffer buffer))
+      (when (buffer-live-p outside-buffer)
+        (kill-buffer outside-buffer))
+      (when (file-exists-p file)
+        (delete-file file))
+      (when (file-exists-p outside-file)
+        (delete-file outside-file))
+      (when (file-directory-p dir)
+        (delete-directory dir)))))
+
 (ert-deftest test-ellama-shell-command-tool-default-timeout ()
   (ellama-test--ensure-local-ellama-tools)
   (let ((ellama-tools-shell-command-default-timeout 5))

--- a/tests/test-ellama-transient.el
+++ b/tests/test-ellama-transient.el
@@ -295,9 +295,72 @@
       (should-not (string-match-p (regexp-quote secret)
                                   (prin1-to-string captured))))))
 
+(ert-deftest test-ellama-transient-set-provider-type ()
+  (let ((ellama-transient-provider
+         (make-llm-openai-compatible
+          :url "http://127.0.0.1:8000/v1"
+          :chat-model "old-model"))
+        (ellama-transient-provider-types
+         '((llm-claude "Claude" llm-claude make-llm-claude)))
+        (ellama-transient-provider-type-selected-p nil))
+    (cl-letf (((symbol-function 'completing-read)
+               (lambda (&rest _args)
+                 "Claude")))
+      (ellama-transient-set-provider-type)
+      (should (eq (type-of ellama-transient-provider) 'llm-claude))
+      (should ellama-transient-provider-type-selected-p)
+      (should (equal (ellama-transient-provider-type-description)
+                     "Provider Type (Claude)")))))
+
+(ert-deftest test-ellama-transient-set-provider-applies-selected-type ()
+  (require 'llm-claude)
+  (let ((ellama-provider
+         (make-llm-openai-compatible
+          :url "http://127.0.0.1:8000/v1"
+          :chat-model "old-model"
+          :key "openai-compatible-secret"))
+        (ellama-coding-provider
+         (make-llm-openai-compatible
+          :url "http://127.0.0.1:9000/v1"
+          :chat-model "old-coding-model"))
+        (ellama-provider-list '(ellama-provider ellama-coding-provider))
+        (ellama-transient-provider
+         (make-llm-claude
+          :key "claude-secret"
+          :chat-model "claude-sonnet-4-6"))
+        (ellama-transient-provider-type-selected-p t)
+        (ellama-transient-model-name "claude-custom-model")
+        (ellama-transient-temperature 0.3)
+        (providers (list
+                    (ellama-transient--provider-label 'ellama-provider)
+                    (ellama-transient--provider-label
+                     'ellama-coding-provider))))
+    (cl-letf (((symbol-function 'completing-read)
+               (lambda (&rest _args)
+                 (prog1 (car providers)
+                   (setq providers (cdr providers))))))
+      (ellama-transient-set-provider)
+      (should (eq (type-of ellama-provider) 'llm-claude))
+      (should (equal (ellama--provider-slot-value
+                      ellama-provider 'chat-model)
+                     "claude-custom-model"))
+      (should (= (llm-standard-chat-provider-default-chat-temperature
+                  ellama-provider)
+                 0.3))
+      (should (equal
+               (funcall (ellama--provider-slot-value ellama-provider 'key))
+               "claude-secret"))
+      (should ellama-transient-provider-type-selected-p)
+      (ellama-transient-set-provider)
+      (should (eq (type-of ellama-coding-provider) 'llm-claude))
+      (should (equal (ellama--provider-slot-value
+                      ellama-coding-provider 'chat-model)
+                     "claude-custom-model")))))
+
 (ert-deftest test-ellama-transient-set-provider-does-not-pass-provider-arg ()
   (let ((ellama-provider :old-default)
-        (received-args :unset))
+        (received-args :unset)
+        (ellama-transient-provider-type-selected-p nil))
     (cl-letf (((symbol-function 'completing-read)
                (lambda (&rest _args)
                  (ellama-transient--provider-label 'ellama-provider)))
@@ -311,7 +374,8 @@
 
 (ert-deftest test-ellama-transient-set-provider-updates-selected-symbol ()
   (let ((ellama-provider :old-default)
-        (ellama-coding-provider :old-coding))
+        (ellama-coding-provider :old-coding)
+        (ellama-transient-provider-type-selected-p nil))
     (cl-letf (((symbol-function 'completing-read)
                (lambda (&rest _args)
                  (ellama-transient--provider-label 'ellama-coding-provider)))
@@ -328,6 +392,7 @@
         (ellama-coding-provider :coding-provider)
         (ellama--current-session-id "session-1")
         (ellama--current-session-uid "uid-1")
+        (ellama-transient-provider-type-selected-p nil)
         (providers (list (ellama-transient--provider-label 'ellama-provider)
                          (ellama-transient--provider-label
                           'ellama-coding-provider)))

--- a/tests/test-ellama.el
+++ b/tests/test-ellama.el
@@ -1441,6 +1441,33 @@ detailed comparison to help you decide:
         (ellama--default-audio-recording-command "/tmp/a.wav" 7)
         '("rec" "%f" "trim" "0" "%d"))))))
 
+(ert-deftest test-ellama-record-audio-includes-recorder-output-in-error ()
+  (let ((ellama-audio-recording-command '("recorder" "%f")))
+    (cl-letf (((symbol-function 'call-process)
+               (lambda (_program _infile destination _display &rest _args)
+                 (with-current-buffer (car destination)
+                   (insert "microphone unavailable\n"))
+                 1)))
+      (let ((message
+             (condition-case err
+                 (progn
+                   (ellama-record-audio 1 "/tmp/a.wav")
+                   nil)
+               (error (error-message-string err)))))
+        (should message)
+        (should (string-match-p "microphone unavailable" message))))))
+
+(ert-deftest test-ellama-audio-recording-error-suggests-macos-permission ()
+  (let ((system-type 'darwin))
+    (condition-case err
+        (ellama--audio-recording-error
+         '("ffmpeg" "-f" "avfoundation") "Abort trap: 6" "")
+      (error
+       (should
+        (string-match-p
+         "Privacy & Security > Microphone"
+         (error-message-string err)))))))
+
 (ert-deftest test-ellama-audio-recording-shows-recording-lighter ()
   (ellama-test--with-temp-audio-file
    (lambda (file-name)

--- a/tests/test-ellama.el
+++ b/tests/test-ellama.el
@@ -1348,36 +1348,6 @@ detailed comparison to help you decide:
          (should (llm-media-p (cadr parts)))
          (should (equal (llm-media-mime-type (cadr parts)) "audio/wav")))))))
 
-(ert-deftest test-ellama-rejects-broken-openai-compatible-audio-transport ()
-  (let ((provider
-         (make-llm-openai-compatible :chat-model "audio-model")))
-    (cl-letf (((symbol-function 'llm-capabilities)
-               (lambda (_provider) '(audio-input)))
-              ((symbol-function 'llm-provider-chat-request)
-               (lambda (&rest _args)
-                 '(:messages
-                   [(:role "user"
-                           :content
-                           [(:type "image_url"
-                                   :image_url (:url "data:audio/wav;base64,"))])]))))
-      (should-error
-       (ellama--validate-provider-audio-transport provider)
-       :type 'error))))
-
-(ert-deftest test-ellama-accepts-openai-compatible-input-audio-transport ()
-  (let ((provider
-         (make-llm-openai-compatible :chat-model "audio-model")))
-    (cl-letf (((symbol-function 'llm-capabilities)
-               (lambda (_provider) '(audio-input)))
-              ((symbol-function 'llm-provider-chat-request)
-               (lambda (&rest _args)
-                 '(:messages
-                   [(:role "user"
-                           :content
-                           [(:type "input_audio"
-                                   :input_audio (:data "" :format "wav"))])]))))
-      (ellama--validate-provider-audio-transport provider))))
-
 (ert-deftest test-ellama-stream-rejects-images-without-provider-support ()
   (ellama-test--with-temp-image-file
    (lambda (file-name)

--- a/tests/test-ellama.el
+++ b/tests/test-ellama.el
@@ -1410,7 +1410,8 @@ detailed comparison to help you decide:
                      '("recorder" "3" "/tmp/a.wav"))))))
 
 (ert-deftest test-ellama-default-audio-recording-command-uses-ffmpeg-on-macos ()
-  (let ((system-type 'darwin))
+  (let ((system-type 'darwin)
+        (ellama-audio-recording-ffmpeg-filter "normalize"))
     (cl-letf (((symbol-function 'executable-find)
                (lambda (program)
                  (and (equal program "ffmpeg") "/usr/local/bin/ffmpeg"))))
@@ -1418,8 +1419,20 @@ detailed comparison to help you decide:
        (equal
         (ellama--default-audio-recording-command "/tmp/a.wav" 12)
         '("ffmpeg" "-nostdin" "-hide_banner" "-loglevel" "error"
-          "-f" "avfoundation" "-i" "none:default" "-t" "%d"
-          "-y" "%f"))))))
+          "-f" "avfoundation" "-i" "none:default" "-af" "normalize"
+          "-t" "%d" "-y" "%f"))))))
+
+(ert-deftest test-ellama-default-audio-recording-command-can-disable-filter ()
+  (let ((system-type 'darwin)
+        (ellama-audio-recording-ffmpeg-filter nil))
+    (cl-letf (((symbol-function 'executable-find)
+               (lambda (program)
+                 (and (equal program "ffmpeg") "/usr/local/bin/ffmpeg"))))
+      (should
+       (equal
+        (ellama--default-audio-recording-command "/tmp/a.wav")
+        '("ffmpeg" "-nostdin" "-hide_banner" "-loglevel" "error"
+          "-f" "avfoundation" "-i" "none:default" "-y" "%f"))))))
 
 (ert-deftest test-ellama-default-audio-recording-command-uses-arecord-on-linux ()
   (let ((system-type 'gnu/linux))

--- a/tests/test-ellama.el
+++ b/tests/test-ellama.el
@@ -1404,10 +1404,42 @@ detailed comparison to help you decide:
 (ert-deftest test-ellama-audio-recording-command-uses-default-when-nil ()
   (let ((ellama-audio-recording-command nil))
     (cl-letf (((symbol-function 'ellama--default-audio-recording-command)
-               (lambda (&optional duration)
+               (lambda (_file-name &optional duration)
                  (list "recorder" (number-to-string duration) "%f"))))
       (should (equal (ellama--audio-recording-command "/tmp/a.wav" 3)
                      '("recorder" "3" "/tmp/a.wav"))))))
+
+(ert-deftest test-ellama-default-audio-recording-command-uses-ffmpeg-on-macos ()
+  (let ((system-type 'darwin))
+    (cl-letf (((symbol-function 'executable-find)
+               (lambda (program)
+                 (and (equal program "ffmpeg") "/usr/local/bin/ffmpeg"))))
+      (should
+       (equal
+        (ellama--default-audio-recording-command "/tmp/a.wav" 12)
+        '("ffmpeg" "-nostdin" "-hide_banner" "-loglevel" "error"
+          "-f" "avfoundation" "-i" "none:default" "-t" "%d"
+          "-y" "%f"))))))
+
+(ert-deftest test-ellama-default-audio-recording-command-uses-arecord-on-linux ()
+  (let ((system-type 'gnu/linux))
+    (cl-letf (((symbol-function 'executable-find)
+               (lambda (program)
+                 (and (equal program "arecord") "/usr/bin/arecord"))))
+      (should
+       (equal
+        (ellama--default-audio-recording-command "/tmp/a.wav")
+        '("arecord" "-q" "-f" "cd" "%f"))))))
+
+(ert-deftest test-ellama-default-audio-recording-command-falls-back-to-sox ()
+  (let ((system-type 'darwin))
+    (cl-letf (((symbol-function 'executable-find)
+               (lambda (program)
+                 (and (equal program "rec") "/usr/local/bin/rec"))))
+      (should
+       (equal
+        (ellama--default-audio-recording-command "/tmp/a.wav" 7)
+        '("rec" "%f" "trim" "0" "%d"))))))
 
 (ert-deftest test-ellama-audio-recording-shows-recording-lighter ()
   (ellama-test--with-temp-audio-file

--- a/tests/test-ellama.el
+++ b/tests/test-ellama.el
@@ -1290,6 +1290,67 @@ detailed comparison to help you decide:
          (should (llm-media-p (cadr parts)))
          (should (equal (llm-media-mime-type (cadr parts)) "audio/wav")))))))
 
+(ert-deftest test-ellama-stream-builds-multipart-with-audio-context ()
+  (ellama-test--with-temp-audio-file
+   (lambda (file-name)
+     (let* ((provider (make-llm-fake))
+            (ellama-context-global nil)
+            (ellama-context-ephemeral
+             (list (ellama-context-element-audio-file :name file-name)))
+            (ellama-response-process-method 'streaming)
+            (ellama-spinner-enabled nil)
+            (ellama-fill-paragraphs nil)
+            captured-prompt)
+       (cl-letf (((symbol-function 'llm-capabilities)
+                  (lambda (_provider) '(audio-input)))
+                 ((symbol-function 'llm-chat-streaming)
+                  (lambda (_provider prompt _partial-callback response-callback
+                                     _error-callback &optional _multi-output)
+                    (setq captured-prompt prompt)
+                    (funcall response-callback '(:text "ok"))
+                    nil)))
+         (with-temp-buffer
+           (ellama-stream "Transcribe audio" :provider provider)))
+       (should-not ellama-context-ephemeral)
+       (let* ((content
+               (llm-chat-prompt-interaction-content
+                (car (llm-chat-prompt-interactions captured-prompt))))
+              (parts (llm-multipart-parts content)))
+         (should (llm-multipart-p content))
+         (should (string-match-p "Transcribe audio" (car parts)))
+         (should (llm-media-p (cadr parts)))
+         (should (equal (llm-media-mime-type (cadr parts)) "audio/wav")))))))
+
+(ert-deftest test-ellama-rejects-broken-openai-compatible-audio-transport ()
+  (let ((provider
+         (make-llm-openai-compatible :chat-model "audio-model")))
+    (cl-letf (((symbol-function 'llm-capabilities)
+               (lambda (_provider) '(audio-input)))
+              ((symbol-function 'llm-provider-chat-request)
+               (lambda (&rest _args)
+                 '(:messages
+                   [(:role "user"
+                           :content
+                           [(:type "image_url"
+                                   :image_url (:url "data:audio/wav;base64,"))])]))))
+      (should-error
+       (ellama--validate-provider-audio-transport provider)
+       :type 'error))))
+
+(ert-deftest test-ellama-accepts-openai-compatible-input-audio-transport ()
+  (let ((provider
+         (make-llm-openai-compatible :chat-model "audio-model")))
+    (cl-letf (((symbol-function 'llm-capabilities)
+               (lambda (_provider) '(audio-input)))
+              ((symbol-function 'llm-provider-chat-request)
+               (lambda (&rest _args)
+                 '(:messages
+                   [(:role "user"
+                           :content
+                           [(:type "input_audio"
+                                   :input_audio (:data "" :format "wav"))])]))))
+      (ellama--validate-provider-audio-transport provider))))
+
 (ert-deftest test-ellama-stream-rejects-images-without-provider-support ()
   (ellama-test--with-temp-image-file
    (lambda (file-name)

--- a/tests/test-ellama.el
+++ b/tests/test-ellama.el
@@ -474,20 +474,47 @@ STYLE controls partial message shape.  Default value is `word-leading'."
      (ellama-make-format "as list"))))
 
 (ert-deftest test-ellama-change-restores-buffer-on-stream-error ()
-  (let ((ellama-spinner-enabled nil)
+  (let ((ellama-provider (make-llm-fake))
+        (ellama-spinner-enabled nil)
         (ellama-response-process-method 'streaming)
-        (original "Hello world.\n"))
+        (ellama-undo-on-error t)
+        (original "Hello world.\n")
+        streaming-called)
     (with-temp-buffer
       (insert original)
       (cl-letf (((symbol-function 'llm-chat-streaming)
-                 (lambda (_provider _prompt _partial-callback _response-callback
+                 (lambda (_provider _prompt partial-callback _response-callback
                                     error-callback _multi-output)
+                   (setq streaming-called t)
+                   (funcall partial-callback '(:text "Partial response"))
                    (funcall error-callback 'error "network failed")
                    'request)))
         (should-error
          (ellama-change "fix grammar")
          :type 'error))
+      (should streaming-called)
       (should (equal (buffer-string) original)))))
+
+(ert-deftest test-ellama-change-keeps-partial-response-on-stream-error ()
+  (let ((ellama-provider (make-llm-fake))
+        (ellama-spinner-enabled nil)
+        (ellama-response-process-method 'streaming)
+        (ellama-undo-on-error nil)
+        streaming-called)
+    (with-temp-buffer
+      (insert "Hello world.\n")
+      (cl-letf (((symbol-function 'llm-chat-streaming)
+                 (lambda (_provider _prompt partial-callback _response-callback
+                                    error-callback _multi-output)
+                   (setq streaming-called t)
+                   (funcall partial-callback '(:text "Partial response"))
+                   (funcall error-callback 'error "network failed")
+                   'request)))
+        (should-error
+         (ellama-change "fix grammar")
+         :type 'error))
+      (should streaming-called)
+      (should (equal (buffer-string) "Partial response")))))
 
 (ert-deftest test-ellama--code-filter ()
   (should (equal "" (ellama--code-filter "")))

--- a/tests/test-ellama.el
+++ b/tests/test-ellama.el
@@ -1197,12 +1197,33 @@ detailed comparison to help you decide:
       (when (file-exists-p file-name)
         (delete-file file-name)))))
 
+(defun ellama-test--with-temp-audio-file (body)
+  "Call BODY with a tiny temporary WAV file."
+  (let ((file-name (make-temp-file "ellama-audio-" nil ".wav")))
+    (unwind-protect
+        (progn
+          (with-temp-buffer
+            (set-buffer-multibyte nil)
+            (insert "RIFF\0\0\0\0WAVE")
+            (write-region nil nil file-name nil 'silent))
+          (funcall body file-name))
+      (when (file-exists-p file-name)
+        (delete-file file-name)))))
+
 (ert-deftest test-ellama-file-to-llm-media ()
   (ellama-test--with-temp-image-file
    (lambda (file-name)
      (let ((media (ellama--file-to-llm-media file-name)))
        (should (llm-media-p media))
        (should (equal (llm-media-mime-type media) "image/png"))
+       (should-not (multibyte-string-p (llm-media-data media)))))))
+
+(ert-deftest test-ellama-audio-file-to-llm-media ()
+  (ellama-test--with-temp-audio-file
+   (lambda (file-name)
+     (let ((media (ellama--file-to-llm-media file-name)))
+       (should (llm-media-p media))
+       (should (equal (llm-media-mime-type media) "audio/wav"))
        (should-not (multibyte-string-p (llm-media-data media)))))))
 
 (ert-deftest test-ellama-stream-builds-multipart-with-images ()
@@ -1237,6 +1258,38 @@ detailed comparison to help you decide:
          (should (llm-media-p (cadr parts)))
          (should (equal (llm-media-mime-type (cadr parts)) "image/png")))))))
 
+(ert-deftest test-ellama-stream-builds-multipart-with-audios ()
+  (ellama-test--with-temp-audio-file
+   (lambda (file-name)
+     (let* ((provider (make-llm-fake))
+            (ellama-provider provider)
+            (ellama-response-process-method 'streaming)
+            (ellama-spinner-enabled nil)
+            (ellama-fill-paragraphs nil)
+            captured-prompt
+            done-text)
+       (cl-letf (((symbol-function 'llm-capabilities)
+                  (lambda (_provider) '(audio-input)))
+                 ((symbol-function 'llm-chat-streaming)
+                  (lambda (_provider prompt _partial-callback response-callback
+                                     _error-callback &optional _multi-output)
+                    (setq captured-prompt prompt)
+                    (funcall response-callback '(:text "ok"))
+                    nil)))
+         (with-temp-buffer
+           (ellama-stream "Transcribe audio"
+                          :provider provider
+                          :audios (list file-name)
+                          :on-done (lambda (text) (setq done-text text)))))
+       (should (equal done-text "ok"))
+       (let* ((content (llm-chat-prompt-interaction-content
+                        (car (llm-chat-prompt-interactions captured-prompt))))
+              (parts (llm-multipart-parts content)))
+         (should (llm-multipart-p content))
+         (should (equal (car parts) "Transcribe audio"))
+         (should (llm-media-p (cadr parts)))
+         (should (equal (llm-media-mime-type (cadr parts)) "audio/wav")))))))
+
 (ert-deftest test-ellama-stream-rejects-images-without-provider-support ()
   (ellama-test--with-temp-image-file
    (lambda (file-name)
@@ -1249,6 +1302,19 @@ detailed comparison to help you decide:
             (ellama-stream "Describe image"
                            :provider provider
                            :images (list file-name)))))))))
+
+(ert-deftest test-ellama-stream-rejects-audios-without-provider-support ()
+  (ellama-test--with-temp-audio-file
+   (lambda (file-name)
+     (let ((provider (make-llm-fake))
+           (ellama-response-process-method 'streaming))
+       (cl-letf (((symbol-function 'llm-capabilities)
+                  (lambda (_provider) nil)))
+         (should-error
+          (with-temp-buffer
+            (ellama-stream "Transcribe audio"
+                           :provider provider
+                           :audios (list file-name)))))))))
 
 (ert-deftest test-ellama-prompt-attach-pending-tool-media ()
   (ellama-test--with-temp-image-file
@@ -1269,7 +1335,7 @@ detailed comparison to help you decide:
                         (car (last (llm-chat-prompt-interactions prompt)))))
               (parts (llm-multipart-parts content)))
          (should (llm-multipart-p content))
-         (should (string-match-p "Images read by tools" (car parts)))
+         (should (string-match-p "Media read by tools" (car parts)))
          (should (llm-media-p (cadr parts))))))))
 
 (ert-deftest test-ellama-ask-image-adds-ephemeral-context ()
@@ -1297,6 +1363,81 @@ detailed comparison to help you decide:
     (should (equal (nreverse context-calls)
                    '(("/tmp/one.png" t) ("/tmp/two.png" t))))
     (should (equal chat-call '("Compare them" nil (:ephemeral t))))))
+
+(ert-deftest test-ellama-ask-audio-adds-ephemeral-context ()
+  (let (context-call chat-call)
+    (cl-letf (((symbol-function 'ellama-context-add-audio-file)
+               (lambda (file-name &optional ephemeral)
+                 (setq context-call (list file-name ephemeral))))
+              ((symbol-function 'ellama-chat)
+               (lambda (prompt create-session &rest args)
+                 (setq chat-call (list prompt create-session args)))))
+      (ellama-ask-audio "/tmp/audio.wav" "Transcribe it" t :ephemeral t))
+    (should (equal context-call '("/tmp/audio.wav" t)))
+    (should (equal chat-call '("Transcribe it" t (:ephemeral t))))))
+
+(ert-deftest test-ellama-chat-with-audios-adds-ephemeral-context ()
+  (let (context-calls chat-call)
+    (cl-letf (((symbol-function 'ellama-context-add-audio-file)
+               (lambda (file-name &optional ephemeral)
+                 (push (list file-name ephemeral) context-calls)))
+              ((symbol-function 'ellama-chat)
+               (lambda (prompt create-session &rest args)
+                 (setq chat-call (list prompt create-session args)))))
+      (ellama-chat-with-audios
+       '("/tmp/one.wav" "/tmp/two.wav") "Compare them" nil :ephemeral t))
+    (should (equal (nreverse context-calls)
+                   '(("/tmp/one.wav" t) ("/tmp/two.wav" t))))
+    (should (equal chat-call '("Compare them" nil (:ephemeral t))))))
+
+(ert-deftest test-ellama-audio-recording-command-replaces-placeholders ()
+  (let ((ellama-audio-recording-command
+         '("recorder" "--seconds" "%d" "--output" "%f")))
+    (should (equal (ellama--audio-recording-command "/tmp/a.wav" 12)
+                   '("recorder" "--seconds" "12" "--output" "/tmp/a.wav")))))
+
+(ert-deftest test-ellama-audio-recording-command-rejects-duration-placeholder-for-start-stop ()
+  (let ((ellama-audio-recording-command
+         '("recorder" "--seconds" "%d" "--output" "%f")))
+    (should-error (ellama--audio-recording-command "/tmp/a.wav"))))
+
+(ert-deftest test-ellama-audio-recording-command-uses-default-when-nil ()
+  (let ((ellama-audio-recording-command nil))
+    (cl-letf (((symbol-function 'ellama--default-audio-recording-command)
+               (lambda (&optional duration)
+                 (list "recorder" (number-to-string duration) "%f"))))
+      (should (equal (ellama--audio-recording-command "/tmp/a.wav" 3)
+                     '("recorder" "3" "/tmp/a.wav"))))))
+
+(ert-deftest test-ellama-audio-recording-shows-recording-lighter ()
+  (ellama-test--with-temp-audio-file
+   (lambda (file-name)
+     (let ((ellama-audio-recording-command '("recorder" "%f"))
+           (ellama--audio-recording-process nil)
+           (ellama--audio-recording-file nil)
+           (live t))
+       (ellama-audio-recording-mode -1)
+       (cl-letf (((symbol-function 'start-process)
+                  (lambda (&rest _args) 'process))
+                 ((symbol-function 'set-process-query-on-exit-flag)
+                  (lambda (&rest _args) nil))
+                 ((symbol-function 'process-live-p)
+                  (lambda (_process) live))
+                 ((symbol-function 'interrupt-process)
+                  (lambda (_process) (setq live nil)))
+                 ((symbol-function 'kill-process)
+                  (lambda (_process) (setq live nil)))
+                 ((symbol-function 'accept-process-output)
+                  (lambda (&rest _args) nil)))
+         (unwind-protect
+             (progn
+               (ellama-start-audio-recording file-name)
+               (should ellama-audio-recording-mode)
+               (should (equal (ellama-stop-audio-recording) file-name))
+               (should-not ellama-audio-recording-mode))
+           (ellama-audio-recording-mode -1)
+           (setq ellama--audio-recording-process nil
+                 ellama--audio-recording-file nil)))))))
 
 (ert-deftest test-ellama-chat-send-last-message-displays-ephemeral-image-context ()
   (ellama-test--with-temp-image-file


### PR DESCRIPTION
## Summary
- add media-aware prompt handling so audio files can be attached alongside image inputs
- add audio context elements, transient entries, key bindings, and microphone recording commands
- add a mode-line lighter while start/stop audio recording is active
- let the read_file tool auto-detect audio or queue it explicitly with mode=audio
- reject OpenAI-compatible audio before sending when the installed llm package cannot serialize input_audio
- document recorder selection, macOS permissions, normalization, tool usage, and provider transport requirements

## Dependency
- OpenAI-compatible audio serialization: https://github.com/ahyatt/llm/pull/289

## Tests
- make check-elisp (519 ERT tests)
- make check-readme
- GitHub Actions matrix for Emacs 28.1 through 30.1