### PR TITLE
Omit tool results from session compaction by default

### DIFF
--- a/README.org
+++ b/README.org
@@ -447,6 +447,9 @@ generated text string.
   session provider.
 - ~ellama-session-auto-compact-show-message~: Show compaction notices in chat
   buffers. Enabled by default.
+- ~ellama-session-auto-compact-include-tool-results~: Include tool results in
+  the history sent to the compaction provider. Disabled by default. Tool calls
+  are still included so the summary can record actions taken during the session.
 - ~ellama-session-auto-compact-prompt-template~: Prompt template for automatic
   session context compaction.
 - ~ellama-naming-scheme~: How to name new sessions.
@@ -726,6 +729,11 @@ The system message is not summarized by the compaction LLM.  Ellama restores the
 original system message in the compacted session prompt context, including when
 an LLM provider moved the system message into a system interaction before the
 request.
+
+Tool calls are included in the history sent to the compaction provider, but tool
+results are omitted by default.  Set
+~ellama-session-auto-compact-include-tool-results~ to a non-nil value when the
+summary needs the full tool output.
 
 Example configuration:
 

--- a/ellama-eval.el
+++ b/ellama-eval.el
@@ -105,7 +105,7 @@ Only one evaluation run is supported at a time.")
   "Tool names included in every hypothesis profile.")
 
 (defconst ellama-eval-hypothesis-profiles
-  '(baseline balanced-edit)
+  '(baseline balanced-edit balanced-edit-hooks)
   "Profiles used by hypothesis suites.")
 
 (defconst ellama-eval--coder-system
@@ -437,19 +437,59 @@ in one short sentence."
     (error "Unknown evaluation profile %S" profile))
   (append ellama-eval--base-tool-names '("edit_file")))
 
+(defun ellama-eval--emacs-executable ()
+  "Return the Emacs executable used to run the current process."
+  (or (and invocation-directory
+           invocation-name
+           (expand-file-name invocation-name invocation-directory))
+      (and invocation-name (executable-find invocation-name))
+      invocation-name
+      "emacs"))
+
+(defun ellama-eval--byte-compile-hook-command ()
+  "Return shell command for the eval byte-compilation edit hook."
+  (mapconcat
+   #'identity
+   (list (shell-quote-argument (ellama-eval--emacs-executable))
+         "-Q"
+         "--batch"
+         "--load"
+         (shell-quote-argument
+          (expand-file-name "byte-compile-hook.el"
+                            ellama-eval--fixtures-directory)))
+   " "))
+
+(defun ellama-eval-hooked-edit-file-tool
+    (callback file-name oldcontent newcontent)
+  "Edit FILE-NAME and validate it through balanced edit and a shell hook.
+OLDCONTENT is replaced with NEWCONTENT.  CALLBACK receives the complete edit
+result, including byte-compilation hook failures that the agent can act on."
+  (let ((ellama-tools-balanced-edit-enabled t)
+        (ellama-tools-edit-before-shell-commands nil)
+        (ellama-tools-edit-after-shell-commands
+         `((:name "byte-compile"
+                  :command ,(ellama-eval--byte-compile-hook-command)))))
+    (ellama-tools-edit-file-tool callback file-name oldcontent newcontent)))
+
 
 
 (defun ellama-eval--replace-profile-edit-specs (spec profile)
   "Return SPEC adjusted for edit validation in PROFILE."
   (pcase (plist-get spec :name)
     ("edit_file"
-     (plist-put
-      (copy-sequence spec)
-      :function
-      (lambda (file-name oldcontent newcontent)
-        (ellama-eval-monitored-edit-file-tool
-         file-name oldcontent newcontent
-         (eq profile 'balanced-edit)))))
+     (if (eq profile 'balanced-edit-hooks)
+         (let ((hooked (copy-sequence spec)))
+           (setq hooked
+                 (plist-put hooked :function
+                            #'ellama-eval-hooked-edit-file-tool))
+           (plist-put hooked :async t))
+       (plist-put
+        (copy-sequence spec)
+        :function
+        (lambda (file-name oldcontent newcontent)
+          (ellama-eval-monitored-edit-file-tool
+           file-name oldcontent newcontent
+           (eq profile 'balanced-edit))))))
     (_
      spec)))
 
@@ -556,19 +596,37 @@ for the agent."
 (defun ellama-eval--instrument-tool-spec (spec)
   "Return SPEC with tool function wrapped for eval tracing."
   (let ((name (plist-get spec :name))
-        (function (plist-get spec :function)))
+        (function (plist-get spec :function))
+        (async (plist-get spec :async)))
     (plist-put
      (copy-sequence spec)
      :function
      (lambda (&rest args)
-       (condition-case err
-           (let ((result (apply function args)))
-             (or (ellama-eval--trace-tool-call name args 'ok result)
-                 result))
-         (error
-          (ellama-eval--trace-tool-call
-           name args 'error (error-message-string err))
-          (signal (car err) (cdr err))))))))
+       (if (and async args (functionp (car args)))
+           (let ((callback (car args))
+                 (call-args (cdr args)))
+             (condition-case err
+                 (apply
+                  function
+                  (lambda (result)
+                    (funcall
+                     callback
+                     (or (ellama-eval--trace-tool-call
+                          name call-args 'ok result)
+                         result)))
+                  call-args)
+               (error
+                (ellama-eval--trace-tool-call
+                 name call-args 'error (error-message-string err))
+                (signal (car err) (cdr err)))))
+         (condition-case err
+             (let ((result (apply function args)))
+               (or (ellama-eval--trace-tool-call name args 'ok result)
+                   result))
+           (error
+            (ellama-eval--trace-tool-call
+             name args 'error (error-message-string err))
+            (signal (car err) (cdr err)))))))))
 
 (defun ellama-eval--make-profile-tools (profile)
   "Return instrumented `llm' tools for PROFILE."
@@ -1190,6 +1248,48 @@ ELISP-CHECKS and ANSWER-CHECKS contain oracle results."
             (setq pending (remove file pending)))))))
     count))
 
+(defun ellama-eval--tool-trace-result (entry)
+  "Return the original tool result text from trace ENTRY."
+  (or (plist-get entry :raw-result)
+      (plist-get entry :result)))
+
+(defun ellama-eval--edit-hook-failure-p (entry)
+  "Return non-nil when tool trace ENTRY reports an edit hook failure."
+  (let ((result (ellama-eval--tool-trace-result entry)))
+    (and (equal (plist-get entry :name) "edit_file")
+         (stringp result)
+         (string-match-p
+          "\\(?:Before\\|After\\) edit hook.* failed with exit status"
+          result))))
+
+(defun ellama-eval--successful-edit-p (entry)
+  "Return non-nil when tool trace ENTRY reports an applied successful edit."
+  (let ((result (ellama-eval--tool-trace-result entry)))
+    (and (equal (plist-get entry :name) "edit_file")
+         (stringp result)
+         (string-match-p "\\`Edited " result)
+         (not (ellama-eval--edit-hook-failure-p entry)))))
+
+(defun ellama-eval--edit-hook-failure-count (trace)
+  "Return number of edit hook failures recorded in TRACE."
+  (cl-count-if #'ellama-eval--edit-hook-failure-p trace))
+
+(defun ellama-eval--edit-hook-recovery-count (trace)
+  "Return number of edit hook failures recovered later in TRACE."
+  (let ((count 0)
+        pending)
+    (dolist (entry trace)
+      (let ((file (car (plist-get entry :args))))
+        (cond
+         ((and file (ellama-eval--edit-hook-failure-p entry))
+          (cl-pushnew file pending :test #'equal))
+         ((and file
+               (member file pending)
+               (ellama-eval--successful-edit-p entry))
+          (setq count (1+ count)
+                pending (remove file pending))))))
+    count))
+
 (defun ellama-eval--final-syntax-check-paths (expected-files syntax-files)
   "Return relative paths from EXPECTED-FILES and SYNTAX-FILES."
   (delete-dups
@@ -1345,6 +1445,10 @@ EXPECTED-FILES and SYNTAX-FILES define the relative file paths to check."
                   validation-trace)
      :edit-recovery-count
      (ellama-eval--edit-recovery-count validation-trace)
+     :edit-hook-failure-count
+     (ellama-eval--edit-hook-failure-count trace)
+     :edit-hook-recovery-count
+     (ellama-eval--edit-hook-recovery-count trace)
      :syntax-valid-final-files
      (ellama-eval--syntax-check-count final-syntax-checks t)
      :syntax-invalid-final-files

--- a/ellama.el
+++ b/ellama.el
@@ -157,6 +157,11 @@ When nil, use `ellama-summarization-provider', then the session provider."
   "Show compaction notices in chat buffers."
   :type 'boolean)
 
+(defcustom ellama-session-auto-compact-include-tool-results nil
+  "Include tool results in the history sent for session compaction.
+Tool calls remain in the compaction input when this option is nil."
+  :type 'boolean)
+
 (defcustom ellama-session-persist-provider-keys nil
   "Control provider key persistence in session files.
 When nil, provider keys are removed before saving sessions and restored
@@ -1907,26 +1912,30 @@ Return the output FILE-NAME.  Finish the recording with
    "\n\n"))
 
 (defun ellama--session-compact-render-interaction (interaction)
-  "Render INTERACTION for summary generation."
+  "Render INTERACTION for summary generation, or return nil when omitted."
   (let ((role (llm-chat-prompt-interaction-role interaction))
         (content (llm-chat-prompt-interaction-content interaction))
         (tool-results (llm-chat-prompt-interaction-tool-results
                        interaction)))
-    (string-join
-     (delq nil
-           (list
-            (format "%s:\n%s"
-                    (capitalize (symbol-name role))
-                    (ellama--session-compact-content-to-string content))
-            (when tool-results
-              (format "Tool results:\n%s"
-                      (ellama--format-tool-results tool-results)))))
-     "\n")))
+    (unless (and (eq role 'tool-results)
+                 (not ellama-session-auto-compact-include-tool-results))
+      (string-join
+       (delq nil
+             (list
+              (format "%s:\n%s"
+                      (capitalize (symbol-name role))
+                      (ellama--session-compact-content-to-string content))
+              (when (and tool-results
+                         ellama-session-auto-compact-include-tool-results)
+                (format "Tool results:\n%s"
+                        (ellama--format-tool-results tool-results)))))
+       "\n"))))
 
 (defun ellama--session-compact-render-interactions (interactions)
   "Render INTERACTIONS for summary generation."
   (string-join
-   (mapcar #'ellama--session-compact-render-interaction interactions)
+   (delq nil
+         (mapcar #'ellama--session-compact-render-interaction interactions))
    "\n\n"))
 
 (defun ellama--session-compact-split-interactions

--- a/ellama.info
+++ b/ellama.info
@@ -733,6 +733,10 @@ argument generated text string.
      ‘ellama-summarization-provider’, then the session provider.
    • ‘ellama-session-auto-compact-show-message’: Show compaction notices
      in chat buffers.  Enabled by default.
+   • ‘ellama-session-auto-compact-include-tool-results’: Include tool
+     results in the history sent to the compaction provider.  Disabled
+     by default.  Tool calls are still included so the summary can
+     record actions taken during the session.
    • ‘ellama-session-auto-compact-prompt-template’: Prompt template for
      automatic session context compaction.
    • ‘ellama-naming-scheme’: How to name new sessions.
@@ -1082,6 +1086,11 @@ The system message is not summarized by the compaction LLM.  Ellama
 restores the original system message in the compacted session prompt
 context, including when an LLM provider moved the system message into a
 system interaction before the request.
+
+Tool calls are included in the history sent to the compaction provider,
+but tool results are omitted by default.  Set
+‘ellama-session-auto-compact-include-tool-results’ to a non-nil value
+when the summary needs the full tool output.
 
 Example configuration:
 
@@ -2928,52 +2937,52 @@ Node: Configuration26322
 Node: Option Reference26917
 Node: Core Behavior and Providers27446
 Node: Sessions and Naming29056
-Node: Task Providers and Media31939
-Node: Display Context and Reasoning32872
-Node: Blueprints Prompts and Conversion35975
-Node: Tool Prompts and Edit Behavior37276
-Node: DLP and Irreversible Actions38103
-Node: Transient Menus Community Prompts and Diagnostics39218
-Node: Tool Access and Sandboxing40648
-Node: Task Templates Blueprints and Skills43720
-Node: Agent and Subagent Loops45099
-Node: Session Provider Keys46395
-Node: Session Compaction47840
-Node: Image Input50134
-Node: Audio Input52449
-Node: macOS microphone permission55117
-Node: Task Tool Subagents57278
-Node: Plan-and-Act Agent Loop61184
-Node: Edit Tool Shell Hooks63765
-Node: DLP for Tool Input/Output66058
-Node: SRT Filesystem Policy for Tools81627
-Node: Context Management87298
-Node: Transient Menus for Context Management88366
-Node: Managing the Context90440
-Node: Considerations91215
-Node: Minor modes91542
-Node: ellama-context-header-line-mode92054
-Node: ellama-context-header-line-global-mode92672
-Node: ellama-context-mode-line-mode93076
-Node: ellama-context-mode-line-global-mode93655
-Node: ellama-session-header-line-mode94049
-Node: ellama-session-mode-line-mode94553
-Node: Using Blueprints94980
-Node: Key Components95376
-Node: Creating and Managing95735
-Node: Blueprint Files96373
-Node: Variables96792
-Node: Keymap and Mode97128
-Node: Transient Menus97652
-Node: Running Blueprints Programmatically98166
-Node: MCP Integration98720
-Node: Agent Skills99898
-Node: Directory Structure100297
-Node: Creating a Skill101277
-Node: How It Works101667
-Node: Acknowledgments102073
-Node: Contributions102759
-Node: GNU Free Documentation License103284
+Node: Task Providers and Media32199
+Node: Display Context and Reasoning33132
+Node: Blueprints Prompts and Conversion36235
+Node: Tool Prompts and Edit Behavior37536
+Node: DLP and Irreversible Actions38363
+Node: Transient Menus Community Prompts and Diagnostics39478
+Node: Tool Access and Sandboxing40908
+Node: Task Templates Blueprints and Skills43980
+Node: Agent and Subagent Loops45359
+Node: Session Provider Keys46655
+Node: Session Compaction48100
+Node: Image Input50632
+Node: Audio Input52947
+Node: macOS microphone permission55615
+Node: Task Tool Subagents57776
+Node: Plan-and-Act Agent Loop61682
+Node: Edit Tool Shell Hooks64263
+Node: DLP for Tool Input/Output66556
+Node: SRT Filesystem Policy for Tools82125
+Node: Context Management87796
+Node: Transient Menus for Context Management88864
+Node: Managing the Context90938
+Node: Considerations91713
+Node: Minor modes92040
+Node: ellama-context-header-line-mode92552
+Node: ellama-context-header-line-global-mode93170
+Node: ellama-context-mode-line-mode93574
+Node: ellama-context-mode-line-global-mode94153
+Node: ellama-session-header-line-mode94547
+Node: ellama-session-mode-line-mode95051
+Node: Using Blueprints95478
+Node: Key Components95874
+Node: Creating and Managing96233
+Node: Blueprint Files96871
+Node: Variables97290
+Node: Keymap and Mode97626
+Node: Transient Menus98150
+Node: Running Blueprints Programmatically98664
+Node: MCP Integration99218
+Node: Agent Skills100396
+Node: Directory Structure100795
+Node: Creating a Skill101775
+Node: How It Works102165
+Node: Acknowledgments102571
+Node: Contributions103257
+Node: GNU Free Documentation License103782
 
 End Tag Table
 

--- a/tests/fixtures/ellama-eval/byte-compile-hook.el
+++ b/tests/fixtures/ellama-eval/byte-compile-hook.el
@@ -1,0 +1,26 @@
+;;; byte-compile-hook.el --- Eval edit hook -*- lexical-binding: t; -*-
+
+;;; Commentary:
+;;
+;; Byte-compile the file identified by ELLAMA_FILE_NAME and exit unsuccessfully
+;; when compilation reports warnings or errors.
+
+;;; Code:
+
+(require 'bytecomp)
+(require 'seq)
+(require 'subr-x)
+
+(setq byte-compile-error-on-warn t
+      byte-compile-dest-file-function (lambda (_file) null-device))
+
+(condition-case err
+    (unless (byte-compile-file (getenv "ELLAMA_FILE_NAME"))
+      (princ "Hook validation failed: byte compilation reported errors.\n")
+      (kill-emacs 1))
+  (error
+   (princ (format "Hook validation failed: %s\n"
+                  (error-message-string err)))
+   (kill-emacs 1)))
+
+;;; byte-compile-hook.el ends here

--- a/tests/fixtures/ellama-eval/cases/edit-expand-guard-clause/workspace/strings.el
+++ b/tests/fixtures/ellama-eval/cases/edit-expand-guard-clause/workspace/strings.el
@@ -1,3 +1,4 @@
+;; -*- lexical-binding: t; -*-
 (defun ellama-eval-guarded-join (items)
   (if (null items)
       ""

--- a/tests/fixtures/ellama-eval/cases/edit-nested-accumulator/workspace/errors.el
+++ b/tests/fixtures/ellama-eval/cases/edit-nested-accumulator/workspace/errors.el
@@ -1,3 +1,4 @@
+;; -*- lexical-binding: t; -*-
 (defconst ellama-eval-warning-level 'warning
   "Level symbol used for non-fatal warning entries.")
 

--- a/tests/fixtures/ellama-eval/cases/edit-nested-backquote-template/workspace/dashboard.el
+++ b/tests/fixtures/ellama-eval/cases/edit-nested-backquote-template/workspace/dashboard.el
@@ -1,3 +1,4 @@
+;; -*- lexical-binding: t; -*-
 (defconst ellama-eval-dashboard-default-status 'unknown
   "Default dashboard row status symbol.")
 

--- a/tests/fixtures/ellama-eval/cases/edit-nested-branch-plists/workspace/request-router.el
+++ b/tests/fixtures/ellama-eval/cases/edit-nested-branch-plists/workspace/request-router.el
@@ -1,3 +1,4 @@
+;; -*- lexical-binding: t; -*-
 (defun ellama-eval-route-request (request)
   (let* ((headers (plist-get request :headers))
          (auth (alist-get "authorization" headers nil nil #'string=)))

--- a/tests/fixtures/ellama-eval/cases/edit-nested-condition-case/workspace/loader.el
+++ b/tests/fixtures/ellama-eval/cases/edit-nested-condition-case/workspace/loader.el
@@ -1,3 +1,4 @@
+;; -*- lexical-binding: t; -*-
 (defun ellama-eval-load-record (reader path)
   (condition-case err
       (let ((record (funcall reader path)))

--- a/tests/fixtures/ellama-eval/cases/edit-nested-filter-lambda/workspace/items.el
+++ b/tests/fixtures/ellama-eval/cases/edit-nested-filter-lambda/workspace/items.el
@@ -1,3 +1,4 @@
+;; -*- lexical-binding: t; -*-
 (defconst ellama-eval-inactive-item-flags '(disabled archived)
   "Item flags that remove an item from active listings.")
 

--- a/tests/fixtures/ellama-eval/cases/edit-nested-pcase-branch/workspace/message.el
+++ b/tests/fixtures/ellama-eval/cases/edit-nested-pcase-branch/workspace/message.el
@@ -1,3 +1,4 @@
+;; -*- lexical-binding: t; -*-
 (defconst ellama-eval-message-default-source 'internal
   "Default event message source symbol.")
 

--- a/tests/fixtures/ellama-eval/cases/edit-nested-plist-construction/workspace/event.el
+++ b/tests/fixtures/ellama-eval/cases/edit-nested-plist-construction/workspace/event.el
@@ -1,3 +1,4 @@
+;; -*- lexical-binding: t; -*-
 (defconst ellama-eval-event-payload-example
   '(:kind job :name "Build" :meta (:enabled t))
   "Example enabled event payload used by eval fixtures.")

--- a/tests/fixtures/ellama-eval/cases/edit-nested-state-machine/workspace/state.el
+++ b/tests/fixtures/ellama-eval/cases/edit-nested-state-machine/workspace/state.el
@@ -1,3 +1,4 @@
+;; -*- lexical-binding: t; -*-
 (defun ellama-eval-next-state (state event)
   (let ((kind (plist-get event :kind)))
     (cond

--- a/tests/fixtures/ellama-eval/cases/edit-remove-obsolete-binding/workspace/request.el
+++ b/tests/fixtures/ellama-eval/cases/edit-remove-obsolete-binding/workspace/request.el
@@ -1,3 +1,4 @@
+;; -*- lexical-binding: t; -*-
 (defun ellama-eval-build-request (payload kind)
   (let ((legacy-mode nil)
         (request-id (format "%s-%s" kind payload)))

--- a/tests/fixtures/ellama-eval/cases/edit-replace-function-body/workspace/sample.el
+++ b/tests/fixtures/ellama-eval/cases/edit-replace-function-body/workspace/sample.el
@@ -1,3 +1,4 @@
+;; -*- lexical-binding: t; -*-
 (defun ellama-eval-score-value (value limit weight)
   "Return VALUE scaled by WEIGHT, clamped to LIMIT."
   (* value weight))

--- a/tests/fixtures/ellama-eval/cases/edit-update-target-branch/workspace/router.el
+++ b/tests/fixtures/ellama-eval/cases/edit-update-target-branch/workspace/router.el
@@ -1,3 +1,4 @@
+;; -*- lexical-binding: t; -*-
 (defun ellama-eval-route-status (status)
   (cond
    ((eq status 'ready) 'run)

--- a/tests/fixtures/ellama-eval/cases/explore-identify-read-helper/workspace/reader.el
+++ b/tests/fixtures/ellama-eval/cases/explore-identify-read-helper/workspace/reader.el
@@ -1,3 +1,4 @@
+;; -*- lexical-binding: t; -*-
 (defun ellama-eval-read-file-tool (file)
   (ellama-eval-sanitize
    (ellama-eval-read-file-as-text file)))

--- a/tests/fixtures/ellama-eval/cases/explore-locate-provider/workspace/tools.el
+++ b/tests/fixtures/ellama-eval/cases/explore-locate-provider/workspace/tools.el
@@ -1,3 +1,4 @@
+;; -*- lexical-binding: t; -*-
 (defun ellama-eval-provider-for-role (role)
   (alist-get role ellama-eval-role-providers nil nil #'string=))
 

--- a/tests/fixtures/ellama-eval/cases/explore-summarize-policy/workspace/policy.el
+++ b/tests/fixtures/ellama-eval/cases/explore-summarize-policy/workspace/policy.el
@@ -1,3 +1,4 @@
+;; -*- lexical-binding: t; -*-
 (defun ellama-eval-check-write (path)
   (if (ellama-eval-path-allowed-p path)
       nil

--- a/tests/test-ellama-eval.el
+++ b/tests/test-ellama-eval.el
@@ -28,6 +28,21 @@
 (require 'ellama-eval)
 (require 'ert)
 
+(defun ellama-test-eval--wait-tool-result (function &rest args)
+  "Call asynchronous eval tool FUNCTION with ARGS and wait for its result."
+  (let ((result :pending)
+        (deadline (+ (float-time) 5.0)))
+    (apply function
+           (lambda (output)
+             (setq result output))
+           args)
+    (while (and (eq result :pending)
+                (< (float-time) deadline))
+      (accept-process-output nil 0.01))
+    (when (eq result :pending)
+      (ert-fail "Timeout waiting for asynchronous eval tool result"))
+    result))
+
 (ert-deftest test-ellama-eval-balanced-edit-file-tool-rejects-broken-elisp ()
   (let ((file (make-temp-file "ellama-eval-balanced-edit-" nil ".el")))
     (unwind-protect
@@ -144,16 +159,103 @@
         (delete-file file)))))
 
 (ert-deftest test-ellama-eval-profile-tools-switch-read-and-edit-shapes ()
-  "Verify both baseline and balanced-edit use edit_file."
+  "Verify every profile uses the expected read and edit tool shape."
   (let ((ellama-tools-allow-all t)
         (ellama-tools-allowed nil)
         (ellama-tools-confirm-allowed (make-hash-table))
         (baseline (ellama-eval--make-profile-tools 'baseline))
-        (balanced (ellama-eval--make-profile-tools 'balanced-edit)))
+        (balanced (ellama-eval--make-profile-tools 'balanced-edit))
+        (hooked (ellama-eval--make-profile-tools 'balanced-edit-hooks)))
     (should (member "edit_file" (mapcar #'llm-tool-name baseline)))
     (should (member "edit_file" (mapcar #'llm-tool-name balanced)))
+    (should (member "edit_file" (mapcar #'llm-tool-name hooked)))
     (should (member "read_file" (mapcar #'llm-tool-name baseline)))
-    (should (member "read_file" (mapcar #'llm-tool-name balanced)))))
+    (should (member "read_file" (mapcar #'llm-tool-name balanced)))
+    (should (member "read_file" (mapcar #'llm-tool-name hooked)))
+    (should-not
+     (llm-tool-async
+      (seq-find (lambda (tool)
+                  (string= (llm-tool-name tool) "edit_file"))
+                baseline)))
+    (should
+     (llm-tool-async
+      (seq-find (lambda (tool)
+                  (string= (llm-tool-name tool) "edit_file"))
+                hooked)))))
+
+(ert-deftest test-ellama-eval-hooked-edit-returns-byte-compile-feedback ()
+  (let* ((file (make-temp-file "ellama-eval-hooked-edit-" nil ".el"))
+         (old ";; -*- lexical-binding: t; -*-\n(defun sample () nil)\n")
+         (new ";; -*- lexical-binding: t; -*-\n(defun sample () (list? nil))\n")
+         (ellama-tools-allow-all t)
+         (ellama-tools-allowed nil)
+         (ellama-tools-confirm-allowed (make-hash-table))
+         (ellama-tools-read-before-write-enabled nil)
+         (state (make-ellama-eval--run-state :trace nil))
+         (ellama-eval--active-run state)
+         (tools (ellama-eval--make-profile-tools 'balanced-edit-hooks))
+         (edit-tool
+          (seq-find (lambda (tool)
+                      (string= (llm-tool-name tool) "edit_file"))
+                    tools)))
+    (unwind-protect
+        (progn
+          (with-temp-file file
+            (insert old))
+          (let ((result
+                 (ellama-test-eval--wait-tool-result
+                  (llm-tool-function edit-tool) file old new)))
+            (should (string-match-p
+                     "After edit hook `byte-compile` failed" result))
+            (should (string-match-p "list\\?" result))
+            (should (string-match-p "Hook validation failed" result))
+            (should (= (length (ellama-eval--run-state-trace state)) 1))
+            (should
+             (equal (plist-get
+                     (car (ellama-eval--run-state-trace state)) :result)
+                    result)))
+          (with-temp-buffer
+            (insert-file-contents file)
+            (should (equal (buffer-string) new))))
+      (when-let* ((buffer (get-file-buffer file)))
+        (kill-buffer buffer))
+      (when (file-exists-p file)
+        (delete-file file)))))
+
+(ert-deftest test-ellama-eval-hooked-edit-accepts-byte-compilable-code ()
+  (let* ((file (make-temp-file "ellama-eval-hooked-edit-" nil ".el"))
+         (old ";; -*- lexical-binding: t; -*-\n(defun sample () nil)\n")
+         (new ";; -*- lexical-binding: t; -*-\n(defun sample () t)\n")
+         (ellama-tools-read-before-write-enabled nil))
+    (unwind-protect
+        (progn
+          (with-temp-file file
+            (insert old))
+          (let ((result
+                 (ellama-test-eval--wait-tool-result
+                  #'ellama-eval-hooked-edit-file-tool file old new)))
+            (should (string-match-p
+                     "Edited .* after syntax validation" result))
+            (should-not (string-match-p "edit hook" result)))
+          (with-temp-buffer
+            (insert-file-contents file)
+            (should (equal (buffer-string) new))))
+      (when-let* ((buffer (get-file-buffer file)))
+        (kill-buffer buffer))
+      (when (file-exists-p file)
+        (delete-file file)))))
+
+(ert-deftest test-ellama-eval-edit-hook-summary-counts-recovery ()
+  (let ((trace
+         '((:name "edit_file" :args ("one.el" "old" "bad")
+                  :result "Edited one.el.\n\nAfter edit hook failed with exit status 1")
+           (:name "read_file" :args ("one.el") :result "bad")
+           (:name "edit_file" :args ("one.el" "bad" "good")
+                  :result "Edited one.el after syntax validation.")
+           (:name "edit_file" :args ("two.el" "old" "bad")
+                  :result "Edited two.el.\n\nBefore edit hook failed with exit status 2"))))
+    (should (= (ellama-eval--edit-hook-failure-count trace) 2))
+    (should (= (ellama-eval--edit-hook-recovery-count trace) 1))))
 
 (ert-deftest test-ellama-eval-run-case-scores-files-and-answer ()
   (let ((case

--- a/tests/test-ellama.el
+++ b/tests/test-ellama.el
@@ -2255,7 +2255,8 @@ detailed comparison to help you decide:
           "user 5" "assistant 5"))))))
 
 (ert-deftest test-ellama-session-compact-renders-tool-results-readably ()
-  (let* ((prompt (llm-make-chat-prompt "user"))
+  (let* ((ellama-session-auto-compact-include-tool-results t)
+         (prompt (llm-make-chat-prompt "user"))
          (interaction
           (make-llm-chat-prompt-interaction
            :role 'assistant
@@ -2268,6 +2269,35 @@ detailed comparison to help you decide:
       (should (string-match-p "Tool results:" rendered))
       (should (string-match-p "grep_in_file\n  90:first line" rendered))
       (should-not (string-match-p "((grep_in_file" rendered)))))
+
+(ert-deftest test-ellama-session-compact-omits-tool-results-by-default ()
+  (let* ((tool-use
+          (make-llm-provider-utils-tool-use
+           :id "call-1"
+           :name "read_file"
+           :args '((file_name . "ellama.el"))))
+         (tool-call
+          (make-llm-chat-prompt-interaction
+           :role 'assistant
+           :content (list tool-use)))
+         (tool-result
+          (make-llm-chat-prompt-interaction
+           :role 'tool-results
+           :tool-results
+           (list
+            (make-llm-chat-prompt-tool-result
+             :call-id "call-1"
+             :tool-name "read_file"
+             :result "tool result sentinel"))))
+         (rendered
+          (ellama--session-compact-render-interactions
+           (list tool-call tool-result))))
+    (should-not ellama-session-auto-compact-include-tool-results)
+    (should (string-match-p "read_file" rendered))
+    (should (string-match-p "ellama.el" rendered))
+    (should-not (string-match-p "tool result sentinel" rendered))
+    (should-not (string-match-p "Tool results:" rendered))
+    (should-not (string-match-p "Tool-results:" rendered))))
 
 (ert-deftest test-ellama-session-compact-uses-stored-token-count ()
   (let* ((provider (make-llm-fake))


### PR DESCRIPTION
## Summary

- add ellama-session-auto-compact-include-tool-results
- omit tool-result interactions from compaction input by default
- keep tool calls and their arguments in compaction history
- preserve the previous behavior when the option is enabled
- document the setting and regenerate the Info manual

## Tests

- make test: 548 passed
- make build
- make checkdocs
- make check-readme
- custom variable and command documentation checks
- git diff --check