### PR TITLE
Align Markdown tables in Org output

### DIFF
--- a/NEWS.org
+++ b/NEWS.org
@@ -1,3 +1,12 @@
+* Version 1.32.0
+
+- Preserve Markdown tables during streaming conversion. Paragraph filling no
+  longer wraps table rows, and streaming fill skips while point is inside a
+  table, avoiding phantom rows and broken cells.
+- Align converted Markdown tables in Org output. Separator rows are normalized
+  and tables are aligned for both builtin and Pandoc converters, with better
+  handling of wider cells during streaming updates.
+
 * Version 1.31.0
 
 - Show irreversible action confirmation details. Named tool arguments are now

--- a/README.org
+++ b/README.org
@@ -672,13 +672,6 @@ If a saved provider key cannot be restored, the session still loads.  Requests
 using that provider can fail later with the provider's normal authentication
 error until the provider is configured again.
 
-The upstream ~llm~ provider-key redaction change is merged, but released
-versions such as ~llm~ 0.30.3 may not include it yet.  Until a released ~llm~
-version containing that change is installed, provider keys can still appear in
-debugger output produced by ~llm~ itself.  Ellama avoids adding new plaintext
-keys to saved session files, but it cannot redact every ~llm~ backtrace from
-older released ~llm~ versions.
-
 Set ~ellama-session-persist-provider-keys~ to ~auth-source~ to save an
 auth-source lookup reference in the session file.  The secret itself stays in
 auth-source and is resolved when the session is loaded.  Ellama uses the

--- a/ellama.el
+++ b/ellama.el
@@ -47,6 +47,11 @@
 (require 'ellama-tools)
 (require 'ellama-skills)
 
+(declare-function org-table-align "org-table")
+(declare-function org-table-begin "org-table")
+(declare-function org-table-end "org-table")
+(declare-function org-table-map-tables "org-table")
+
 (defvar ellama-tools--current-session)
 (defvar ellama-tools-agent-default-max-steps)
 (defvar ellama-tools-allow-all)
@@ -1001,6 +1006,14 @@ Skip code blocks and math environments."
 (defconst ellama--org-verbatim-blocks '("SRC" "EXAMPLE" "EXPORT")
   "Org block names whose contents should stay untouched.")
 
+(defconst ellama--markdown-table-separator-regexp
+  (rx line-start
+      (group (* blank)) "|" (* blank)
+      (? ":") (>= 3 "-") (? ":") (* blank)
+      (* "|" (* blank) (? ":") (>= 3 "-") (? ":") (* blank))
+      (? "|") (* blank) line-end)
+  "Regexp matching a Markdown table separator row.")
+
 (defun ellama--org-keyword-line-start-p ()
   "Return non-nil when point has only blanks before it on its line."
   (save-excursion
@@ -1064,6 +1077,40 @@ Skip code blocks and math environments."
               (insert prefix "\n```\n" suffix))))))
       (forward-line 1))
     (buffer-substring-no-properties (point-min) (point-max))))
+
+(defun ellama--normalize-and-align-org-table ()
+  "Normalize and align the Org table at point."
+  (let ((table-beg (org-table-begin))
+        (table-end (copy-marker (org-table-end) t)))
+    (save-excursion
+      (goto-char table-beg)
+      (while (re-search-forward ellama--markdown-table-separator-regexp
+                                table-end t)
+        (replace-match (concat (match-string 1) "|-") t t)))
+    (goto-char table-beg)
+    (org-table-align)
+    (set-marker table-end nil)))
+
+(defun ellama--align-org-tables (text)
+  "Normalize and align Org tables in TEXT."
+  (if (not (string-match-p "^[ \t]*|" text))
+      text
+    (condition-case err
+        (progn
+          (let ((trailing-newline-p (string-suffix-p "\n" text)))
+            (with-temp-buffer
+              (delay-mode-hooks (org-mode))
+              (insert text)
+              (org-table-map-tables #'ellama--normalize-and-align-org-table t)
+              (let ((result
+                     (buffer-substring-no-properties (point-min) (point-max))))
+                (if trailing-newline-p
+                    result
+                  (string-remove-suffix "\n" result))))))
+      (error
+       (when ellama-debug
+         (message "Cannot align Org tables: %s" (error-message-string err)))
+       text))))
 
 (defun ellama--prepare-markdown-for-pandoc (text)
   "Prepare TEXT for Pandoc Markdown to Org conversion."
@@ -1130,13 +1177,14 @@ This filter contains only subset of markdown syntax to be good enough."
 
 (defun ellama--translate-markdown-to-org-filter (text)
   "Filter to translate Markdown syntax to Org syntax in TEXT."
-  (if (or (eq ellama-markdown-to-org-converter 'pandoc)
-          (and (eq ellama-markdown-to-org-converter 'auto)
-               (ellama--pandoc-available-p)))
-      (condition-case nil
-          (ellama--translate-markdown-to-org-with-pandoc text)
-        (error (ellama--translate-markdown-to-org-builtin text)))
-    (ellama--translate-markdown-to-org-builtin text)))
+  (ellama--align-org-tables
+   (if (or (eq ellama-markdown-to-org-converter 'pandoc)
+           (and (eq ellama-markdown-to-org-converter 'auto)
+                (ellama--pandoc-available-p)))
+       (condition-case nil
+           (ellama--translate-markdown-to-org-with-pandoc text)
+         (error (ellama--translate-markdown-to-org-builtin text)))
+     (ellama--translate-markdown-to-org-builtin text))))
 
 (defcustom ellama-enable-keymap t
   "Enable or disable Ellama keymap."
@@ -3449,14 +3497,21 @@ FILTER is a function for text transformation."
               (let* ((filtered-text
                       (funcall filter text))
                      (use-hard-newlines t)
+                     (valid-safe-common-prefix
+                      (if (and
+                           (string-prefix-p safe-common-prefix filtered-text)
+                           (string-prefix-p safe-common-prefix
+                                            previous-filtered-text))
+                          safe-common-prefix
+                        ""))
                      (common-prefix (concat
-                                     safe-common-prefix
+                                     valid-safe-common-prefix
                                      (ellama-max-common-prefix
                                       (string-remove-prefix
-                                       safe-common-prefix
+                                       valid-safe-common-prefix
                                        filtered-text)
                                       (string-remove-prefix
-                                       safe-common-prefix
+                                       valid-safe-common-prefix
                                        previous-filtered-text))))
                      (wrong-chars-cnt (- (length previous-filtered-text)
                                          (length common-prefix)))

--- a/ellama.el
+++ b/ellama.el
@@ -6,7 +6,7 @@
 ;; URL: http://github.com/s-kostyaev/ellama
 ;; Keywords: help local tools
 ;; Package-Requires: ((emacs "28.1") (llm "0.31.1") (plz "0.8") (transient "0.7") (compat "29.1") (yaml "1.2.3"))
-;; Version: 1.31.0
+;; Version: 1.32.0
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;; Created: 8th Oct 2023
 

--- a/ellama.el
+++ b/ellama.el
@@ -48,6 +48,7 @@
 (require 'ellama-skills)
 
 (declare-function org-table-align "org-table")
+(declare-function org-at-table-p "org-table")
 (declare-function org-table-begin "org-table")
 (declare-function org-table-end "org-table")
 (declare-function org-table-map-tables "org-table")
@@ -911,6 +912,12 @@ into the buffer if the LLM call raises an error."
           (re-search-forward from end t))
     (replace-match to)))
 
+(defun ellama--markdown-table-line-p ()
+  "Return non-nil when point is on a Markdown table line."
+  (save-excursion
+    (beginning-of-line)
+    (looking-at-p "[ \t]*|")))
+
 (defun ellama--apply-transformations (beg end)
   "Apply md to org transformations for region BEG END."
   (let ((beg-pos (make-marker))
@@ -952,7 +959,9 @@ into the buffer if the LLM call raises an error."
     (goto-char beg-pos)
     (set-hard-newline-properties beg-pos end-pos)
     (when ellama-fill-paragraphs
-      (let* ((use-hard-newlines t))
+      (let ((fill-nobreak-predicate
+             (cons #'ellama--markdown-table-line-p fill-nobreak-predicate))
+            (use-hard-newlines t))
         (fill-region beg end-pos nil t t)))))
 
 (defun ellama--replace-outside-of-code-blocks (text)
@@ -3466,9 +3475,10 @@ EVENT is an argument for mweel scroll."
          ((cl-type list) (and (apply #'derived-mode-p
                                      ellama-fill-paragraphs))))
        (not (and (derived-mode-p 'org-mode)
-                 (string-match-p
-                  "#\\+\\(?:BEGIN\\|END\\)_[[:alnum:]_-]+"
-                  delta)))))
+                 (or (org-at-table-p)
+                     (string-match-p
+                      "#\\+\\(?:BEGIN\\|END\\)_[[:alnum:]_-]+"
+                      delta))))))
 
 (defun ellama--insert (buffer point filter)
   "Insert text during streaming.

--- a/ellama.info
+++ b/ellama.info
@@ -1024,13 +1024,6 @@ If a saved provider key cannot be restored, the session still loads.
 Requests using that provider can fail later with the provider's normal
 authentication error until the provider is configured again.
 
-The upstream ‘llm’ provider-key redaction change is merged, but released
-versions such as ‘llm’ 0.30.3 may not include it yet.  Until a released
-‘llm’ version containing that change is installed, provider keys can
-still appear in debugger output produced by ‘llm’ itself.  Ellama avoids
-adding new plaintext keys to saved session files, but it cannot redact
-every ‘llm’ backtrace from older released ‘llm’ versions.
-
 Set ‘ellama-session-persist-provider-keys’ to ‘auth-source’ to save an
 auth-source lookup reference in the session file.  The secret itself
 stays in auth-source and is resolved when the session is loaded.  Ellama
@@ -2945,42 +2938,42 @@ Node: Tool Access and Sandboxing40648
 Node: Task Templates Blueprints and Skills43720
 Node: Agent and Subagent Loops45099
 Node: Session Provider Keys46395
-Node: Session Compaction48281
-Node: Image Input50575
-Node: Audio Input52890
-Node: macOS microphone permission55558
-Node: Task Tool Subagents57719
-Node: Plan-and-Act Agent Loop61625
-Node: Edit Tool Shell Hooks64206
-Node: DLP for Tool Input/Output66499
-Node: SRT Filesystem Policy for Tools82068
-Node: Context Management87739
-Node: Transient Menus for Context Management88807
-Node: Managing the Context90881
-Node: Considerations91656
-Node: Minor modes91983
-Node: ellama-context-header-line-mode92495
-Node: ellama-context-header-line-global-mode93113
-Node: ellama-context-mode-line-mode93517
-Node: ellama-context-mode-line-global-mode94096
-Node: ellama-session-header-line-mode94490
-Node: ellama-session-mode-line-mode94994
-Node: Using Blueprints95421
-Node: Key Components95817
-Node: Creating and Managing96176
-Node: Blueprint Files96814
-Node: Variables97233
-Node: Keymap and Mode97569
-Node: Transient Menus98093
-Node: Running Blueprints Programmatically98607
-Node: MCP Integration99161
-Node: Agent Skills100339
-Node: Directory Structure100738
-Node: Creating a Skill101718
-Node: How It Works102108
-Node: Acknowledgments102514
-Node: Contributions103200
-Node: GNU Free Documentation License103725
+Node: Session Compaction47840
+Node: Image Input50134
+Node: Audio Input52449
+Node: macOS microphone permission55117
+Node: Task Tool Subagents57278
+Node: Plan-and-Act Agent Loop61184
+Node: Edit Tool Shell Hooks63765
+Node: DLP for Tool Input/Output66058
+Node: SRT Filesystem Policy for Tools81627
+Node: Context Management87298
+Node: Transient Menus for Context Management88366
+Node: Managing the Context90440
+Node: Considerations91215
+Node: Minor modes91542
+Node: ellama-context-header-line-mode92054
+Node: ellama-context-header-line-global-mode92672
+Node: ellama-context-mode-line-mode93076
+Node: ellama-context-mode-line-global-mode93655
+Node: ellama-session-header-line-mode94049
+Node: ellama-session-mode-line-mode94553
+Node: Using Blueprints94980
+Node: Key Components95376
+Node: Creating and Managing95735
+Node: Blueprint Files96373
+Node: Variables96792
+Node: Keymap and Mode97128
+Node: Transient Menus97652
+Node: Running Blueprints Programmatically98166
+Node: MCP Integration98720
+Node: Agent Skills99898
+Node: Directory Structure100297
+Node: Creating a Skill101277
+Node: How It Works101667
+Node: Acknowledgments102073
+Node: Contributions102759
+Node: GNU Free Documentation License103284
 
 End Tag Table
 

--- a/tests/test-ellama.el
+++ b/tests/test-ellama.el
@@ -2758,6 +2758,20 @@ Sure! ```emacs-lisp
 |------+-------------|
 | a    | much longer |")))))
 
+(ert-deftest test-ellama-md-to-org-table-does-not-fill-long-rows ()
+  (let ((ellama-markdown-to-org-converter 'builtin)
+        (ellama-fill-paragraphs t)
+        (fill-column 30))
+    (should
+     (string=
+      (ellama--translate-markdown-to-org-filter
+       "| Name | Description |
+| --- | --- |
+| item | This description is longer than the fill column |")
+      "| Name | Description                                     |
+|------+-------------------------------------------------|
+| item | This description is longer than the fill column |"))))
+
 (ert-deftest test-ellama-md-to-org-table-skip-src-block ()
   (let ((ellama-markdown-to-org-converter 'builtin))
     (should
@@ -2783,26 +2797,27 @@ Sure! ```emacs-lisp
 (ert-deftest test-ellama-md-to-org-table-streaming-width-growth ()
   (with-temp-buffer
     (org-mode)
-    (let ((ellama-markdown-to-org-converter 'builtin)
-          (ellama-fill-paragraphs nil)
-          (ellama-auto-scroll nil)
-          (insert-text
-           (ellama--insert
-            (current-buffer) (point)
-            #'ellama--translate-markdown-to-org-filter)))
-      (dolist (text (list "| A | B |\n| --- | --- |\n| x | y |"
-                          "| A | B |\n| --- | --- |\n| x | y |\n| z | q |"
-                          (concat "| A | B |\n| --- | --- |\n| x | y |\n"
-                                  "| z | q |\n| longest | value |")))
-        (funcall insert-text text))
+    (let* ((response
+            (concat "| Name | Rating |\n"
+                    "| --- | --- |\n"
+                    "| short | ⭐ |\n"
+                    "| longest name | ⭐⭐⭐⭐⭐ (Very easy) |"))
+           (ellama-markdown-to-org-converter 'builtin)
+           (ellama-auto-scroll nil)
+           (insert-text
+            (ellama--insert
+             (current-buffer) (point)
+             #'ellama--translate-markdown-to-org-filter)))
+      (dolist (partial
+               (ellama-test--fake-stream-partials response 'word-leading))
+        (funcall insert-text (string-trim partial)))
       (should
        (string=
         (buffer-string)
-        "| A       | B     |
-|---------+-------|
-| x       | y     |
-| z       | q     |
-| longest | value |")))))
+        "| Name         | Rating                 |
+|--------------+------------------------|
+| short        | ⭐                     |
+| longest name | ⭐⭐⭐⭐⭐ (Very easy) |")))))
 
 (ert-deftest test-ellama-md-to-org-code-hard ()
   (let ((result (ellama--translate-markdown-to-org-filter "Here is your TikZ code for a blue rectangle:

--- a/tests/test-ellama.el
+++ b/tests/test-ellama.el
@@ -2732,6 +2732,78 @@ Sure! ```emacs-lisp
                              "Sure! \n```emacs-lisp\n"
                              "(message \"ok\")\n```")))))
 
+(ert-deftest test-ellama-md-to-org-table-builtin ()
+  (let ((ellama-markdown-to-org-converter 'builtin))
+    (should
+     (string=
+      (ellama--translate-markdown-to-org-filter
+       "| Name | Link |
+| :--- | ---: |
+| 猫 | [OpenAI](https://openai.com) |")
+      "| Name | Link   |
+|------+--------|
+| 猫   | [[https://openai.com][OpenAI]] |"))))
+
+(ert-deftest test-ellama-md-to-org-table-pandoc ()
+  (let ((ellama-markdown-to-org-converter 'pandoc))
+    (cl-letf (((symbol-function 'ellama--translate-markdown-to-org-with-pandoc)
+               (lambda (_text)
+                 "| Name | Description |
+|---+---|
+| a | much longer |")))
+      (should
+       (string=
+        (ellama--translate-markdown-to-org-filter "ignored")
+        "| Name | Description |
+|------+-------------|
+| a    | much longer |")))))
+
+(ert-deftest test-ellama-md-to-org-table-skip-src-block ()
+  (let ((ellama-markdown-to-org-converter 'builtin))
+    (should
+     (string=
+      (ellama--translate-markdown-to-org-filter
+       "```text
+|a|long|
+|b|c|
+```
+
+| A | Longer |
+| --- | --- |
+| x | y |")
+      "#+BEGIN_SRC text
+|a|long|
+|b|c|
+#+END_SRC
+
+| A | Longer |
+|---+--------|
+| x | y      |"))))
+
+(ert-deftest test-ellama-md-to-org-table-streaming-width-growth ()
+  (with-temp-buffer
+    (org-mode)
+    (let ((ellama-markdown-to-org-converter 'builtin)
+          (ellama-fill-paragraphs nil)
+          (ellama-auto-scroll nil)
+          (insert-text
+           (ellama--insert
+            (current-buffer) (point)
+            #'ellama--translate-markdown-to-org-filter)))
+      (dolist (text (list "| A | B |\n| --- | --- |\n| x | y |"
+                          "| A | B |\n| --- | --- |\n| x | y |\n| z | q |"
+                          (concat "| A | B |\n| --- | --- |\n| x | y |\n"
+                                  "| z | q |\n| longest | value |")))
+        (funcall insert-text text))
+      (should
+       (string=
+        (buffer-string)
+        "| A       | B     |
+|---------+-------|
+| x       | y     |
+| z       | q     |
+| longest | value |")))))
+
 (ert-deftest test-ellama-md-to-org-code-hard ()
   (let ((result (ellama--translate-markdown-to-org-filter "Here is your TikZ code for a blue rectangle:
 ```


### PR DESCRIPTION
## Summary

- normalize Markdown table separator rows into Org horizontal rules
- align tables produced by both builtin and Pandoc converters with Org table APIs
- keep long table rows out of paragraph filling
- preserve verbatim blocks and handle word-by-word streaming without phantom rows or broken cells

## Testing

- `make test` (537 tests)
- `make build`
- `make check-compile-warnings`
- `make checkdocs`
- `make check-transient-dup-keys check-copyright`
- pre-push `make check-elisp`