### PR TITLE
Add llmman as a provider type in the model transient

### DIFF
--- a/README.org
+++ b/README.org
@@ -55,6 +55,17 @@ If you want to use that default, install Ollama and pull a model from the
 The examples below use ~qwen3.6:35b~ for agentic coding.  Replace it with a
 model that is available in your Ollama installation if needed.
 
+Ellama also works with [[https://github.com/llmmanorg/llmman][llmman]], a local
+model runner that serves the Ollama API on port 17434.  Pull a model with
+~llmman pull gemma4~, then point the Ollama provider at that port.  The model
+transient (~ellama-select-model~) also offers ~llmman~ as a provider type.
+
+#+BEGIN_SRC emacs-lisp
+  (require 'llm-ollama)
+  (setopt ellama-provider
+          (make-llm-ollama :port 17434 :chat-model "gemma4"))
+#+END_SRC
+
 You can also use another LLM provider.  The smallest useful Emacs setup is:
 
 #+BEGIN_SRC emacs-lisp
@@ -236,8 +247,9 @@ Optional provider-specific settings:
 - ~ellama-provider-select~: Select ellama provider.
 - ~ellama-select-model~: Change the current provider model interactively.  The
   model transient can switch the provider type as well as the model.  Built-in
-  choices include Ollama, OpenAI-compatible, OpenAI, Claude, Gemini, DeepSeek,
-  OpenRouter, Azure OpenAI, GitHub Models, Vertex AI, GPT4All, and Llama.cpp.
+  choices include Ollama, llmman, OpenAI-compatible, OpenAI, Claude, Gemini,
+  DeepSeek, OpenRouter, Azure OpenAI, GitHub Models, Vertex AI, GPT4All, and
+  Llama.cpp.
   It also supports providers with a ~chat-model~ slot.  URL editing is available
   when the provider has a ~url~ slot.  It can also set the maximum number of
   output tokens.  Use "Reset model fields" to clear model, temperature,

--- a/ellama-transient.el
+++ b/ellama-transient.el
@@ -162,8 +162,16 @@ Otherwise, prompt the user to enter a system message."
                                ellama-naming-provider)
   "List of providers.")
 
+(defun ellama-transient-make-llmman-provider ()
+  "Return an `llm-ollama' provider for a local llmman server.
+llmman (https://github.com/llmmanorg/llmman) serves the Ollama API on 17434."
+  (declare-function make-llm-ollama "ext:llm-ollama")
+  (require 'llm-ollama)
+  (make-llm-ollama :port 17434))
+
 (defcustom ellama-transient-provider-types
   '((llm-ollama "Ollama" llm-ollama make-llm-ollama)
+    (ellama-llmman "llmman" llm-ollama ellama-transient-make-llmman-provider)
     (llm-openai-compatible "OpenAI-compatible"
                            llm-openai make-llm-openai-compatible)
     (llm-openai "OpenAI" llm-openai make-llm-openai)
@@ -177,7 +185,8 @@ Otherwise, prompt the user to enter a system message."
     (llm-gpt4all "GPT4All" llm-gpt4all make-llm-gpt4all)
     (llm-llamacpp "Llama.cpp" llm-llamacpp make-llm-llamacpp))
   "Provider types available in the model transient.
-Each entry has the form (TYPE LABEL LIBRARY CONSTRUCTOR)."
+Each entry has the form (TYPE LABEL LIBRARY CONSTRUCTOR).  TYPE is the
+provider record type, or a unique symbol for a preset of another type."
   :type '(repeat
           (list (symbol :tag "Provider type")
                 (string :tag "Label")

--- a/tests/test-ellama-transient.el
+++ b/tests/test-ellama-transient.el
@@ -312,6 +312,18 @@
       (should (equal (ellama-transient-provider-type-description)
                      "Provider Type (Claude)")))))
 
+(ert-deftest test-ellama-transient-set-provider-type-llmman ()
+  (let ((ellama-transient-provider nil)
+        (ellama-transient-provider-type-selected-p nil))
+    (cl-letf (((symbol-function 'completing-read)
+               (lambda (&rest _args)
+                 "llmman")))
+      (ellama-transient-set-provider-type)
+      (should (eq (type-of ellama-transient-provider) 'llm-ollama))
+      (should (equal (llm-ollama-port ellama-transient-provider) 17434))
+      (should (equal ellama-transient-port 17434))
+      (should ellama-transient-provider-type-selected-p))))
+
 (ert-deftest test-ellama-transient-set-provider-applies-selected-type ()
   (require 'llm-claude)
   (let ((ellama-provider


### PR DESCRIPTION
Adds [llmman](https://github.com/llmmanorg/llmman), a local model runner that serves the Ollama API on port 17434.

- `ellama-transient.el`: add an `llmman` entry to `ellama-transient-provider-types` whose constructor returns `(make-llm-ollama :port 17434)`. llmman speaks the Ollama API, so it reuses `llm-ollama`; only the port differs.
- The registry key `ellama-llmman` is a preset symbol, not a record type, so the "Provider Type" description reads "Ollama" after selecting it. The defcustom docstring now describes this. Happy to drop the registry entry and keep only the README section if you prefer.
- `README.org`: llmman paragraph and config snippet next to the Ollama setup; `llmman` added to the built-in provider-type list.
- `tests/test-ellama-transient.el`: ert test selecting `llmman` and asserting an `llm-ollama` provider on port 17434.
- Not touched: `NEWS.org` and `ellama.info` (regenerating with makeinfo 7.3 changes ~160 unrelated lines).

**Testing:** byte-compiled with Emacs 31.1 (same 38 pre-existing `when-let`/`if-let` warnings before and after); `tests/test-ellama-transient.el` 28/28; checkdoc and `scripts/check-transient-dup-keys.sh` clean. Not run against a live llmman server.

> AI-assisted, reviewed before submitting.
