### PR TITLE
Preserve file buffer positions during tool updates

### DIFF
--- a/NEWS.org
+++ b/NEWS.org
@@ -1,3 +1,15 @@
+* Version 1.32.1
+
+- Preserve file buffer positions during tool updates. File contents are now
+  updated with marker-preserving replacement, and only stale unmodified buffers
+  are refreshed after shell commands and edit hooks. The system warns instead of
+  discarding unsaved changes, and regression coverage for mutating, read-only,
+  validation, and hook paths has been added.
+
+- Keep visiting buffers attached after file moves. The ~move_file~ tool now
+  retargets an existing source buffer to the destination while preserving point
+  and unsaved changes. Destinations already visited by another buffer are
+  rejected. Regression tests cover both paths.
 * Version 1.32.0
 
 - Preserve Markdown tables during streaming conversion. Paragraph filling no

--- a/ellama-tools.el
+++ b/ellama-tools.el
@@ -3401,27 +3401,49 @@ TIMEOUT is the optional command timeout in seconds."
 
 (defun ellama-tools-move-file-tool (file-name new-file-name)
   "Move the file from the specified FILE-NAME to the NEW-FILE-NAME."
-  (or (ellama-tools--tool-check-file-access file-name 'read)
-      (ellama-tools--tool-check-file-access file-name 'write)
-      (ellama-tools--tool-check-file-access new-file-name 'write)
-      (ellama-tools--read-before-write-check "Move" file-name)
-      (cond
-       ((not (file-exists-p file-name))
-        (format "Cannot move file: source file does not exist: %s."
-                file-name))
-       ((file-exists-p new-file-name)
-        (format "Cannot move file: destination already exists: %s."
-                new-file-name))
-       (t
-        (condition-case err
-            (progn
-              (rename-file file-name new-file-name)
-              (format "Moved %s to %s." file-name new-file-name))
-          (file-error
-           (format "Cannot move %s to %s: %s"
-                   file-name
-                   new-file-name
-                   (error-message-string err))))))))
+  (let* ((expanded-file-name (expand-file-name file-name))
+         (expanded-new-file-name (expand-file-name new-file-name))
+         (source-buffer (get-file-buffer expanded-file-name))
+         (destination-buffer (get-file-buffer expanded-new-file-name)))
+    (or (ellama-tools--tool-check-file-access file-name 'read)
+        (ellama-tools--tool-check-file-access file-name 'write)
+        (ellama-tools--tool-check-file-access new-file-name 'write)
+        (ellama-tools--read-before-write-check "Move" file-name)
+        (cond
+         ((not (file-exists-p file-name))
+          (format "Cannot move file: source file does not exist: %s."
+                  file-name))
+         ((file-exists-p new-file-name)
+          (format "Cannot move file: destination already exists: %s."
+                  new-file-name))
+         ((and destination-buffer
+               (not (eq destination-buffer source-buffer)))
+          (format
+           "Cannot move file: destination is visited by another buffer: %s."
+           new-file-name))
+         (t
+          (condition-case err
+              (progn
+                (rename-file file-name new-file-name)
+                (if (not (buffer-live-p source-buffer))
+                    (format "Moved %s to %s." file-name new-file-name)
+                  (condition-case buffer-err
+                      (with-current-buffer source-buffer
+                        (set-visited-file-name expanded-new-file-name t t)
+                        (format "Moved %s to %s." file-name new-file-name))
+                    (error
+                     (format
+                      (concat
+                       "Moved %s to %s, but could not update its visiting "
+                       "buffer: %s")
+                      file-name
+                      new-file-name
+                      (error-message-string buffer-err))))))
+            (file-error
+             (format "Cannot move %s to %s: %s"
+                     file-name
+                     new-file-name
+                     (error-message-string err)))))))))
 
 (ellama-tools-define-tool
  '(:function

--- a/ellama-tools.el
+++ b/ellama-tools.el
@@ -2170,19 +2170,61 @@ Return a list describing buffers to restore after command completion."
                         :auto-revert-mode auto-revert-enabled)
                   buffers)))))))
 
+(defun ellama-tools--refresh-file-buffer-if-stale (buffer)
+  "Refresh BUFFER when its visited file changed and it is safe to do so.
+Return a warning string when BUFFER cannot be refreshed safely, or nil."
+  (when (buffer-live-p buffer)
+    (with-current-buffer buffer
+      (condition-case err
+          (when-let* ((file-name (buffer-file-name buffer))
+                      ((not (verify-visited-file-modtime buffer))))
+            (cond
+             ((buffer-modified-p)
+              (format
+               (concat
+                "File changed on disk, but its buffer has unsaved changes "
+                "and was not refreshed: %s")
+               file-name))
+             ((not (file-exists-p file-name))
+              (format
+               "File no longer exists; its buffer was not refreshed: %s"
+               file-name))
+             (t
+              (revert-buffer t t t)
+              nil)))
+        (error
+         (format "Could not refresh buffer for %s: %s"
+                 (or (buffer-file-name buffer) (buffer-name buffer))
+                 (error-message-string err)))))))
+
 (defun ellama-tools--restore-shell-command-file-buffers (buffers)
-  "Silently revert BUFFERS and restore their previous auto-revert state."
-  (dolist (state buffers)
-    (let ((buffer (plist-get state :buffer))
-          (auto-revert-enabled (plist-get state :auto-revert-mode)))
-      (when (buffer-live-p buffer)
-        (with-current-buffer buffer
-          (unwind-protect
-              (condition-case nil
-                  (revert-buffer t t t)
-                (error nil))
-            (when auto-revert-enabled
-              (auto-revert-mode 1))))))))
+  "Refresh stale BUFFERS and restore their previous auto-revert state.
+Return warnings for buffers that could not be refreshed safely."
+  (let (warnings)
+    (dolist (state buffers (nreverse warnings))
+      (let ((buffer (plist-get state :buffer))
+            (auto-revert-enabled (plist-get state :auto-revert-mode)))
+        (when (buffer-live-p buffer)
+          (with-current-buffer buffer
+            (unwind-protect
+                (when-let* ((warning
+                             (ellama-tools--refresh-file-buffer-if-stale
+                              buffer)))
+                  (push warning warnings))
+              (when auto-revert-enabled
+                (auto-revert-mode 1)))))))))
+
+(defun ellama-tools--shell-command-result-with-buffer-warnings
+    (result warnings)
+  "Append buffer refresh WARNINGS to shell command RESULT."
+  (if (not warnings)
+      result
+    (concat result
+            "\n\nBuffer refresh warnings:\n"
+            (mapconcat (lambda (warning)
+                         (concat "- " warning))
+                       warnings
+                       "\n"))))
 
 (defun ellama-tools--call-command-to-string (program &rest args)
   "Run PROGRAM with ARGS and return stdout as a string."
@@ -3005,13 +3047,11 @@ stop on the first failure.  After hooks run all commands."
       (run hooks nil nil))))
 
 (defun ellama-tools--refresh-file-buffer-after-hooks (file-name)
-  "Refresh unmodified visiting buffer for FILE-NAME after shell hooks."
+  "Refresh visiting buffer for FILE-NAME after shell hooks.
+Return a warning string when it cannot be refreshed safely, or nil."
   (let ((expanded (expand-file-name file-name)))
     (when-let* ((buffer (get-file-buffer expanded)))
-      (with-current-buffer buffer
-        (when (and (not (buffer-modified-p))
-                   (file-exists-p expanded))
-          (revert-buffer t t t))))))
+      (ellama-tools--refresh-file-buffer-if-stale buffer))))
 
 (defun ellama-tools--edit-output
     (main-message before-sections after-sections)
@@ -3043,8 +3083,18 @@ edit.  CALLBACK receives the final tool output after all relevant hooks finish."
          (ellama-tools--run-edit-shell-hooks
           'after file-name operation tool-name
           (lambda (after)
-            (let ((after-sections (plist-get after :sections)))
-              (ellama-tools--refresh-file-buffer-after-hooks file-name)
+            (let* ((after-sections (plist-get after :sections))
+                   (refresh-warning
+                    (ellama-tools--refresh-file-buffer-after-hooks file-name))
+                   (after-sections
+                    (if refresh-warning
+                        (append
+                         after-sections
+                         (list (ellama-tools--make-output-section
+                                'buffer-refresh-warning
+                                refresh-warning
+                                nil)))
+                      after-sections)))
               (funcall
                callback
                (ellama-tools--edit-output
@@ -3406,16 +3456,20 @@ TIMEOUT is the optional command timeout in seconds."
 (defun ellama-tools--write-file-buffer-content (file-name content)
   "Write CONTENT to FILE-NAME and update any visiting buffer."
   (let ((buffer (find-file-noselect file-name)))
-    (with-current-buffer buffer
-      (let ((coding-system-for-write 'raw-text)
-            (buffer-undo-list t)
-            (inhibit-read-only t))
-        (erase-buffer)
-        (insert content)
-        (save-buffer)
-        ;; Revert the buffer silently to avoid user prompts when
-        ;; Emacs detects that the visited file has changed on disk.
-        (revert-buffer t t t)))))
+    (with-temp-buffer
+      (insert content)
+      (let ((source (current-buffer)))
+        (with-current-buffer buffer
+          (let ((coding-system-for-write 'raw-text)
+                (buffer-undo-list t)
+                (inhibit-read-only t))
+            (save-restriction
+              (widen)
+              (replace-buffer-contents source))
+            (save-buffer)
+            ;; Revert the buffer silently to avoid user prompts when
+            ;; Emacs detects that the visited file has changed on disk.
+            (revert-buffer t t t)))))))
 
 (defun ellama-tools-edit-file-tool (callback file-name oldcontent newcontent)
   "Edit FILE-NAME and call CALLBACK with the result.
@@ -3524,10 +3578,13 @@ TIMEOUT is the optional command timeout in seconds."
                    (when timer
                      (cancel-timer timer))
                    (unwind-protect
-                       (progn
-                         (ellama-tools--restore-shell-command-file-buffers
-                          file-buffers)
-                         (funcall callback result))
+                       (let ((warnings
+                              (ellama-tools--restore-shell-command-file-buffers
+                               file-buffers)))
+                         (funcall
+                          callback
+                          (ellama-tools--shell-command-result-with-buffer-warnings
+                           result warnings)))
                      (when (buffer-live-p buf)
                        (kill-buffer buf)))))
                (finish-process (proc)
@@ -3568,10 +3625,14 @@ TIMEOUT is the optional command timeout in seconds."
                          (delete-process process)
                          (finish result))))))))
       (error
-       (ellama-tools--restore-shell-command-file-buffers file-buffers)
-       (funcall callback
-                (format "Failed to start shell command: %s"
-                        (error-message-string err))))))
+       (let ((warnings
+              (ellama-tools--restore-shell-command-file-buffers file-buffers)))
+         (funcall
+          callback
+          (ellama-tools--shell-command-result-with-buffer-warnings
+           (format "Failed to start shell command: %s"
+                   (error-message-string err))
+           warnings))))))
   ;; async tool should always return nil
   ;; to work properly with the llm library
   nil)
@@ -3778,7 +3839,8 @@ ANSWER-VARIANT-LIST is a list of possible answer variants."))
         (if (file-directory-p file-name)
             (format "%s is a directory, not a file." file-name)
           (with-current-buffer (find-file-noselect file-name)
-            (count-lines (point-min) (point-max)))))))
+            (save-excursion
+              (count-lines (point-min) (point-max))))))))
 
 (ellama-tools-define-tool
  '(:function

--- a/ellama.el
+++ b/ellama.el
@@ -6,7 +6,7 @@
 ;; URL: http://github.com/s-kostyaev/ellama
 ;; Keywords: help local tools
 ;; Package-Requires: ((emacs "28.1") (llm "0.31.1") (plz "0.8") (transient "0.7") (compat "29.1") (yaml "1.2.3"))
-;; Version: 1.32.0
+;; Version: 1.32.1
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;; Created: 8th Oct 2023
 

--- a/tests/test-ellama-tools.el
+++ b/tests/test-ellama-tools.el
@@ -3358,6 +3358,79 @@ Return list with result and prompt."
       (when (file-exists-p dst)
         (delete-file dst)))))
 
+(ert-deftest test-ellama-tools-move-file-updates-visiting-buffer ()
+  (ellama-test--ensure-local-ellama-tools)
+  (let* ((src (make-temp-file "ellama-move-buffer-src-"))
+         (dst (concat src "-dst"))
+         (ellama-tools-read-before-write-enabled nil)
+         buffer expected-point expected-content)
+    (unwind-protect
+        (progn
+          (with-temp-file src
+            (insert "one\ntwo\nthree\n"))
+          (setq buffer (find-file-noselect src))
+          (with-current-buffer buffer
+            (goto-char (point-min))
+            (insert "unsaved\n")
+            (search-forward "two")
+            (setq expected-point (point)
+                  expected-content (buffer-string)))
+          (should
+           (equal (ellama-tools-move-file-tool src dst)
+                  (format "Moved %s to %s." src dst)))
+          (should-not (file-exists-p src))
+          (should (file-exists-p dst))
+          (should-not (get-file-buffer src))
+          (should (eq (get-file-buffer dst) buffer))
+          (with-current-buffer buffer
+            (should (equal buffer-file-name (expand-file-name dst)))
+            (should (buffer-modified-p))
+            (should (= (point) expected-point))
+            (should (equal (buffer-string) expected-content))
+            (save-buffer))
+          (with-temp-buffer
+            (insert-file-contents dst)
+            (should (equal (buffer-string) expected-content))))
+      (when (buffer-live-p buffer)
+        (with-current-buffer buffer
+          (set-buffer-modified-p nil))
+        (kill-buffer buffer))
+      (when (file-exists-p src)
+        (delete-file src))
+      (when (file-exists-p dst)
+        (delete-file dst)))))
+
+(ert-deftest test-ellama-tools-move-file-rejects-visiting-destination ()
+  (ellama-test--ensure-local-ellama-tools)
+  (let* ((src (make-temp-file "ellama-move-buffer-conflict-src-"))
+         (dst (concat src "-dst"))
+         (ellama-tools-read-before-write-enabled nil)
+         destination-buffer)
+    (unwind-protect
+        (progn
+          (with-temp-file src
+            (insert "source"))
+          (setq destination-buffer (find-file-noselect dst))
+          (should
+           (equal
+            (ellama-tools-move-file-tool src dst)
+            (format
+             (concat
+              "Cannot move file: destination is visited by another buffer: "
+              "%s.")
+             dst)))
+          (should (file-exists-p src))
+          (should-not (file-exists-p dst))
+          (should (eq (get-file-buffer dst) destination-buffer)))
+      (when (buffer-live-p destination-buffer)
+        (with-current-buffer destination-buffer
+          (set-buffer-modified-p nil))
+        (kill-buffer destination-buffer))
+      (when (file-exists-p src)
+        (delete-file src))
+      (when (file-exists-p dst)
+        (delete-file dst)))))
+
 (ert-deftest test-ellama-tools-lines-range-boundary ()
   (ellama-test--ensure-local-ellama-tools)
   (let ((file (make-temp-file "ellama-lines-range-")))

--- a/tests/test-ellama-tools.el
+++ b/tests/test-ellama-tools.el
@@ -375,6 +375,107 @@ Return list with result and prompt."
       (when (file-directory-p dir)
         (delete-directory dir)))))
 
+(ert-deftest test-ellama-shell-command-tool-leaves-unchanged-buffer-alone ()
+  (ellama-test--ensure-local-ellama-tools)
+  (let* ((dir (make-temp-file "ellama-shell-buffer-unchanged-" t))
+         (file (expand-file-name "note.txt" dir))
+         (default-directory (file-name-as-directory dir))
+         buffer expected-point expected-content)
+    (unwind-protect
+        (progn
+          (with-temp-file file
+            (insert "one\ntwo\nthree\n"))
+          (setq buffer (find-file-noselect file))
+          (with-current-buffer buffer
+            (goto-char (point-min))
+            (insert "unsaved\n")
+            (search-forward "two")
+            (setq expected-point (point)
+                  expected-content (buffer-string)))
+          (should
+           (equal
+            (ellama-test--wait-shell-command-result "true")
+            "Command completed successfully with no output."))
+          (with-current-buffer buffer
+            (should (buffer-modified-p))
+            (should (= (point) expected-point))
+            (should (equal (buffer-string) expected-content))))
+      (when (buffer-live-p buffer)
+        (with-current-buffer buffer
+          (set-buffer-modified-p nil))
+        (kill-buffer buffer))
+      (when (file-exists-p file)
+        (delete-file file))
+      (when (file-directory-p dir)
+        (delete-directory dir)))))
+
+(ert-deftest test-ellama-shell-command-tool-protects-modified-stale-buffer ()
+  (ellama-test--ensure-local-ellama-tools)
+  (let* ((dir (make-temp-file "ellama-shell-buffer-modified-" t))
+         (file (expand-file-name "note.txt" dir))
+         (default-directory (file-name-as-directory dir))
+         buffer expected-point expected-content)
+    (unwind-protect
+        (progn
+          (with-temp-file file
+            (insert "one\ntwo\nthree\n"))
+          (setq buffer (find-file-noselect file))
+          (with-current-buffer buffer
+            (goto-char (point-min))
+            (insert "unsaved\n")
+            (search-forward "two")
+            (setq expected-point (point)
+                  expected-content (buffer-string)))
+          (let ((result
+                 (ellama-test--wait-shell-command-result
+                  "printf disk-new > note.txt")))
+            (should (string-match-p "Buffer refresh warnings" result))
+            (should (string-match-p "unsaved changes" result)))
+          (with-current-buffer buffer
+            (should (buffer-modified-p))
+            (should (= (point) expected-point))
+            (should (equal (buffer-string) expected-content)))
+          (with-temp-buffer
+            (insert-file-contents file)
+            (should (equal (buffer-string) "disk-new"))))
+      (when (buffer-live-p buffer)
+        (with-current-buffer buffer
+          (set-buffer-modified-p nil))
+        (kill-buffer buffer))
+      (when (file-exists-p file)
+        (delete-file file))
+      (when (file-directory-p dir)
+        (delete-directory dir)))))
+
+(ert-deftest test-ellama-shell-command-tool-preserves-logical-point-on-refresh ()
+  (ellama-test--ensure-local-ellama-tools)
+  (let* ((dir (make-temp-file "ellama-shell-buffer-point-" t))
+         (file (expand-file-name "note.txt" dir))
+         (default-directory (file-name-as-directory dir))
+         buffer)
+    (unwind-protect
+        (progn
+          (with-temp-file file
+            (insert "one\ntwo\nthree\n"))
+          (setq buffer (find-file-noselect file))
+          (with-current-buffer buffer
+            (goto-char (point-min))
+            (search-forward "three")
+            (goto-char (match-beginning 0)))
+          (should
+           (equal
+            (ellama-test--wait-shell-command-result
+             "printf 'prefix\\none\\ntwo\\nthree\\n' > note.txt")
+            "Command completed successfully with no output."))
+          (with-current-buffer buffer
+            (should (looking-at-p "three"))))
+      (when (buffer-live-p buffer)
+        (kill-buffer buffer))
+      (when (file-exists-p file)
+        (delete-file file))
+      (when (file-directory-p dir)
+        (delete-directory dir)))))
+
 (ert-deftest test-ellama-shell-command-tool-default-timeout ()
   (ellama-test--ensure-local-ellama-tools)
   (let ((ellama-tools-shell-command-default-timeout 5))
@@ -2524,6 +2625,124 @@ Return list with result and prompt."
       (when (file-exists-p file)
         (delete-file file)))))
 
+(ert-deftest test-ellama-tools-mutating-file-tools-preserve-logical-point ()
+  (ellama-test--ensure-local-ellama-tools)
+  (let ((ellama-tools-edit-before-shell-commands nil)
+        (ellama-tools-edit-after-shell-commands nil)
+        (ellama-tools-read-before-write-enabled nil)
+        (original "one\ntwo\nthree\n"))
+    (dolist (operation '(write append prepend edit))
+      (let ((file (make-temp-file "ellama-file-tool-point-" nil ".txt"))
+            buffer)
+        (unwind-protect
+            (ert-info ((format "Operation: %s" operation))
+              (with-temp-file file
+                (insert original))
+              (setq buffer (find-file-noselect file))
+              (with-current-buffer buffer
+                (goto-char (point-min))
+                (search-forward "three")
+                (goto-char (match-beginning 0)))
+              (pcase operation
+                ('write
+                 (ellama-test--wait-tool-result
+                  #'ellama-tools-write-file-tool
+                  file
+                  (concat "prefix\n" original)))
+                ('append
+                 (ellama-test--wait-tool-result
+                  #'ellama-tools-append-file-tool file "tail\n"))
+                ('prepend
+                 (ellama-test--wait-tool-result
+                  #'ellama-tools-prepend-file-tool file "prefix\n"))
+                ('edit
+                 (ellama-test--wait-tool-result
+                  #'ellama-tools-edit-file-tool
+                  file "two" "a longer second line")))
+              (with-current-buffer buffer
+                (should (looking-at-p "three"))
+                (should-not (eobp))))
+          (when (buffer-live-p buffer)
+            (kill-buffer buffer))
+          (when (file-exists-p file)
+            (delete-file file)))))))
+
+(ert-deftest test-ellama-tools-edit-after-hook-preserves-logical-point ()
+  (ellama-test--ensure-local-ellama-tools)
+  (let* ((file (make-temp-file "ellama-after-hook-point-" nil ".txt"))
+         (original "one\ntwo\nthree\n")
+         (ellama-tools-edit-before-shell-commands nil)
+         (ellama-tools-edit-after-shell-commands
+          '((:command
+             "printf 'prefix\\none\\ntwo\\nthree\\n' > \"$ELLAMA_FILE_NAME\"")))
+         (ellama-tools-read-before-write-enabled nil)
+         buffer)
+    (unwind-protect
+        (progn
+          (with-temp-file file
+            (insert original))
+          (setq buffer (find-file-noselect file))
+          (with-current-buffer buffer
+            (goto-char (point-min))
+            (search-forward "three")
+            (goto-char (match-beginning 0)))
+          (ellama-test--wait-tool-result
+           #'ellama-tools-write-file-tool file original)
+          (with-current-buffer buffer
+            (should (looking-at-p "three"))))
+      (when (buffer-live-p buffer)
+        (kill-buffer buffer))
+      (when (file-exists-p file)
+        (delete-file file)))))
+
+(ert-deftest test-ellama-tools-edit-after-hook-protects-user-changes ()
+  (ellama-test--ensure-local-ellama-tools)
+  (let* ((file (make-temp-file "ellama-after-hook-modified-" nil ".txt"))
+         (original "one\ntwo\nthree\n")
+         (ellama-tools-edit-before-shell-commands nil)
+         (ellama-tools-edit-after-shell-commands
+          '((:command
+             "sleep 0.1; printf hook-new > \"$ELLAMA_FILE_NAME\"")))
+         (ellama-tools-read-before-write-enabled nil)
+         (result :pending)
+         buffer expected-point expected-content)
+    (unwind-protect
+        (progn
+          (with-temp-file file
+            (insert original))
+          (setq buffer (find-file-noselect file))
+          (should-not
+           (ellama-tools-write-file-tool
+            (lambda (output)
+              (setq result output))
+            file original))
+          (with-current-buffer buffer
+            (goto-char (point-min))
+            (insert "unsaved\n")
+            (search-forward "two")
+            (setq expected-point (point)
+                  expected-content (buffer-string)))
+          (let ((deadline (+ (float-time) 3.0)))
+            (while (and (eq result :pending)
+                        (< (float-time) deadline))
+              (accept-process-output nil 0.01)))
+          (when (eq result :pending)
+            (ert-fail "Timeout waiting for edit hook result"))
+          (should (string-match-p "unsaved changes" result))
+          (with-current-buffer buffer
+            (should (buffer-modified-p))
+            (should (= (point) expected-point))
+            (should (equal (buffer-string) expected-content)))
+          (with-temp-buffer
+            (insert-file-contents file)
+            (should (equal (buffer-string) "hook-new"))))
+      (when (buffer-live-p buffer)
+        (with-current-buffer buffer
+          (set-buffer-modified-p nil))
+        (kill-buffer buffer))
+      (when (file-exists-p file)
+        (delete-file file)))))
+
 (ert-deftest test-ellama-tools-edit-after-hook-shows-enabled-output ()
   (ellama-test--ensure-local-ellama-tools)
   (let ((file (make-temp-file "ellama-after-hook-show-"))
@@ -2851,6 +3070,38 @@ Return list with result and prompt."
       (when (file-exists-p file)
         (delete-file file)))))
 
+(ert-deftest test-ellama-tools-rejected-edit-preserves-point ()
+  (ellama-test--ensure-local-ellama-tools)
+  (let* ((file (make-temp-file "ellama-edit-rejected-point-" nil ".el"))
+         (original
+          (concat
+           "(defun first ()\n  (message \"first\"))\n\n"
+           "(defun second ()\n  (message \"second\"))\n"))
+         buffer expected-point)
+    (unwind-protect
+        (progn
+          (with-temp-file file
+            (insert original))
+          (setq buffer (find-file-noselect file))
+          (with-current-buffer buffer
+            (goto-char (point-min))
+            (search-forward "second")
+            (setq expected-point (point)))
+          (let ((result
+                 (ellama-test--wait-tool-result
+                  #'ellama-tools-edit-file-tool
+                  file
+                  "(defun first ()\n  (message \"first\"))"
+                  "(defun first ()\n  (message \"first\")")))
+            (should (string-match-p "Edit rejected" result)))
+          (with-current-buffer buffer
+            (should (= (point) expected-point))
+            (should (equal (buffer-string) original))))
+      (when (buffer-live-p buffer)
+        (kill-buffer buffer))
+      (when (file-exists-p file)
+        (delete-file file)))))
+
 (ert-deftest test-ellama-tools-write-file-rejects-invalid-elisp ()
   (ellama-test--ensure-local-ellama-tools)
   (let ((file (make-temp-file "ellama-write-invalid-" nil ".el")))
@@ -3133,6 +3384,37 @@ Return list with result and prompt."
       (delete-file file))
     (should (equal (ellama-tools-count-lines-tool file)
                    (format "File %s does not exist." file)))))
+
+(ert-deftest test-ellama-tools-read-only-file-tools-preserve-point ()
+  (ellama-test--ensure-local-ellama-tools)
+  (let* ((dir (make-temp-file "ellama-read-only-point-" t))
+         (file (expand-file-name "note.txt" dir))
+         buffer expected-point)
+    (unwind-protect
+        (progn
+          (with-temp-file file
+            (insert "alpha\nbeta\ngamma\n"))
+          (setq buffer (find-file-noselect file))
+          (with-current-buffer buffer
+            (goto-char (point-min))
+            (search-forward "beta")
+            (setq expected-point (point)))
+          (dolist (reader
+                   (list
+                    (lambda () (ellama-tools-read-file-tool file "text"))
+                    (lambda () (ellama-tools-grep-in-file-tool "beta" file))
+                    (lambda () (ellama-tools-grep-tool dir "beta"))
+                    (lambda () (ellama-tools-count-lines-tool file))
+                    (lambda () (ellama-tools-lines-range-tool file 1 2))))
+            (funcall reader)
+            (with-current-buffer buffer
+              (should (= (point) expected-point)))))
+      (when (buffer-live-p buffer)
+        (kill-buffer buffer))
+      (when (file-exists-p file)
+        (delete-file file))
+      (when (file-directory-p dir)
+        (delete-directory dir)))))
 
 (ert-deftest test-ellama-tools-lines-range-explains-invalid-input ()
   (ellama-test--ensure-local-ellama-tools)

--- a/tests/test-ellama-tools.el
+++ b/tests/test-ellama-tools.el
@@ -2636,32 +2636,32 @@ Return list with result and prompt."
             buffer)
         (unwind-protect
             (ert-info ((format "Operation: %s" operation))
-              (with-temp-file file
-                (insert original))
-              (setq buffer (find-file-noselect file))
-              (with-current-buffer buffer
-                (goto-char (point-min))
-                (search-forward "three")
-                (goto-char (match-beginning 0)))
-              (pcase operation
-                ('write
-                 (ellama-test--wait-tool-result
-                  #'ellama-tools-write-file-tool
-                  file
-                  (concat "prefix\n" original)))
-                ('append
-                 (ellama-test--wait-tool-result
-                  #'ellama-tools-append-file-tool file "tail\n"))
-                ('prepend
-                 (ellama-test--wait-tool-result
-                  #'ellama-tools-prepend-file-tool file "prefix\n"))
-                ('edit
-                 (ellama-test--wait-tool-result
-                  #'ellama-tools-edit-file-tool
-                  file "two" "a longer second line")))
-              (with-current-buffer buffer
-                (should (looking-at-p "three"))
-                (should-not (eobp))))
+                      (with-temp-file file
+                        (insert original))
+                      (setq buffer (find-file-noselect file))
+                      (with-current-buffer buffer
+                        (goto-char (point-min))
+                        (search-forward "three")
+                        (goto-char (match-beginning 0)))
+                      (pcase operation
+                        ('write
+                         (ellama-test--wait-tool-result
+                          #'ellama-tools-write-file-tool
+                          file
+                          (concat "prefix\n" original)))
+                        ('append
+                         (ellama-test--wait-tool-result
+                          #'ellama-tools-append-file-tool file "tail\n"))
+                        ('prepend
+                         (ellama-test--wait-tool-result
+                          #'ellama-tools-prepend-file-tool file "prefix\n"))
+                        ('edit
+                         (ellama-test--wait-tool-result
+                          #'ellama-tools-edit-file-tool
+                          file "two" "a longer second line")))
+                      (with-current-buffer buffer
+                        (should (looking-at-p "three"))
+                        (should-not (eobp))))
           (when (buffer-live-p buffer)
             (kill-buffer buffer))
           (when (file-exists-p file)


### PR DESCRIPTION
Summary
- preserve point and markers when write_file, append_file, prepend_file, and edit_file update visiting buffers
- keep an open source buffer attached to the destination after move_file while preserving point and unsaved changes
- reject move_file destinations already visited by another buffer
- refresh only stale unmodified buffers after shell commands and edit hooks
- keep unsaved buffer changes intact and report refresh conflicts
- cover mutating, read-only, validation, move, shell command, and edit hook paths with regression tests

Tests
- make test (547 tests)
- make build
- make check-compile-warnings
- make checkdocs
- pre-push make check-elisp